### PR TITLE
Fix WordPress WP_Error handling in MCP handlers

### DIFF
--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -111,7 +111,13 @@ class PromptsHandler {
 					return array( 'error' => McpErrorFactory::permission_denied( $request_id, 'Access denied for prompt: ' . $prompt_name )['error'] );
 				}
 
-				return $prompt->execute_direct( $arguments );
+				$result = $prompt->execute_direct( $arguments );
+
+				if ( is_wp_error( $result ) ) {
+					return array( 'error' => McpErrorFactory::internal_error( $request_id, 'Error executing prompt' )['error'] );
+				}
+
+				return $result;
 			}
 
 			/**
@@ -128,7 +134,13 @@ class PromptsHandler {
 				return array( 'error' => McpErrorFactory::permission_denied( $request_id, 'Access denied for prompt: ' . $prompt_name )['error'] );
 			}
 
-			return $ability->execute( $arguments );
+			$result = $ability->execute( $arguments );
+
+			if ( is_wp_error( $result ) ) {
+				return array( 'error' => McpErrorFactory::internal_error( $request_id, 'Error executing prompt' )['error'] );
+			}
+
+			return $result;
 		} catch ( \Throwable $e ) {
 			if ( $this->mcp->error_handler ) {
 				$this->mcp->error_handler->log(

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -136,6 +136,10 @@ class ResourcesHandler {
 
 			$contents = $ability->execute( $request_params );
 
+			if ( is_wp_error( $contents ) ) {
+				return array( 'error' => McpErrorFactory::internal_error( $request_id, 'Error reading resource' )['error'] );
+			}
+
 			return array(
 				'contents' => $contents,
 			);

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -291,6 +291,10 @@ class ToolsHandler {
 		try {
 			$result = $ability->execute( $args );
 
+			if ( is_wp_error( $result ) ) {
+				return array( 'error' => McpErrorFactory::internal_error( $request_id, 'Error executing tool' )['error'] );
+			}
+
 			// Track successful tool execution.
 			$this->mcp->observability_handler::record_event(
 				'mcp.tool.execution_success',

--- a/tests/Fixtures/DummyAbility.php
+++ b/tests/Fixtures/DummyAbility.php
@@ -154,6 +154,66 @@ final class DummyAbility {
 				),
 			)
 		);
+
+		// WP_Error tool: returns WP_Error object
+		wp_register_ability(
+			'test/wp-error-tool',
+			array(
+				'label'               => 'WP Error Tool',
+				'description'         => 'Returns a WP_Error object',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return new \WP_Error( 'test_error', 'This is a test error message', array( 'data' => 'test' ) );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+			)
+		);
+
+		// WP_Error resource: returns WP_Error object
+		wp_register_ability(
+			'test/wp-error-resource',
+			array(
+				'label'               => 'WP Error Resource',
+				'description'         => 'Returns a WP_Error object',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return new \WP_Error( 'resource_error', 'Resource could not be loaded', array( 'uri' => 'WordPress://error/resource' ) );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'uri' => 'WordPress://error/resource',
+				),
+			)
+		);
+
+		// WP_Error prompt: returns WP_Error object
+		wp_register_ability(
+			'test/wp-error-prompt',
+			array(
+				'label'               => 'WP Error Prompt',
+				'description'         => 'Returns a WP_Error object',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return new \WP_Error( 'prompt_error', 'Prompt could not be executed', array( 'input' => $input ) );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'arguments' => array(
+						array(
+							'name'        => 'query',
+							'description' => 'Query parameter',
+							'required'    => false,
+						),
+					),
+				),
+			)
+		);
 	}
 
 	public static function unregister_all(): void {
@@ -165,6 +225,9 @@ final class DummyAbility {
 			'test/image',
 			'test/resource',
 			'test/prompt',
+			'test/wp-error-tool',
+			'test/wp-error-resource',
+			'test/wp-error-prompt',
 		);
 
 		// Ensure abilities API is initialized so the registry exists

--- a/tests/Unit/Handlers/PromptsHandlerWpErrorTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerWpErrorTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\MCP\Tests\Unit\Handlers;
+
+use WP\MCP\Core\McpServer;
+use WP\MCP\Handlers\Prompts\PromptsHandler;
+use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
+use WP\MCP\Tests\Fixtures\DummyAbility;
+use WP\MCP\Tests\Fixtures\DummyErrorHandler;
+use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
+use WP\MCP\Tests\TestCase;
+
+final class PromptsHandlerWpErrorTest extends TestCase {
+
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+		do_action( 'abilities_api_init' );
+		DummyAbility::register_all();
+	}
+
+	public function test_wp_error_from_prompt_returns_internal_error(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-prompt' ) );
+		$handler = new PromptsHandler( $server );
+		
+		$result = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name' => 'test-wp-error-prompt',
+					'arguments' => array( 'query' => 'test' ),
+				),
+			),
+			123
+		);
+
+		// Should return an error response
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertArrayNotHasKey( 'messages', $result );
+		
+		// Verify error structure matches MCP error format
+		$error = $result['error'];
+		$this->assertArrayHasKey( 'code', $error );
+		$this->assertArrayHasKey( 'message', $error );
+		
+		// Should be an internal error
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $error['code'] );
+		$this->assertStringContainsString( 'Error executing prompt', $error['message'] );
+	}
+
+	public function test_wp_error_from_prompt_with_different_request_id(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-prompt' ) );
+		$handler = new PromptsHandler( $server );
+		
+		$request_id = 789;
+		$result = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name' => 'test-wp-error-prompt',
+					'arguments' => array(),
+				),
+			),
+			$request_id
+		);
+
+		$this->assertArrayHasKey( 'error', $result );
+		
+		// The error should contain the internal error code
+		$error = $result['error'];
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $error['code'] );
+	}
+
+	public function test_successful_prompt_execution_still_works(): void {
+		$server  = $this->makeServer( array( 'test/prompt', 'test/wp-error-prompt' ) );
+		$handler = new PromptsHandler( $server );
+		
+		// Test that normal prompts still work
+		$result = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name' => 'test-prompt',
+					'arguments' => array( 'code' => 'test code' ),
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'messages', $result );
+		$this->assertArrayNotHasKey( 'error', $result );
+		
+		// Verify the prompt response structure
+		$this->assertIsArray( $result['messages'] );
+		$this->assertNotEmpty( $result['messages'] );
+		$this->assertArrayHasKey( 'role', $result['messages'][0] );
+		$this->assertSame( 'assistant', $result['messages'][0]['role'] );
+	}
+
+	public function test_wp_error_prompt_mixed_with_normal_prompts(): void {
+		$server  = $this->makeServer( array( 'test/prompt', 'test/wp-error-prompt' ) );
+		$handler = new PromptsHandler( $server );
+		
+		// Test normal prompt
+		$normal_result = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name' => 'test-prompt',
+					'arguments' => array( 'code' => 'test' ),
+				),
+			)
+		);
+		$this->assertArrayHasKey( 'messages', $normal_result );
+		
+		// Test error prompt
+		$error_result = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name' => 'test-wp-error-prompt',
+					'arguments' => array(),
+				),
+			)
+		);
+		$this->assertArrayHasKey( 'error', $error_result );
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $error_result['error']['code'] );
+	}
+
+	public function test_wp_error_prompt_with_arguments(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-prompt' ) );
+		$handler = new PromptsHandler( $server );
+		
+		$result = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name' => 'test-wp-error-prompt',
+					'arguments' => array(
+						'query' => 'complex query',
+						'context' => 'test context',
+					),
+				),
+			)
+		);
+
+		// Even with arguments, WP_Error should still be handled
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $result['error']['code'] );
+	}
+
+	public function test_wp_error_vs_exception_handling_in_prompts(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-prompt', 'test/permission-exception' ) );
+		$handler = new PromptsHandler( $server );
+		
+		// Test WP_Error prompt
+		$wp_error_result = $handler->get_prompt(
+			array(
+				'params' => array( 'name' => 'test-wp-error-prompt' ),
+			)
+		);
+		
+		// Test exception prompt (using permission-exception as it will throw during execution)
+		$exception_result = $handler->get_prompt(
+			array(
+				'params' => array( 'name' => 'test-permission-exception' ),
+			)
+		);
+
+		// Both should return internal errors
+		$this->assertArrayHasKey( 'error', $wp_error_result );
+		$this->assertArrayHasKey( 'error', $exception_result );
+		
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $wp_error_result['error']['code'] );
+		
+		// The exception case should return a different error (permission check failed)
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $exception_result['error']['code'] );
+		
+		// Both should contain error messages
+		$this->assertStringContainsString( 'Error executing prompt', $wp_error_result['error']['message'] );
+		$this->assertStringContainsString( 'Prompt execution failed', $exception_result['error']['message'] );
+	}
+
+	public function test_missing_prompt_name_returns_missing_parameter_error(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-prompt' ) );
+		$handler = new PromptsHandler( $server );
+		
+		$result = $handler->get_prompt(
+			array(
+				'params' => array(
+					'arguments' => array(),
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertSame( McpErrorFactory::MISSING_PARAMETER, $result['error']['code'] );
+		$this->assertStringContainsString( 'name', $result['error']['message'] );
+	}
+
+	public function test_unknown_prompt_returns_prompt_not_found_error(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-prompt' ) );
+		$handler = new PromptsHandler( $server );
+		
+		$result = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name' => 'nonexistent-prompt',
+					'arguments' => array(),
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertSame( McpErrorFactory::PROMPT_NOT_FOUND, $result['error']['code'] );
+		$this->assertStringContainsString( 'nonexistent-prompt', $result['error']['message'] );
+	}
+
+	private function makeServer( array $prompts = array() ): McpServer {
+		return new McpServer(
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			array(),
+			array(),
+			$prompts,
+		);
+	}
+}

--- a/tests/Unit/Handlers/ResourcesHandlerWpErrorTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerWpErrorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\MCP\Tests\Unit\Handlers;
+
+use WP\MCP\Core\McpServer;
+use WP\MCP\Handlers\Resources\ResourcesHandler;
+use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
+use WP\MCP\Tests\Fixtures\DummyAbility;
+use WP\MCP\Tests\Fixtures\DummyErrorHandler;
+use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
+use WP\MCP\Tests\TestCase;
+
+final class ResourcesHandlerWpErrorTest extends TestCase {
+
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+		do_action( 'abilities_api_init' );
+		DummyAbility::register_all();
+	}
+
+	public function test_wp_error_from_resource_returns_internal_error(): void {
+		wp_set_current_user( 1 );
+		$server  = $this->makeServer( array( 'test/wp-error-resource' ) );
+		$handler = new ResourcesHandler( $server );
+		
+		$result = $handler->read_resource( 
+			array( 'params' => array( 'uri' => 'WordPress://error/resource' ) ), 
+			123 
+		);
+
+		// Should return an error response
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertArrayNotHasKey( 'contents', $result );
+		
+		// Verify error structure matches MCP error format
+		$error = $result['error'];
+		$this->assertArrayHasKey( 'code', $error );
+		$this->assertArrayHasKey( 'message', $error );
+		
+		// Should be an internal error
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $error['code'] );
+		$this->assertStringContainsString( 'Error reading resource', $error['message'] );
+	}
+
+	public function test_wp_error_from_resource_with_different_request_id(): void {
+		wp_set_current_user( 1 );
+		$server  = $this->makeServer( array( 'test/wp-error-resource' ) );
+		$handler = new ResourcesHandler( $server );
+		
+		$request_id = 456;
+		$result = $handler->read_resource( 
+			array( 'params' => array( 'uri' => 'WordPress://error/resource' ) ), 
+			$request_id
+		);
+
+		$this->assertArrayHasKey( 'error', $result );
+		
+		// The error should contain the internal error code
+		$error = $result['error'];
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $error['code'] );
+	}
+
+	public function test_successful_resource_read_still_works(): void {
+		wp_set_current_user( 1 );
+		$server  = $this->makeServer( array( 'test/resource', 'test/wp-error-resource' ) );
+		$handler = new ResourcesHandler( $server );
+		
+		// Test that normal resources still work
+		$result = $handler->read_resource( 
+			array( 'params' => array( 'uri' => 'WordPress://local/resource-1' ) ) 
+		);
+
+		$this->assertArrayHasKey( 'contents', $result );
+		$this->assertArrayNotHasKey( 'error', $result );
+		$this->assertSame( 'content', $result['contents'] );
+	}
+
+	public function test_wp_error_resource_mixed_with_normal_resources(): void {
+		wp_set_current_user( 1 );
+		$server  = $this->makeServer( array( 'test/resource', 'test/wp-error-resource' ) );
+		$handler = new ResourcesHandler( $server );
+		
+		// Test normal resource
+		$normal_result = $handler->read_resource( 
+			array( 'params' => array( 'uri' => 'WordPress://local/resource-1' ) ) 
+		);
+		$this->assertArrayHasKey( 'contents', $normal_result );
+		
+		// Test error resource
+		$error_result = $handler->read_resource( 
+			array( 'params' => array( 'uri' => 'WordPress://error/resource' ) ) 
+		);
+		$this->assertArrayHasKey( 'error', $error_result );
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $error_result['error']['code'] );
+	}
+
+	private function makeServer( array $resources = array() ): McpServer {
+		return new McpServer(
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			array(),
+			$resources,
+		);
+	}
+}

--- a/tests/Unit/Handlers/ToolsHandlerWpErrorTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerWpErrorTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\MCP\Tests\Unit\Handlers;
+
+use WP\MCP\Core\McpServer;
+use WP\MCP\Handlers\Tools\ToolsHandler;
+use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
+use WP\MCP\Tests\Fixtures\DummyAbility;
+use WP\MCP\Tests\Fixtures\DummyErrorHandler;
+use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
+use WP\MCP\Tests\TestCase;
+
+final class ToolsHandlerWpErrorTest extends TestCase {
+
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+		do_action( 'abilities_api_init' );
+		DummyAbility::register_all();
+	}
+
+	public function test_wp_error_from_tool_returns_internal_error(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-tool' ) );
+		$handler = new ToolsHandler( $server );
+		
+		$result = $handler->call_tool(
+			array(
+				'params' => array(
+					'name' => 'test-wp-error-tool',
+				),
+			),
+			123
+		);
+
+		// Should return an error response
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertArrayNotHasKey( 'content', $result );
+		
+		// Verify error structure matches MCP error format
+		$error = $result['error'];
+		$this->assertArrayHasKey( 'code', $error );
+		$this->assertArrayHasKey( 'message', $error );
+		
+		// Should be an internal error
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $error['code'] );
+		$this->assertStringContainsString( 'Error executing tool', $error['message'] );
+	}
+
+	public function test_wp_error_from_tool_with_different_request_id(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-tool' ) );
+		$handler = new ToolsHandler( $server );
+		
+		$request_id = 789;
+		$result = $handler->call_tool(
+			array(
+				'params' => array(
+					'name' => 'test-wp-error-tool',
+				),
+			),
+			$request_id
+		);
+
+		$this->assertArrayHasKey( 'error', $result );
+		
+		// The error should contain the internal error code
+		$error = $result['error'];
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $error['code'] );
+	}
+
+	public function test_successful_tool_execution_still_works(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed', 'test/wp-error-tool' ) );
+		$handler = new ToolsHandler( $server );
+		
+		// Test that normal tools still work
+		$result = $handler->call_tool(
+			array(
+				'params' => array(
+					'name' => 'test-always-allowed',
+					'arguments' => array( 'test' => 'data' ),
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'content', $result );
+		$this->assertArrayNotHasKey( 'error', $result );
+		$this->assertSame( 'text', $result['content'][0]['type'] );
+		
+		// Verify the structured content is correct
+		$this->assertArrayHasKey( 'structuredContent', $result );
+		$this->assertArrayHasKey( 'ok', $result['structuredContent'] );
+		$this->assertTrue( $result['structuredContent']['ok'] );
+	}
+
+	public function test_wp_error_tool_mixed_with_normal_tools(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed', 'test/wp-error-tool' ) );
+		$handler = new ToolsHandler( $server );
+		
+		// Test normal tool
+		$normal_result = $handler->call_tool(
+			array(
+				'params' => array(
+					'name' => 'test-always-allowed',
+					'arguments' => array(),
+				),
+			)
+		);
+		$this->assertArrayHasKey( 'content', $normal_result );
+		
+		// Test error tool
+		$error_result = $handler->call_tool(
+			array(
+				'params' => array(
+					'name' => 'test-wp-error-tool',
+				),
+			)
+		);
+		$this->assertArrayHasKey( 'error', $error_result );
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $error_result['error']['code'] );
+	}
+
+	public function test_wp_error_tool_with_arguments(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-tool' ) );
+		$handler = new ToolsHandler( $server );
+		
+		$result = $handler->call_tool(
+			array(
+				'params' => array(
+					'name' => 'test-wp-error-tool',
+					'arguments' => array(
+						'param1' => 'value1',
+						'param2' => 'value2',
+					),
+				),
+			)
+		);
+
+		// Even with arguments, WP_Error should still be handled
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $result['error']['code'] );
+	}
+
+	public function test_wp_error_vs_exception_handling(): void {
+		$server  = $this->makeServer( array( 'test/wp-error-tool', 'test/execute-exception' ) );
+		$handler = new ToolsHandler( $server );
+		
+		// Test WP_Error tool
+		$wp_error_result = $handler->call_tool(
+			array(
+				'params' => array( 'name' => 'test-wp-error-tool' ),
+			)
+		);
+		
+		// Test exception tool
+		$exception_result = $handler->call_tool(
+			array(
+				'params' => array( 'name' => 'test-execute-exception' ),
+			)
+		);
+
+		// Both should return internal errors, but they're handled differently
+		$this->assertArrayHasKey( 'error', $wp_error_result );
+		$this->assertArrayHasKey( 'error', $exception_result );
+		
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $wp_error_result['error']['code'] );
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $exception_result['error']['code'] );
+		
+		// Both should contain "Error executing tool" as that's the message used in both cases
+		// The WP_Error path and exception path both use the same error message
+		$this->assertStringContainsString( 'Error executing tool', $wp_error_result['error']['message'] );
+		$this->assertStringContainsString( 'Error executing tool', $exception_result['error']['message'] );
+	}
+
+	private function makeServer( array $tools ): McpServer {
+		return new McpServer(
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			$tools,
+		);
+	}
+}


### PR DESCRIPTION
Fixes #39

### Problem

The MCP adapter's handlers (Tools, Resources, and Prompts) were not properly handling WordPress `WP_Error` objects returned by ability execution. When abilities returned `WP_Error` objects, they were being passed through as-is instead of being converted to proper MCP-compliant error responses, causing protocol violations and inconsistent error handling.

### Solution

Added comprehensive `WP_Error` handling across all three MCP handlers to ensure WordPress errors are correctly converted to MCP internal error responses.

### Changes Made

#### **Core Handler Updates**

**ToolsHandler** (`includes/Handlers/Tools/ToolsHandler.php`)
- Added `is_wp_error()` check after ability execution (line 294-296)
- Returns proper MCP internal error response when `WP_Error` is detected

**ResourcesHandler** (`includes/Handlers/Resources/ResourcesHandler.php`)  
- Added `is_wp_error()` check after ability execution (line 139-141)
- Returns proper MCP internal error response when `WP_Error` is detected

**PromptsHandler** (`includes/Handlers/Prompts/PromptsHandler.php`)
- Added `is_wp_error()` handling for **both execution paths**:
  - Builder-based prompt execution: `$prompt->execute_direct()` (lines 114-120)
  - Traditional ability-based execution: `$ability->execute()` (lines 137-143)
- Ensures consistent error handling across all prompt execution methods

#### **Comprehensive Test Coverage**

Added **18 new tests** across three new test files:

**ResourcesHandlerWpErrorTest.php** (4 tests)
- WP_Error returns proper MCP internal error
- Different request IDs handled correctly
- Normal resources continue to work
- Mixed error/normal resource scenarios

**ToolsHandlerWpErrorTest.php** (6 tests)
- WP_Error returns proper MCP internal error  
- Different request IDs handled correctly
- Normal tools continue to work
- Mixed error/normal tool scenarios
- WP_Error handling with arguments
- WP_Error vs exception handling comparison

**PromptsHandlerWpErrorTest.php** (8 tests)
- WP_Error returns proper MCP internal error
- Different request IDs handled correctly
- Normal prompts continue to work
- Mixed error/normal prompt scenarios
- WP_Error handling with arguments
- WP_Error vs exception handling comparison  
- Missing parameter error handling
- Unknown prompt error handling

#### **Test Infrastructure**

**Enhanced DummyAbility fixtures** (`tests/Fixtures/DummyAbility.php`)
- Added `test/wp-error-tool`: Returns `WP_Error` for tool testing
- Added `test/wp-error-resource`: Returns `WP_Error` for resource testing
- Added `test/wp-error-prompt`: Returns `WP_Error` for prompt testing

### Error Response Format

All handlers now consistently return MCP-compliant error responses:

```json
{
  "error": {
    "code": -32603,
    "message": "Internal error: Error executing [tool|resource|prompt]"
  }
}
```

### Benefits

1. **Protocol Compliance**: WordPress errors are now properly converted to MCP error responses
2. **Consistency**: All three handlers use identical error handling patterns
3. **Robustness**: Prevents protocol violations from malformed responses
4. **Observability**: Maintains proper error tracking and logging
5. **Compatibility**: Existing functionality remains completely unchanged

### Breaking Changes

None. This is a backward-compatible enhancement that only affects error scenarios.

---

**Reviewers:** Please verify that the error handling patterns are consistent across all handlers and that the test coverage adequately validates both success and error scenarios.