### PR TITLE
Add structuredContent to tool callback response

### DIFF
--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -143,6 +143,7 @@ class ToolsHandler {
 				$response['content'][0]['mimeType'] = $result['mimeType'] ?? 'image/png';
 			} else {
 				$response['content'][0]['text'] = wp_json_encode( $result );
+				$response['structuredContent'] = $result;
 			}
 
 			return $response;

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -143,7 +143,7 @@ class ToolsHandler {
 				$response['content'][0]['mimeType'] = $result['mimeType'] ?? 'image/png';
 			} else {
 				$response['content'][0]['text'] = wp_json_encode( $result );
-				$response['structuredContent'] = $result;
+				$response['structuredContent']  = $result;
 			}
 
 			return $response;


### PR DESCRIPTION
When using the mcp-adapter in Cursor, ran into issues detecting the tool. The error looks like this:  `{"error": "MCP error -32600: Tool <name> has an output schema but did not return structured content"}`. 

I was reading here: 
https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
https://github.com/modelcontextprotocol/typescript-sdk/issues/911

 and found that Cursor and other IDE's handle their MCP implementation inconsistently. VS Code did not have this error, because it seems to not check for existence of `outputSchema` and expect a `structuredContent` object, while Cursor does.
 
Adding `structuredContent` to the output fixes it.

I have tested this when creating a tool that has no `outputSchema`, and it still seems to work just fine. It may need to be improved to check for `outputSchema` first before including `structuredContent`