### PR TITLE
dev: downgrade php 7.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Join the `#core-ai` channel [on WordPress Slack](http://wordpress.slack.com) ([s
 In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). All code in the Performance Lab plugin must follow these requirements:
 
 - **WordPress**: As of MCP Adapter v0.1.0, released {@todo}, the plugin's minimum WordPress version requirement is 6.8.
-- **PHP**: The minimum required version right now is 8.1. This is subject to change and will be brought in sync with the WordPress core minimum PHP version requirement closer to release.
+- **PHP**: The minimum required version right now is 7.4. This is subject to change and will be brought in sync with the WordPress core minimum PHP version requirement closer to release.
 
 We include [several tools](#useful-commands) to help ensure your code meets contribution
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Individual server management with comprehensive configuration:
 
 ### Required Dependencies
 
-- **PHP**: >= 8.1
+- **PHP**: >= 7.4
 - **WordPress Abilities API**: For ability registration and management
 - **Automattic Jetpack Autoloader**: For PSR-4 autoloading
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	"prefer-stable": true,
 	"config": {
 		"platform": {
-			"php": "8.1"
+			"php": "7.4"
 		},
 		"sort-packages": true,
 		"optimize-autoloader": true,
@@ -72,7 +72,7 @@
 		}
 	},
 	"require": {
-		"php": ">=8.1",
+		"php": "^7.4 || ^8.0",
 		"automattic/jetpack-autoloader": "^5.0"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed19d74a87b1e089da1491d483581f1f",
+    "content-hash": "dacd2ab782c23bd837e0d45c3f71ef36",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -371,30 +371,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -421,7 +421,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -437,7 +437,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3139,11 +3139,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": "^7.4 || ^8.0"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "7.4"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -13,7 +13,7 @@ expose your WordPress capabilities to AI systems.
 
 Before you begin, ensure you have:
 
-- **PHP 8.1 or higher**
+- **PHP 7.4 or higher**
 - **WordPress with Abilities API** loaded
 - **Basic understanding of WordPress plugins/themes**
 - **Optional**: Composer (for enhanced dependency management)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -151,7 +151,7 @@ If your project uses Composer, you can install the adapter for enhanced dependen
     "name": "my-company/my-wordpress-plugin",
     "description": "WordPress plugin with MCP integration",
     "require": {
-        "php": ">=8.1",
+        "php": "^7.4 || ^8.0",
         "wordpress/mcp-adapter": "^1.0"
     },
     "autoload": {

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -7,7 +7,7 @@ This guide explains how to run and write tests for the MCP Adapter. The suite su
 
 ## Prerequisites
 
-- PHP 8.1+
+- PHP 7.4+
 - Composer
 - Optional (for full WP tests): a local MySQL/MariaDB server or a WordPress test DB
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,7 @@ parameters:
 		# Configuration
 		level: 8
 		phpVersion:
-			min: 80100 # @todo drop to 7.4
+			min: 70400
 			max: 80400
 		paths:
 				- src/

--- a/src/Core/McpServer.php
+++ b/src/Core/McpServer.php
@@ -595,15 +595,17 @@ class McpServer {
 
 		// Create context for the router first (without router to avoid circular dependency)
 		$router_context = new McpTransportContext(
-			mcp_server: $this,
-			initialize_handler: $initialize_handler,
-			tools_handler: $tools_handler,
-			resources_handler: $resources_handler,
-			prompts_handler: $prompts_handler,
-			system_handler: $system_handler,
-			observability_handler: $this->observability_handler,
-			request_router: null,
-			transport_permission_callback: $this->transport_permission_callback
+			array(
+				'mcp_server'                    => $this,
+				'initialize_handler'            => $initialize_handler,
+				'tools_handler'                 => $tools_handler,
+				'resources_handler'             => $resources_handler,
+				'prompts_handler'               => $prompts_handler,
+				'system_handler'                => $system_handler,
+				'observability_handler'         => $this->observability_handler,
+				'request_router'                => null,
+				'transport_permission_callback' => $this->transport_permission_callback,
+			)
 		);
 
 		// Create the router
@@ -611,15 +613,17 @@ class McpServer {
 
 		// Create the final context with the router
 		return new McpTransportContext(
-			mcp_server: $this,
-			initialize_handler: $initialize_handler,
-			tools_handler: $tools_handler,
-			resources_handler: $resources_handler,
-			prompts_handler: $prompts_handler,
-			system_handler: $system_handler,
-			observability_handler: $this->observability_handler,
-			request_router: $request_router,
-			transport_permission_callback: $this->transport_permission_callback
+			array(
+				'mcp_server'                    => $this,
+				'initialize_handler'            => $initialize_handler,
+				'tools_handler'                 => $tools_handler,
+				'resources_handler'             => $resources_handler,
+				'prompts_handler'               => $prompts_handler,
+				'system_handler'                => $system_handler,
+				'observability_handler'         => $this->observability_handler,
+				'request_router'                => $request_router,
+				'transport_permission_callback' => $this->transport_permission_callback,
+			)
 		);
 	}
 

--- a/src/Domain/Prompts/McpPromptValidator.php
+++ b/src/Domain/Prompts/McpPromptValidator.php
@@ -133,7 +133,7 @@ class McpPromptValidator {
 	 *
 	 * @return array Array of validation errors, empty if valid.
 	 */
-	private static function get_arguments_validation_errors( mixed $arguments ): array {
+	private static function get_arguments_validation_errors( $arguments ): array {
 		$errors = array();
 
 		// Arguments must be an array

--- a/src/Domain/Resources/McpResource.php
+++ b/src/Domain/Resources/McpResource.php
@@ -276,7 +276,7 @@ class McpResource {
 	 *
 	 * @return void
 	 */
-	public function add_annotation( string $key, mixed $value ): void {
+	public function add_annotation( string $key, $value ): void {
 		$this->annotations[ $key ] = $value;
 	}
 

--- a/src/Domain/Tools/McpTool.php
+++ b/src/Domain/Tools/McpTool.php
@@ -234,7 +234,7 @@ class McpTool {
 	 *
 	 * @return void
 	 */
-	public function add_annotation( string $key, mixed $value ): void {
+	public function add_annotation( string $key, $value ): void {
 		$this->annotations[ $key ] = $value;
 	}
 

--- a/src/Domain/Tools/McpToolValidator.php
+++ b/src/Domain/Tools/McpToolValidator.php
@@ -123,7 +123,7 @@ class McpToolValidator {
 	 *
 	 * @return array Array of validation errors, empty if valid.
 	 */
-	private static function get_schema_validation_errors( mixed $schema, string $field_name ): array {
+	private static function get_schema_validation_errors( $schema, string $field_name ): array {
 		// Normalize stdClass to array for validation, and reject scalars/null.
 		if ( $schema instanceof stdClass ) {
 			$schema = (array) $schema;

--- a/src/Handlers/Prompts/PromptsHandler.php
+++ b/src/Handlers/Prompts/PromptsHandler.php
@@ -41,7 +41,7 @@ class PromptsHandler {
 	 *
 	 * @return array|null Returns error if permission denied, null if allowed.
 	 */
-	private function check_permission(): null|array {
+	private function check_permission(): ?array {
 		$enforce_handler_auth = (bool) apply_filters( 'mcp_enforce_handler_auth', false );
 
 		if ( $enforce_handler_auth && ! is_user_logged_in() ) {

--- a/src/Handlers/Resources/ResourcesHandler.php
+++ b/src/Handlers/Resources/ResourcesHandler.php
@@ -41,7 +41,7 @@ class ResourcesHandler {
 	 *
 	 * @return array|null Returns error if permission denied, null if allowed.
 	 */
-	private function check_permission(): null|array {
+	private function check_permission(): ?array {
 		$enforce_handler_auth = (bool) apply_filters( 'mcp_enforce_handler_auth', false );
 
 		if ( $enforce_handler_auth && ! is_user_logged_in() ) {

--- a/src/Handlers/Tools/ToolsHandler.php
+++ b/src/Handlers/Tools/ToolsHandler.php
@@ -18,6 +18,20 @@ use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
  */
 class ToolsHandler {
 	/**
+	 * Error categories keyed by throwable class name.
+	 *
+	 * @used-by ::categorize_error() method.
+	*/
+	private static array $error_categories = array(
+		\ArgumentCountError::class       => 'arguments',
+		\Error::class                    => 'system',
+		\InvalidArgumentException::class => 'validation',
+		\LogicException::class           => 'logic',
+		\RuntimeException::class         => 'execution',
+		\TypeError::class                => 'type',
+	);
+
+	/**
 	 * The WordPress MCP instance.
 	 *
 	 * @var \WP\MCP\Core\McpServer
@@ -316,14 +330,6 @@ class ToolsHandler {
 	 * @return string
 	 */
 	private function categorize_error( \Throwable $exception ): string {
-		return match ( get_class( $exception ) ) {
-			'InvalidArgumentException' => 'validation',
-			'RuntimeException' => 'execution',
-			'LogicException' => 'logic',
-			'Error' => 'system',
-			'TypeError' => 'type',
-			'ArgumentCountError' => 'arguments',
-			default => 'unknown'
-		};
+		return self::$error_categories[ get_class( $exception ) ] ?? 'unknown';
 	}
 }

--- a/src/Infrastructure/ErrorHandling/McpErrorFactory.php
+++ b/src/Infrastructure/ErrorHandling/McpErrorFactory.php
@@ -47,7 +47,7 @@ class McpErrorFactory {
 	 *
 	 * @return array
 	 */
-	public static function create_error_response( int $id, int $code, string $message, mixed $data = null ): array {
+	public static function create_error_response( int $id, int $code, string $message, $data = null ): array {
 		$response = array(
 			'jsonrpc' => '2.0',
 			'id'      => $id,
@@ -288,7 +288,7 @@ class McpErrorFactory {
 	 *
 	 * @return bool|array Returns true if valid, or error array if invalid.
 	 */
-	public static function validate_jsonrpc_message( mixed $message ): bool|array {
+	public static function validate_jsonrpc_message( $message ) {
 		if ( ! is_array( $message ) ) {
 			return self::invalid_request( 0, __( 'Message must be a JSON object', 'mcp-adapter' ) );
 		}

--- a/src/Infrastructure/Observability/McpObservabilityHelperTrait.php
+++ b/src/Infrastructure/Observability/McpObservabilityHelperTrait.php
@@ -16,6 +16,19 @@ namespace WP\MCP\Infrastructure\Observability;
  * tag management, metric formatting, and sanitization functionality.
  */
 trait McpObservabilityHelperTrait {
+	/**
+	 * Error categories keyed by throwable class name.
+	 *
+	 * @used-by ::categorize_error() method.
+	*/
+	private static array $error_categories = array(
+		\ArgumentCountError::class       => 'arguments',
+		\Error::class                    => 'system',
+		\InvalidArgumentException::class => 'validation',
+		\LogicException::class           => 'logic',
+		\RuntimeException::class         => 'execution',
+		\TypeError::class                => 'type',
+	);
 
 	/**
 	 * Get default tags that should be included with all metrics.
@@ -120,14 +133,6 @@ trait McpObservabilityHelperTrait {
 	 * @return string
 	 */
 	public static function categorize_error( \Throwable $exception ): string {
-		return match ( get_class( $exception ) ) {
-			'InvalidArgumentException' => 'validation',
-			'RuntimeException' => 'execution',
-			'LogicException' => 'logic',
-			'Error' => 'system',
-			'TypeError' => 'type',
-			'ArgumentCountError' => 'arguments',
-			default => 'unknown'
-		};
+		return self::$error_categories[ get_class( $exception ) ] ?? 'unknown';
 	}
 }

--- a/src/Transport/Contracts/McpTransportInterface.php
+++ b/src/Transport/Contracts/McpTransportInterface.php
@@ -32,7 +32,7 @@ interface McpTransportInterface {
 	 *
 	 * @return bool|\WP_Error True if allowed, WP_Error or false if not.
 	 */
-	public function check_permission(): \WP_Error|bool;
+	public function check_permission();
 
 	/**
 	 * Handle incoming requests.
@@ -42,7 +42,7 @@ interface McpTransportInterface {
 	 * @param mixed $request The request object (type varies by transport).
 	 * @return mixed Transport-specific response format.
 	 */
-	public function handle_request( mixed $request ): mixed;
+	public function handle_request( $request );
 
 	/**
 	 * Register transport-specific routes.

--- a/src/Transport/Http/RestTransport.php
+++ b/src/Transport/Http/RestTransport.php
@@ -63,7 +63,7 @@ class RestTransport implements McpTransportInterface {
 	 *
 	 * @return bool|\WP_Error
 	 */
-	public function check_permission(): \WP_Error|bool {
+	public function check_permission() {
 		// Use custom permission callback if provided
 		if ( null !== $this->context->transport_permission_callback ) {
 			try {
@@ -97,7 +97,7 @@ class RestTransport implements McpTransportInterface {
 	 *
 	 * @return \WP_REST_Response|\WP_Error
 	 */
-	public function handle_request( mixed $request ): \WP_Error|WP_REST_Response {
+	public function handle_request( $request ) {
 		$message = $request->get_json_params();
 
 		$validation = $this->validate_rest_message( is_array( $message ) ? $message : array() );
@@ -125,7 +125,7 @@ class RestTransport implements McpTransportInterface {
 	 * @param array $message Incoming message.
 	 * @return \WP_Error|true
 	 */
-	private function validate_rest_message( array $message ): \WP_Error|bool {
+	private function validate_rest_message( array $message ) {
 		if ( empty( $message ) ) {
 			return new \WP_Error( 'invalid_request', 'Invalid request: Empty body', array( 'status' => 400 ) );
 		}

--- a/src/Transport/Http/StreamableTransport.php
+++ b/src/Transport/Http/StreamableTransport.php
@@ -71,7 +71,7 @@ class StreamableTransport implements McpTransportInterface {
 	 *
 	 * @return bool|\WP_Error
 	 */
-	public function check_permission( ?WP_REST_Request $request = null ): \WP_Error|bool {
+	public function check_permission( ?WP_REST_Request $request = null ) {
 		// Use custom permission callback if provided
 		if ( null !== $this->context->transport_permission_callback ) {
 			try {
@@ -105,7 +105,7 @@ class StreamableTransport implements McpTransportInterface {
 	 *
 	 * @return \WP_REST_Response
 	 */
-	public function handle_request( mixed $request ): WP_REST_Response {
+	public function handle_request( $request ): WP_REST_Response {
 		// Handle preflight requests.
 		if ( 'OPTIONS' === $request->get_method() ) {
 			return new WP_REST_Response( null );

--- a/src/Transport/Infrastructure/McpRequestRouter.php
+++ b/src/Transport/Infrastructure/McpRequestRouter.php
@@ -60,25 +60,27 @@ class McpRequestRouter {
 		// Record request event.
 		$this->context->observability_handler::record_event( 'mcp.request.count', $common_tags );
 
+		$handlers = array(
+			'initialize'               => fn() => $this->context->initialize_handler->handle( $request_id ),
+			'init'                     => fn() => $this->context->initialize_handler->handle( $request_id ),
+			'ping'                     => fn() => $this->context->system_handler->ping( $request_id ),
+			'tools/list'               => fn() => $this->context->tools_handler->list_tools( $request_id ),
+			'tools/list/all'           => fn() => $this->context->tools_handler->list_all_tools( $request_id ),
+			'tools/call'               => fn() => $this->context->tools_handler->call_tool( $params, $request_id ),
+			'resources/list'           => fn() => $this->add_cursor_compatibility( $this->context->resources_handler->list_resources( $request_id ) ),
+			'resources/templates/list' => fn() => $this->add_cursor_compatibility( $this->context->resources_handler->list_resource_templates( $request_id ) ),
+			'resources/read'           => fn() => $this->context->resources_handler->read_resource( $params, $request_id ),
+			'resources/subscribe'      => fn() => $this->context->resources_handler->subscribe_resource( $params, $request_id ),
+			'resources/unsubscribe'    => fn() => $this->context->resources_handler->unsubscribe_resource( $params, $request_id ),
+			'prompts/list'             => fn() => $this->context->prompts_handler->list_prompts( $request_id ),
+			'prompts/get'              => fn() => $this->context->prompts_handler->get_prompt( $params, $request_id ),
+			'logging/setLevel'         => fn() => $this->context->system_handler->set_logging_level( $params, $request_id ),
+			'completion/complete'      => fn() => $this->context->system_handler->complete( $request_id ),
+			'roots/list'               => fn() => $this->context->system_handler->list_roots( $request_id ),
+		);
+
 		try {
-			$result = match ( $method ) {
-				'initialize', 'init' => $this->context->initialize_handler->handle( $request_id ),
-				'ping' => $this->context->system_handler->ping( $request_id ),
-				'tools/list' => $this->context->tools_handler->list_tools( $request_id ),
-				'tools/list/all' => $this->context->tools_handler->list_all_tools( $request_id ),
-				'tools/call' => $this->context->tools_handler->call_tool( $params, $request_id ),
-				'resources/list' => $this->add_cursor_compatibility( $this->context->resources_handler->list_resources( $request_id ) ),
-				'resources/templates/list' => $this->add_cursor_compatibility( $this->context->resources_handler->list_resource_templates( $request_id ) ),
-				'resources/read' => $this->context->resources_handler->read_resource( $params, $request_id ),
-				'resources/subscribe' => $this->context->resources_handler->subscribe_resource( $params, $request_id ),
-				'resources/unsubscribe' => $this->context->resources_handler->unsubscribe_resource( $params, $request_id ),
-				'prompts/list' => $this->context->prompts_handler->list_prompts( $request_id ),
-				'prompts/get' => $this->context->prompts_handler->get_prompt( $params, $request_id ),
-				'logging/setLevel' => $this->context->system_handler->set_logging_level( $params, $request_id ),
-				'completion/complete' => $this->context->system_handler->complete( $request_id ),
-				'roots/list' => $this->context->system_handler->list_roots( $request_id ),
-				default => $this->create_method_not_found_error( $method ),
-			};
+			$result = isset( $handlers[ $method ] ) ? $handlers[ $method ]() : $this->create_method_not_found_error( $method );
 
 			// Handle array error formats.
 			if ( is_array( $result ) && isset( $result['error'] ) ) {

--- a/src/Transport/Infrastructure/McpTransportContext.php
+++ b/src/Transport/Infrastructure/McpTransportContext.php
@@ -37,15 +37,83 @@ class McpTransportContext {
 	 * @param \WP\MCP\Transport\Infrastructure\McpRequestRouter|null $request_router The request router service.
 	 * @param callable|null         $transport_permission_callback Optional custom permission callback for transport-level authentication.
 	 */
-	public function __construct(
-		public McpServer $mcp_server,
-		public InitializeHandler $initialize_handler,
-		public ToolsHandler $tools_handler,
-		public ResourcesHandler $resources_handler,
-		public PromptsHandler $prompts_handler,
-		public SystemHandler $system_handler,
-		public string $observability_handler,
-		public ?McpRequestRouter $request_router,
-		public $transport_permission_callback = null
-	) {}
+	/**
+	 * The MCP server instance.
+	 *
+	 * @var \WP\MCP\Core\McpServer
+	 */
+	public McpServer $mcp_server;
+
+	/**
+	 * The initialize handler.
+	 *
+	 * @var \WP\MCP\Handlers\Initialize\InitializeHandler
+	 */
+	public InitializeHandler $initialize_handler;
+
+	/**
+	 * The tools handler.
+	 *
+	 * @var \WP\MCP\Handlers\Tools\ToolsHandler
+	 */
+	public ToolsHandler $tools_handler;
+
+	/**
+	 * The resources handler.
+	 *
+	 * @var \WP\MCP\Handlers\Resources\ResourcesHandler
+	 */
+	public ResourcesHandler $resources_handler;
+
+	/**
+	 * The prompts handler.
+	 *
+	 * @var \WP\MCP\Handlers\Prompts\PromptsHandler
+	 */
+	public PromptsHandler $prompts_handler;
+
+	/**
+	 * The system handler.
+	 *
+	 * @var \WP\MCP\Handlers\System\SystemHandler
+	 */
+	public SystemHandler $system_handler;
+
+	/**
+	 * The observability handler class name.
+	 */
+	public string $observability_handler;
+
+	/**
+	 * The request router service.
+	 */
+	public ?\WP\MCP\Transport\Infrastructure\McpRequestRouter $request_router;
+
+	/**
+	 * Optional custom permission callback for transport-level authentication.
+	 *
+	 * @var callable|callable-string|null
+	 */
+	public $transport_permission_callback;
+
+	/**
+	 * Initialize the transport context.
+	 *
+	 * @param array{
+	 *   mcp_server: \WP\MCP\Core\McpServer,
+	 *   initialize_handler: \WP\MCP\Handlers\Initialize\InitializeHandler,
+	 *   tools_handler: \WP\MCP\Handlers\Tools\ToolsHandler,
+	 *   resources_handler: \WP\MCP\Handlers\Resources\ResourcesHandler,
+	 *   prompts_handler: \WP\MCP\Handlers\Prompts\PromptsHandler,
+	 *   system_handler: \WP\MCP\Handlers\System\SystemHandler,
+	 *   observability_handler: string,
+	 *   request_router?: \WP\MCP\Transport\Infrastructure\McpRequestRouter|null,
+	 *   transport_permission_callback?: callable|null
+	 * } $properties Properties to set on the context.
+	 */
+	public function __construct( array $properties ) {
+		foreach ( $properties as $name => $value ) {
+				$this->$name = $value;
+		}
+	}
 }

--- a/tests/Fixtures/DummyTransport.php
+++ b/tests/Fixtures/DummyTransport.php
@@ -21,11 +21,11 @@ class DummyTransport implements McpTransportInterface {
 		// No route registration needed for tests
 	}
 
-	public function check_permission(): \WP_Error|bool {
+	public function check_permission() {
 		return true;
 	}
 
-	public function handle_request( mixed $request ): mixed {
+	public function handle_request( $request ) {
 		// Simple test implementation
 		return array( 'success' => true );
 	}

--- a/tests/Integration/BuilderPromptExecutionTest.php
+++ b/tests/Integration/BuilderPromptExecutionTest.php
@@ -63,15 +63,15 @@ final class BuilderPromptExecutionTest extends TestCase {
 
 	private function makeServer(): McpServer {
 		return new McpServer(
-			server_id: 'test-srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Test Server',
-			server_description: 'Test server for builder prompts',
-			server_version: '1.0.0',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'test-srv',
+			'mcp/v1',
+			'/mcp',
+			'Test Server',
+			'Test server for builder prompts',
+			'1.0.0',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 	}
 

--- a/tests/Integration/ErrorHandlingIntegrationTest.php
+++ b/tests/Integration/ErrorHandlingIntegrationTest.php
@@ -67,15 +67,15 @@ final class ErrorHandlingIntegrationTest extends TestCase {
 
 	public function test_server_instantiates_error_handler_correctly(): void {
 		$server = new McpServer(
-			server_id: 'test',
-			server_route_namespace: 'test/v1',
-			server_route: '/test',
-			server_name: 'Test Server',
-			server_description: 'Test Description',
-			server_version: '1.0.0',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'test',
+			'test/v1',
+			'/test',
+			'Test Server',
+			'Test Description',
+			'1.0.0',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 
 		$this->assertInstanceOf( McpErrorHandlerInterface::class, $server->error_handler );
@@ -188,16 +188,16 @@ final class ErrorHandlingIntegrationTest extends TestCase {
 
 	private function makeServer( array $tools = array() ): McpServer {
 		return new McpServer(
-			server_id: 'test',
-			server_route_namespace: 'test/v1',
-			server_route: '/test',
-			server_name: 'Test Server',
-			server_description: 'Test Description',
-			server_version: '1.0.0',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
-			tools: $tools,
+			'test',
+			'test/v1',
+			'/test',
+			'Test Server',
+			'Test Description',
+			'1.0.0',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			$tools,
 		);
 	}
 }

--- a/tests/Integration/TransportRoutingTest.php
+++ b/tests/Integration/TransportRoutingTest.php
@@ -28,18 +28,18 @@ final class TransportRoutingTest extends TestCase {
 
 	public function test_tools_and_prompts_routed_and_cursor_added(): void {
 		$server = new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array( DummyTransport::class ),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
-			tools: array( 'test/always-allowed' ),
-			resources: array( 'test/resource' ),
-			prompts: array( 'test/prompt' ),
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array( DummyTransport::class ),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			array( 'test/always-allowed' ),
+			array( 'test/resource' ),
+			array( 'test/prompt' ),
 		);
 
 		// Create transport with proper context
@@ -64,14 +64,16 @@ final class TransportRoutingTest extends TestCase {
 
 		// Create context for the router first (without router to avoid circular dependency)
 		$router_context = new McpTransportContext(
-			mcp_server: $server,
-			initialize_handler: $initialize_handler,
-			tools_handler: $tools_handler,
-			resources_handler: $resources_handler,
-			prompts_handler: $prompts_handler,
-			system_handler: $system_handler,
-			observability_handler: DummyObservabilityHandler::class,
-			request_router: null
+			array(
+				'mcp_server'            => $server,
+				'initialize_handler'    => $initialize_handler,
+				'tools_handler'         => $tools_handler,
+				'resources_handler'     => $resources_handler,
+				'prompts_handler'       => $prompts_handler,
+				'system_handler'        => $system_handler,
+				'observability_handler' => DummyObservabilityHandler::class,
+				'request_router'        => null,
+			)
 		);
 
 		// Create the router
@@ -79,14 +81,16 @@ final class TransportRoutingTest extends TestCase {
 
 		// Create the final context with the router
 		return new McpTransportContext(
-			mcp_server: $server,
-			initialize_handler: $initialize_handler,
-			tools_handler: $tools_handler,
-			resources_handler: $resources_handler,
-			prompts_handler: $prompts_handler,
-			system_handler: $system_handler,
-			observability_handler: DummyObservabilityHandler::class,
-			request_router: $request_router
+			array(
+				'mcp_server'            => $server,
+				'initialize_handler'    => $initialize_handler,
+				'tools_handler'         => $tools_handler,
+				'resources_handler'     => $resources_handler,
+				'prompts_handler'       => $prompts_handler,
+				'system_handler'        => $system_handler,
+				'observability_handler' => DummyObservabilityHandler::class,
+				'request_router'        => $request_router,
+			)
 		);
 	}
 }

--- a/tests/Integration/WordPressFiltersTest.php
+++ b/tests/Integration/WordPressFiltersTest.php
@@ -15,15 +15,15 @@ final class WordPressFiltersTest extends TestCase {
 		add_filter( 'mcp_validation_enabled', '__return_false' );
 
 		$server = new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 
 		$this->assertFalse( $server->is_mcp_validation_enabled() );

--- a/tests/Unit/Handlers/InitializeHandlerTest.php
+++ b/tests/Unit/Handlers/InitializeHandlerTest.php
@@ -14,15 +14,15 @@ final class InitializeHandlerTest extends TestCase {
 
 	public function test_handle_returns_expected_shape(): void {
 		$server = new McpServer(
-			server_id: 'test',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Test Server',
-			server_description: 'Desc',
-			server_version: '1.0.0',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'test',
+			'mcp/v1',
+			'/mcp',
+			'Test Server',
+			'Desc',
+			'1.0.0',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 
 		$handler = new InitializeHandler( $server );

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -21,16 +21,16 @@ final class PromptsHandlerTest extends TestCase {
 
 	private function makeServer( array $prompts = array() ): McpServer {
 		return new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
-			prompts: $prompts,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			$prompts,
 		);
 	}
 

--- a/tests/Unit/Handlers/ResourcesHandlerListTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerListTest.php
@@ -24,16 +24,16 @@ final class ResourcesHandlerListTest extends TestCase {
 		wp_set_current_user( 1 );
 
 		$server = new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
-			resources: array( 'test/resource' ),
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			array( 'test/resource' ),
 		);
 
 		$handler = new ResourcesHandler( $server );

--- a/tests/Unit/Handlers/ResourcesHandlerReadTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerReadTest.php
@@ -45,16 +45,16 @@ final class ResourcesHandlerReadTest extends TestCase {
 
 	private function makeServer( array $resources = array() ): McpServer {
 		return new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
-			resources: $resources,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			$resources,
 		);
 	}
 }

--- a/tests/Unit/Handlers/SystemHandlerTest.php
+++ b/tests/Unit/Handlers/SystemHandlerTest.php
@@ -14,15 +14,15 @@ final class SystemHandlerTest extends TestCase {
 
 	public function test_ping_returns_empty_array(): void {
 		$server  = new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 		$handler = new SystemHandler( $server );
 		$this->assertSame( array(), $handler->ping() );
@@ -30,15 +30,15 @@ final class SystemHandlerTest extends TestCase {
 
 	public function test_set_logging_level_missing_level_returns_error(): void {
 		$server  = new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 		$handler = new SystemHandler( $server );
 		$res     = $handler->set_logging_level( array( 'params' => array() ) );
@@ -47,15 +47,15 @@ final class SystemHandlerTest extends TestCase {
 
 	public function test_complete_and_roots_list_return_expected_shapes(): void {
 		$server  = new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 		$handler = new SystemHandler( $server );
 		$this->assertTrue( $handler->complete()['success'] );

--- a/tests/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerCallTest.php
@@ -21,16 +21,16 @@ final class ToolsHandlerCallTest extends TestCase {
 
 	private function makeServer( array $tools ): McpServer {
 		return new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
-			tools: $tools,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			$tools,
 		);
 	}
 

--- a/tests/Unit/Handlers/ToolsHandlerListTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerListTest.php
@@ -21,16 +21,16 @@ final class ToolsHandlerListTest extends TestCase {
 
 	public function test_list_and_list_all_only_include_json_safe_fields(): void {
 		$server = new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
-			tools: array( 'test/always-allowed' ),
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			array( 'test/always-allowed' ),
 		);
 
 		$handler = new ToolsHandler( $server );

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -14,15 +14,15 @@ final class McpServerTest extends TestCase {
 
 	public function test_it_initializes_and_exposes_basic_getters(): void {
 		$server = new McpServer(
-			server_id: 'test-server',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Test MCP',
-			server_description: 'Testing server',
-			server_version: '0.1.0',
-			mcp_transports: array( DummyTransport::class ),
-			error_handler: NullMcpErrorHandler::class,
-			observability_handler: NullMcpObservabilityHandler::class,
+			'test-server',
+			'mcp/v1',
+			'/mcp',
+			'Test MCP',
+			'Testing server',
+			'0.1.0',
+			array( DummyTransport::class ),
+			NullMcpErrorHandler::class,
+			NullMcpObservabilityHandler::class,
 		);
 
 		$this->assertSame( 'test-server', $server->get_server_id() );

--- a/tests/Unit/McpTransportTest.php
+++ b/tests/Unit/McpTransportTest.php
@@ -75,16 +75,16 @@ final class McpTransportTest extends TestCase {
 
 	private function makeServer( array $tools = array() ): McpServer {
 		return new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
-			tools: $tools,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			$tools,
 		);
 	}
 
@@ -98,14 +98,16 @@ final class McpTransportTest extends TestCase {
 
 		// Create context for the router first (without router to avoid circular dependency)
 		$router_context = new McpTransportContext(
-			mcp_server: $server,
-			initialize_handler: $initialize_handler,
-			tools_handler: $tools_handler,
-			resources_handler: $resources_handler,
-			prompts_handler: $prompts_handler,
-			system_handler: $system_handler,
-			observability_handler: DummyObservabilityHandler::class,
-			request_router: null
+			array(
+				'mcp_server'            => $server,
+				'initialize_handler'    => $initialize_handler,
+				'tools_handler'         => $tools_handler,
+				'resources_handler'     => $resources_handler,
+				'prompts_handler'       => $prompts_handler,
+				'system_handler'        => $system_handler,
+				'observability_handler' => DummyObservabilityHandler::class,
+				'request_router'        => null,
+			)
 		);
 
 		// Create the router
@@ -113,14 +115,16 @@ final class McpTransportTest extends TestCase {
 
 		// Create the final context with the router
 		return new McpTransportContext(
-			mcp_server: $server,
-			initialize_handler: $initialize_handler,
-			tools_handler: $tools_handler,
-			resources_handler: $resources_handler,
-			prompts_handler: $prompts_handler,
-			system_handler: $system_handler,
-			observability_handler: DummyObservabilityHandler::class,
-			request_router: $request_router
+			array(
+				'mcp_server'            => $server,
+				'initialize_handler'    => $initialize_handler,
+				'tools_handler'         => $tools_handler,
+				'resources_handler'     => $resources_handler,
+				'prompts_handler'       => $prompts_handler,
+				'system_handler'        => $system_handler,
+				'observability_handler' => DummyObservabilityHandler::class,
+				'request_router'        => $request_router,
+			)
 		);
 	}
 }

--- a/tests/Unit/Prompts/McpPromptBuilderTest.php
+++ b/tests/Unit/Prompts/McpPromptBuilderTest.php
@@ -41,15 +41,15 @@ final class McpPromptBuilderTest extends TestCase {
 
 	private function makeServer(): McpServer {
 		return new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 	}
 

--- a/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
+++ b/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
@@ -21,15 +21,15 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 
 	private function makeServer(): McpServer {
 		return new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 	}
 

--- a/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
+++ b/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
@@ -21,15 +21,15 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 
 	private function makeServer(): McpServer {
 		return new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 	}
 

--- a/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
+++ b/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
@@ -21,15 +21,15 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 	private function makeServer(): McpServer {
 		return new McpServer(
-			server_id: 'srv',
-			server_route_namespace: 'mcp/v1',
-			server_route: '/mcp',
-			server_name: 'Srv',
-			server_description: 'desc',
-			server_version: '0.0.1',
-			mcp_transports: array(),
-			error_handler: DummyErrorHandler::class,
-			observability_handler: DummyObservabilityHandler::class,
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
 		);
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * PHPUnit bootstrap file for mcp-adapter (WordPress-style with unit fallback).
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals
  */
 
 // Load Composer autoloader for the library code under test.


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is based on #14 , which should be merged first.
> Ideally #13 would be merged as well to provide additional validation.
>
> Relevant diff: https://github.com/WordPress/mcp-adapter/pull/16/files/35302636dd4c6d99a12730de64f7672f2bbb9fcc..fc60ddd377dc2445a1eb01da7ce838df1f15692d

## What

Downgrades PHP to v7.4

- Removes incompatible type signatures
- Replaces `match`
-  Replaces named properties.

## Why

Closes #11 

## Additional Notes

This PR **does not** make any attempt to fix issues with improve the underlying code. It solely fixes compatibility with PHP 7.4 while leaving behavior intact and unaudited.
