### PR TITLE
Add type property to empty input schema

### DIFF
--- a/includes/Domain/Tools/McpTool.php
+++ b/includes/Domain/Tools/McpTool.php
@@ -275,7 +275,9 @@ class McpTool {
 	 * @return array
 	 */
 	public function to_array(): array {
-		$input_schema_for_json = empty( $this->input_schema ) ? (object) array() : $this->input_schema;
+		$input_schema_for_json = empty( $this->input_schema )
+			? array( 'type' => 'object' )
+			: $this->input_schema;
 
 		$tool_data = array(
 			'name'        => $this->name,


### PR DESCRIPTION
In cursor tools will fail to register if the input schema is empty. This is what solved it for me.

Issue: https://github.com/WordPress/mcp-adapter/issues/35