### PR TITLE
chore(phpstan): add PHP8 stubs for WP polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,6 @@
 		},
 		"sort-packages": true,
 		"optimize-autoloader": true,
-		"classmap-authoritative": false,
-		"apcu-autoloader": false,
 		"preferred-install": "dist",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpstan/extension-installer": "^1.3",
 		"phpstan/phpstan": "^2.1.22",
+		"phpstan/php-8-stubs": "^0.4.24",
 		"phpstan/phpstan-deprecation-rules": "^2.0.3",
 		"phpunit/phpunit": "^9.6",
 		"slevomat/coding-standard": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a93f7b0607452bfd5a7dca4c4b1ab0d5",
+    "content-hash": "152ced40e029fe53fa4aec344dec806e",
     "packages": [],
     "packages-dev": [
         {
@@ -1123,6 +1123,38 @@
                 "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
             },
             "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
+            "name": "phpstan/php-8-stubs",
+            "version": "0.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/php-8-stubs.git",
+                "reference": "40dea0d7d8c3ee7afa2aee7c71a5d78a53506b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/php-8-stubs/zipball/40dea0d7d8c3ee7afa2aee7c71a5d78a53506b2e",
+                "reference": "40dea0d7d8c3ee7afa2aee7c71a5d78a53506b2e",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Php8StubsMap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT",
+                "PHP-3.01"
+            ],
+            "description": "PHP stubs extracted from php-src",
+            "support": {
+                "issues": "https://github.com/phpstan/php-8-stubs/issues",
+                "source": "https://github.com/phpstan/php-8-stubs/tree/0.4.24"
+            },
+            "time": "2025-08-27T00:22:10+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,7 +20,12 @@ parameters:
 		bootstrapFiles:
 			- mcp-adapter.php
 		paths:
-				- includes/
+			- includes/
+		scanFiles:
+			# These are needed due config.platform.php being 7.4 in composer.json and wordpress-stubs not including polyfills.
+			# See <https://github.com/php-stubs/wordpress-stubs/issues/100>.
+			- vendor/phpstan/php-8-stubs/stubs/ext/standard/str_contains.php
+			- vendor/phpstan/php-8-stubs/stubs/ext/standard/str_starts_with.php
 		scanDirectories:
 			- ../abilities-api
 		excludePaths:


### PR DESCRIPTION
## What

This PR adds PHPStan stubs for `str_contains` and `str_starts_with`.

## Why

`php-stubs/wordpress-stubs` doesn't contain methods from `wp-includes/compat.php`

- https://github.com/php-stubs/wordpress-stubs/issues/100

## How

Prior art: 
- https://github.com/WordPress/performance/pull/1188