### PR TITLE
dev!: cleanup and update compatibility with `abilities-api` v0.1.0

### DIFF
--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -273,6 +273,7 @@ class McpServer {
 			if ( ! is_string( $ability_name ) ) {
 				continue;
 			}
+
 			try {
 				$ability = wp_get_ability( $ability_name );
 

--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -273,9 +273,14 @@ class McpServer {
 			if ( ! is_string( $ability_name ) ) {
 				continue;
 			}
-
 			try {
-				$tool = RegisterAbilityAsMcpTool::make( $ability_name, $this );
+				$ability = wp_get_ability( $ability_name );
+
+				if ( ! $ability ) {
+					throw new \InvalidArgumentException( esc_html( "WordPress ability '{$ability_name}' does not exist." ) );
+				}
+
+				$tool = RegisterAbilityAsMcpTool::make( $ability, $this );
 				// Add the processed tools to this server.
 				$this->tools[ $tool->get_name() ] = $tool;
 
@@ -321,7 +326,13 @@ class McpServer {
 			}
 
 			try {
-				$resource = RegisterAbilityAsMcpResource::make( $ability_name, $this );
+				$ability = wp_get_ability( $ability_name );
+
+				if ( ! $ability ) {
+					throw new \InvalidArgumentException( esc_html( "WordPress ability '{$ability_name}' does not exist." ) );
+				}
+
+				$resource = RegisterAbilityAsMcpResource::make( $ability, $this );
 				// Add the processed resources to this server.
 				$this->resources[ $resource->get_uri() ] = $resource;
 
@@ -412,8 +423,14 @@ class McpServer {
 			} else {
 				// Treat as ability name (legacy behavior)
 				try {
+					$ability = wp_get_ability( $prompt_item );
+
+					if ( ! $ability ) {
+						throw new \InvalidArgumentException( esc_html( "WordPress ability '{$prompt_item}' does not exist." ) );
+					}
+
 					// Use RegisterMcpPrompt to handle all validation and processing.
-					$prompt = RegisterAbilityAsMcpPrompt::make( $prompt_item, $this );
+					$prompt = RegisterAbilityAsMcpPrompt::make( $ability, $this );
 
 					// Add the processed prompts to this server.
 					$this->prompts[ $prompt->get_name() ] = $prompt;

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -25,13 +25,12 @@ use WP_Ability;
  * )
  */
 class RegisterAbilityAsMcpPrompt {
-
 	/**
-	 * The ability name.
+	 * The WordPress ability instance.
 	 *
-	 * @var string
+	 * @var \WP_Ability
 	 */
-	private string $ability_name;
+	private WP_Ability $ability;
 
 	/**
 	 * The MCP server.
@@ -41,23 +40,16 @@ class RegisterAbilityAsMcpPrompt {
 	private McpServer $mcp_server;
 
 	/**
-	 * The WordPress ability instance.
-	 *
-	 * @var \WP_Ability|null
-	 */
-	private ?WP_Ability $ability;
-
-	/**
 	 * Make a new instance of the class.
 	 *
-	 * @param string    $ability_name The ability name.
+	 * @param \WP_Ability            $ability    The ability.
 	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
 	 *
 	 * @return \WP\MCP\Domain\Prompts\McpPrompt Returns prompt instance if valid
 	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
 	 */
-	public static function make( string $ability_name, McpServer $mcp_server ): McpPrompt {
-		$prompt = new self( $ability_name, $mcp_server );
+	public static function make( WP_Ability $ability, McpServer $mcp_server ): McpPrompt {
+		$prompt = new self( $ability, $mcp_server );
 
 		return $prompt->get_prompt();
 	}
@@ -65,38 +57,24 @@ class RegisterAbilityAsMcpPrompt {
 	/**
 	 * Constructor.
 	 *
-	 * @param string    $ability_name The ability name.
+	 * @param \WP_Ability            $ability    The ability.
 	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
 	 */
-	public function __construct( string $ability_name, McpServer $mcp_server ) {
-		$this->ability_name = $ability_name;
-		$this->mcp_server   = $mcp_server;
-		$this->ability      = wp_get_ability( $ability_name );
-	}
-
-	/**
-	 * Get the prompt name.
-	 *
-	 * @return string
-	 */
-	public function get_name(): string {
-		return $this->transform_ability_name( $this->ability_name );
+	private function __construct( WP_Ability $ability, McpServer $mcp_server ) {
+		$this->mcp_server = $mcp_server;
+		$this->ability    = $ability;
 	}
 
 	/**
 	 * Get the MCP prompt data array.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
 	 */
-	public function get_data(): array {
-		if ( ! $this->ability ) {
-			throw new \InvalidArgumentException( 'WordPress ability does not exist or could not be loaded' );
-		}
-
+	private function get_data(): array {
 		$prompt_data = array(
 			'ability' => $this->ability->get_name(),
-			'name'    => $this->get_name(),
+			'name'    => str_replace( '/', '-', $this->ability->get_name() ),
 		);
 
 		// Add optional title from ability label
@@ -121,64 +99,12 @@ class RegisterAbilityAsMcpPrompt {
 	}
 
 	/**
-	 * Transform ability name to MCP prompt name format.
-	 * Converts slashes to dashes for MCP compatibility.
-	 *
-	 * @param string $ability_name The ability name.
-	 *
-	 * @return string
-	 */
-	private function transform_ability_name( string $ability_name ): string {
-		return str_replace( '/', '-', $ability_name );
-	}
-
-	/**
-	 * Check if the WordPress ability exists and was successfully loaded.
-	 *
-	 * @return bool
-	 */
-	public function is_ability(): bool {
-		return $this->ability instanceof WP_Ability;
-	}
-
-	/**
-	 * Validate the MCP prompt data and throw exception if invalid.
-	 * Uses the centralized McpPromptValidator for consistent validation.
-	 *
-	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
-	 * @return void
-	 */
-	public function validate_mcp_prompt(): void {
-		if ( ! $this->is_ability() ) {
-			throw new \InvalidArgumentException( 'WordPress ability does not exist or could not be loaded' );
-		}
-
-		$prompt_data = $this->get_data();
-		McpPromptValidator::validate_prompt_data( $prompt_data, "RegisterAbilityAsMcpPrompt::{$this->ability_name}" );
-	}
-
-	/**
-	 * Get validation errors for debugging purposes.
-	 *
-	 * @return array Array of validation errors, empty if valid.
-	 */
-	public function get_validation_errors(): array {
-		if ( ! $this->is_ability() ) {
-			return array( 'WordPress ability does not exist or could not be loaded' );
-		}
-
-		$prompt_data = $this->get_data();
-
-		return McpPromptValidator::get_validation_errors( $prompt_data );
-	}
-
-	/**
 	 * Get the MCP prompt instance.
 	 *
 	 * @return \WP\MCP\Domain\Prompts\McpPrompt MCP prompt instance.
 	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
 	 */
-	public function get_prompt(): McpPrompt {
+	private function get_prompt(): McpPrompt {
 		return McpPrompt::from_array( $this->get_data(), $this->mcp_server );
 	}
 }

--- a/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -26,13 +26,12 @@ use WP_Ability;
  * )
  */
 class RegisterAbilityAsMcpResource {
-
 	/**
-	 * The ability name.
+	 * The WordPress ability instance.
 	 *
-	 * @var string
+	 * @var \WP_Ability
 	 */
-	private string $ability_name;
+	private WP_Ability $ability;
 
 	/**
 	 * The MCP server.
@@ -42,23 +41,16 @@ class RegisterAbilityAsMcpResource {
 	private McpServer $mcp_server;
 
 	/**
-	 * The WordPress ability instance.
-	 *
-	 * @var \WP_Ability|null
-	 */
-	private ?WP_Ability $ability;
-
-	/**
 	 * Make a new instance of the class.
 	 *
-	 * @param string    $ability_name The ability name.
+	 * @param \WP_Ability            $ability    The ability.
 	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
 	 *
 	 * @return \WP\MCP\Domain\Resources\McpResource Returns resource instance if valid
 	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
 	 */
-	public static function make( string $ability_name, McpServer $mcp_server ): McpResource {
-		$resource = new self( $ability_name, $mcp_server );
+	public static function make( WP_Ability $ability, McpServer $mcp_server ): McpResource {
+		$resource = new self( $ability, $mcp_server );
 
 		return $resource->get_resource();
 	}
@@ -66,13 +58,12 @@ class RegisterAbilityAsMcpResource {
 	/**
 	 * Constructor.
 	 *
-	 * @param string    $ability_name The ability name.
+	 * @param \WP_Ability            $ability    The ability.
 	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
 	 */
-	public function __construct( string $ability_name, McpServer $mcp_server ) {
-		$this->ability_name = $ability_name;
-		$this->mcp_server   = $mcp_server;
-		$this->ability      = wp_get_ability( $ability_name );
+	private function __construct( WP_Ability $ability, McpServer $mcp_server ) {
+		$this->mcp_server = $mcp_server;
+		$this->ability    = $ability;
 	}
 
 	/**
@@ -82,10 +73,6 @@ class RegisterAbilityAsMcpResource {
 	 * @throws \InvalidArgumentException If URI is not found in ability meta.
 	 */
 	public function get_uri(): string {
-		if ( ! $this->ability ) {
-			throw new \InvalidArgumentException( 'WordPress ability does not exist or could not be loaded' );
-		}
-
 		$ability_meta = $this->ability->get_meta();
 
 		// First try to get URI from ability meta
@@ -94,20 +81,16 @@ class RegisterAbilityAsMcpResource {
 		}
 
 		// If not found in meta, throw an error since URI should be provided in ability meta
-		throw new \InvalidArgumentException( esc_html( "Resource URI not found in ability meta for '{$this->ability_name}'. URI must be provided in ability meta data." ) );
+		throw new \InvalidArgumentException( esc_html( "Resource URI not found in ability meta for '{$this->ability->get_name()}'. URI must be provided in ability meta data." ) );
 	}
 
 	/**
 	 * Get the MCP resource data array.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
 	 */
-	public function get_data(): array {
-		if ( ! $this->is_ability() ) {
-			throw new \InvalidArgumentException( 'WordPress ability does not exist or could not be loaded' );
-		}
-
+	private function get_data(): array {
 		$resource_data = array(
 			'ability' => $this->ability->get_name(),
 			'uri'     => $this->get_uri(),
@@ -150,7 +133,7 @@ class RegisterAbilityAsMcpResource {
 	 * Get resource content from the ability.
 	 * This method should be implemented based on how abilities provide resource content.
 	 *
-	 * @return array Array with 'text', 'blob', and/or 'mimeType' keys
+	 * @return array<string,mixed> Array with 'text', 'blob', and/or 'mimeType' keys
 	 */
 	private function get_ability_content(): array {
 		// @todo: Probably this can be improved so it will not be loaded when the resource list is called
@@ -175,22 +158,13 @@ class RegisterAbilityAsMcpResource {
 	}
 
 	/**
-	 * Check if the WordPress ability exists and was successfully loaded.
-	 *
-	 * @return bool
-	 */
-	public function is_ability(): bool {
-		return $this->ability instanceof WP_Ability;
-	}
-
-	/**
 	 * Validate the MCP resource data and throw exception if invalid.
 	 * Uses the centralized McpResourceValidator for consistent validation.
 	 *
 	 * @return \WP\MCP\Domain\Resources\McpResource Returns the MCP resource instance if valid.
 	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
 	 */
-	public function get_resource(): McpResource {
+	private function get_resource(): McpResource {
 		return McpResource::from_array( $this->get_data(), $this->mcp_server );
 	}
 }

--- a/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -20,20 +20,12 @@ use WP_Ability;
  * @package McpAdapter
  */
 class RegisterAbilityAsMcpTool {
-
-	/**
-	 * The ability name.
-	 *
-	 * @var string
-	 */
-	private string $ability_name;
-
 	/**
 	 * The WordPress ability instance.
 	 *
-	 * @var \WP_Ability|null
+	 * @var \WP_Ability
 	 */
-	private ?WP_Ability $ability;
+	private WP_Ability $ability;
 
 	/**
 	 * The MCP server.
@@ -45,14 +37,14 @@ class RegisterAbilityAsMcpTool {
 	/**
 	 * Make a new instance of the class.
 	 *
-	 * @param string    $ability_name The ability name.
+	 * @param \WP_Ability            $ability    The ability.
 	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
 	 *
 	 * @return \WP\MCP\Domain\Tools\McpTool returns a new instance of McpTool.
 	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
 	 */
-	public static function make( string $ability_name, McpServer $mcp_server ): McpTool {
-		$tool = new self( $ability_name, $mcp_server );
+	public static function make( WP_Ability $ability, McpServer $mcp_server ): McpTool {
+		$tool = new self( $ability, $mcp_server );
 
 		return $tool->get_tool();
 	}
@@ -60,29 +52,24 @@ class RegisterAbilityAsMcpTool {
 	/**
 	 * Constructor.
 	 *
-	 * @param string    $ability_name The ability name.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server instance.
+	 * @param \WP_Ability            $ability    The ability.
+	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
 	 */
-	public function __construct( string $ability_name, McpServer $mcp_server ) {
-		$this->ability_name = $ability_name;
-		$this->mcp_server   = $mcp_server;
-		$this->ability      = wp_get_ability( $ability_name );
+	private function __construct( WP_Ability $ability, McpServer $mcp_server ) {
+		$this->mcp_server = $mcp_server;
+		$this->ability    = $ability;
 	}
 
 	/**
 	 * Get the MCP tool data array.
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
 	 */
-	public function get_data(): array {
-		if ( ! $this->is_ability() ) {
-			throw new \InvalidArgumentException( 'WordPress ability does not exist or could not be loaded' );
-		}
-
+	private function get_data(): array {
 		$tool_data = array(
 			'ability'     => $this->ability->get_name(),
-			'name'        => $this->get_name(),
+			'name'        => str_replace( '/', '-', $this->ability->get_name() ),
 			'description' => $this->ability->get_description(),
 			'inputSchema' => $this->ability->get_input_schema(),
 		);
@@ -109,30 +96,12 @@ class RegisterAbilityAsMcpTool {
 	}
 
 	/**
-	 * Get the tool name.
-	 *
-	 * @return string
-	 */
-	private function get_name(): string {
-		return str_replace( '/', '-', $this->ability_name );
-	}
-
-	/**
-	 * Check if the WordPress ability exists and was successfully loaded.
-	 *
-	 * @return bool
-	 */
-	public function is_ability(): bool {
-		return $this->ability instanceof WP_Ability;
-	}
-
-	/**
 	 * Get the MCP tool instance.
 	 *
 	 * @throws \InvalidArgumentException If WordPress ability doesn't exist or validation fails.
 	 * @return \WP\MCP\Domain\Tools\McpTool The validated MCP tool instance.
 	 */
-	public function get_tool(): McpTool {
+	private function get_tool(): McpTool {
 		return McpTool::from_array( $this->get_data(), $this->mcp_server );
 	}
 }

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -114,7 +114,14 @@ class PromptsHandler {
 				return $prompt->execute_direct( $arguments );
 			}
 
-			// Traditional ability-based execution
+			/**
+			 * Traditional ability-based execution
+			 *
+			 * Assume non-builder based prompts can only be registered with valid abilities.
+			 * If not, the has_permission() will let us know.
+			 *
+			 * @var \WP_Ability $ability
+			 */
 			$ability        = $prompt->get_ability();
 			$has_permission = $ability->has_permission( $arguments );
 			if ( ! $has_permission ) {

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -124,7 +124,7 @@ class PromptsHandler {
 			 */
 			$ability        = $prompt->get_ability();
 			$has_permission = $ability->has_permission( $arguments );
-			if ( ! $has_permission ) {
+			if ( true !== $has_permission ) {
 				return array( 'error' => McpErrorFactory::permission_denied( $request_id, 'Access denied for prompt: ' . $prompt_name )['error'] );
 			}
 

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -129,7 +129,10 @@ class ResourcesHandler {
 		$ability = $resource->get_ability();
 
 		try {
-			$ability->has_permission( $request_params );
+			$has_permission = $ability->has_permission( $request_params );
+			if ( true !== $has_permission ) {
+				return array( 'error' => McpErrorFactory::permission_denied( $request_id, 'Access denied for resource: ' . $resource->get_name() )['error'] );
+			}
 
 			$contents = $ability->execute( $request_params );
 

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -120,8 +120,15 @@ class ResourcesHandler {
 			return array( 'error' => McpErrorFactory::resource_not_found( $request_id, $uri )['error'] );
 		}
 
+		/**
+		 * Assume tools can only be registered with valid abilities.
+		 * If not, the has_permission() will let us know in the try-catch block.
+		 *
+		 * @var \WP_Ability $ability
+		 */
+		$ability = $resource->get_ability();
+
 		try {
-			$ability = $resource->get_ability();
 			$ability->has_permission( $request_params );
 
 			$contents = $ability->execute( $request_params );

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -121,7 +121,7 @@ class ResourcesHandler {
 		}
 
 		/**
-		 * Assume tools can only be registered with valid abilities.
+		 * Assume resources can only be registered with valid abilities.
 		 * If not, the has_permission() will let us know in the try-catch block.
 		 *
 		 * @var \WP_Ability $ability

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -248,7 +248,7 @@ class ToolsHandler {
 		// Run ability Permission Callback.
 		try {
 			$has_permission = $ability->has_permission( $args );
-			if ( ! $has_permission ) {
+			if ( true !== $has_permission ) {
 				// Track permission denied event.
 				$this->mcp->observability_handler::record_event(
 					'mcp.tool.permission_denied',

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -237,6 +237,12 @@ class ToolsHandler {
 			return array( 'error' => McpErrorFactory::tool_not_found( $request_id, $tool_name )['error'] );
 		}
 
+		/**
+		 * Assume tools can only be registered with valid abilities.
+		 * If not, the has_permission() will let us know in the try-catch block.
+		 *
+		 * @var \WP_Ability $ability
+		 */
 		$ability = $tool->get_ability();
 
 		// Run ability Permission Callback.

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -30,6 +30,8 @@ final class PromptsHandlerTest extends TestCase {
 			array(),
 			DummyErrorHandler::class,
 			DummyObservabilityHandler::class,
+			array(),
+			array(),
 			$prompts,
 		);
 	}

--- a/tests/Unit/Handlers/ResourcesHandlerListTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerListTest.php
@@ -33,6 +33,7 @@ final class ResourcesHandlerListTest extends TestCase {
 			array(),
 			DummyErrorHandler::class,
 			DummyObservabilityHandler::class,
+			array(),
 			array( 'test/resource' ),
 		);
 

--- a/tests/Unit/Handlers/ResourcesHandlerReadTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerReadTest.php
@@ -54,6 +54,7 @@ final class ResourcesHandlerReadTest extends TestCase {
 			array(),
 			DummyErrorHandler::class,
 			DummyObservabilityHandler::class,
+			array(),
 			$resources,
 		);
 	}

--- a/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
+++ b/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
@@ -34,14 +34,11 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 	}
 
 	public function test_make_builds_prompt_from_ability(): void {
-		$prompt = RegisterAbilityAsMcpPrompt::make( 'test/prompt', $this->makeServer() );
-		$arr    = $prompt->to_array();
+		$ability = wp_get_ability( 'test/prompt' );
+		$prompt  = RegisterAbilityAsMcpPrompt::make( $ability, $this->makeServer() );
+		$arr     = $prompt->to_array();
 		$this->assertSame( 'test-prompt', $arr['name'] );
 		$this->assertArrayHasKey( 'arguments', $arr );
-	}
-
-	public function test_make_invalid_ability_throws(): void {
-		$this->expectException( \InvalidArgumentException::class );
-		RegisterAbilityAsMcpPrompt::make( 'test/missing', $this->makeServer() );
+		$this->assertSame( $ability, $prompt->get_ability() );
 	}
 }

--- a/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
+++ b/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
@@ -34,13 +34,10 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 	}
 
 	public function test_make_builds_resource_from_ability(): void {
-		$resource = RegisterAbilityAsMcpResource::make( 'test/resource', $this->makeServer() );
+		$ability  = wp_get_ability( 'test/resource' );
+		$resource = RegisterAbilityAsMcpResource::make( $ability, $this->makeServer() );
 		$arr      = $resource->to_array();
 		$this->assertSame( 'WordPress://local/resource-1', $arr['uri'] );
-	}
-
-	public function test_make_invalid_ability_throws(): void {
-		$this->expectException( \InvalidArgumentException::class );
-		RegisterAbilityAsMcpResource::make( 'test/missing', $this->makeServer() );
+		$this->assertSame( $ability, $resource->get_ability() );
 	}
 }

--- a/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
+++ b/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
@@ -34,14 +34,10 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 	}
 
 	public function test_make_builds_tool_from_ability(): void {
-		$tool = RegisterAbilityAsMcpTool::make( 'test/always-allowed', $this->makeServer() );
-		$arr  = $tool->to_array();
+		$ability = wp_get_ability( 'test/always-allowed' );
+		$tool    = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
+		$arr     = $tool->to_array();
 		$this->assertSame( 'test-always-allowed', $arr['name'] );
 		$this->assertArrayHasKey( 'inputSchema', $arr );
-	}
-
-	public function test_make_invalid_ability_throws(): void {
-		$this->expectException( \InvalidArgumentException::class );
-		RegisterAbilityAsMcpTool::make( 'test/missing', $this->makeServer() );
 	}
 }


### PR DESCRIPTION
## What

This PR updates compatibility with the initial v0.1.0 release of the `abilities-api` and cleans up the unnecessary boilerplate from the `RegisterAbilityAs*` factories.

More specifically, `RegisterAbilityAs*::make()` now takes the actual `WP_Ability` instead of the name, and internal factory methods have been made `private`. Methods/tests that are no longer necessary have been removed.

## Why

https://github.com/WordPress/abilities-api/releases/tag/v0.1.0