### PR TITLE
ci: reenable codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,16 +244,15 @@ jobs:
         run: |
           npm run test:php
 
-      # @TODO: Reenable once a Codecov token has been configured.
-      # - name: Upload code coverage report
-      #   continue-on-error: true
-      #   if: ${{ matrix.coverage }}
-      #   uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     files: tests/_output/php-coverage.xml
-      #     flags: unit
-      #     fail_ci_if_error: true
+      - name: Upload code coverage report
+        continue-on-error: true
+        if: ${{ matrix.coverage }}
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: tests/_output/php-coverage.xml
+          flags: unit
+          fail_ci_if_error: true
 
       - name: Upload HTML coverage report as artifact
         if: ${{ matrix.coverage }}


### PR DESCRIPTION
## What

This PR re-enables codecov 

## Why

Followup to https://github.com/WordPress/abilities-api/issues/45

Once #27 is merged all tests will be passing. 