### PR TITLE
Relax parameter validation to allow some falsy values as parameters.

### DIFF
--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -110,9 +110,11 @@ class ToolsHandler {
 		if ( ! empty( $request_params['arguments'] ) ) {
 			foreach ( $request_params['arguments'] as $key => $value ) {
 				// Only remove truly empty values (null, empty strings) but preserve valid falsy values like 0
-				if ( null === $value || '' === $value || 'null' === $value ) {
-					unset( $request_params['arguments'][ $key ] );
+				if ( null !== $value && '' !== $value && 'null' !== $value ) {
+					continue;
 				}
+
+				unset( $request_params['arguments'][ $key ] );
 			}
 		}
 

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -106,18 +106,6 @@ class ToolsHandler {
 			return array( 'error' => McpErrorFactory::missing_parameter( $request_id, 'name' )['error'] );
 		}
 
-		// Clean parameters arguments.
-		if ( ! empty( $request_params['arguments'] ) ) {
-			foreach ( $request_params['arguments'] as $key => $value ) {
-				// Only remove truly empty values (null, empty strings) but preserve valid falsy values like 0
-				if ( null !== $value && '' !== $value && 'null' !== $value ) {
-					continue;
-				}
-
-				unset( $request_params['arguments'][ $key ] );
-			}
-		}
-
 		try {
 			// Implement a tool calling logic here.
 			$result = $this->handle_tool_call( $request_params, $request_id );

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -109,11 +109,10 @@ class ToolsHandler {
 		// Clean parameters arguments.
 		if ( ! empty( $request_params['arguments'] ) ) {
 			foreach ( $request_params['arguments'] as $key => $value ) {
-				if ( ! empty( $value ) && 'null' !== $value ) {
-					continue;
+				// Only remove truly empty values (null, empty strings) but preserve valid falsy values like 0
+				if ( null === $value || '' === $value || 'null' === $value ) {
+					unset( $request_params['arguments'][ $key ] );
 				}
-
-				unset( $request_params['arguments'][ $key ] );
 			}
 		}
 

--- a/tests/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerCallTest.php
@@ -62,6 +62,7 @@ final class ToolsHandlerCallTest extends TestCase {
 						'a' => '',
 						'b' => 'null',
 						'c' => 'ok',
+						'd' => 0,
 					),
 				),
 			)
@@ -73,7 +74,7 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertSame(
 			array(
 				'ok'   => true,
-				'echo' => array( 'c' => 'ok' ),
+				'echo' => array( 'c' => 'ok', 'd' => 0 ),
 			),
 			$payload
 		);

--- a/tests/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerCallTest.php
@@ -51,35 +51,6 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertNotEmpty( DummyErrorHandler::$logs );
 	}
 
-	public function test_arguments_trimmed_before_execution(): void {
-		$server  = $this->makeServer( array( 'test/always-allowed' ) );
-		$handler = new ToolsHandler( $server );
-		$res     = $handler->call_tool(
-			array(
-				'params' => array(
-					'name'      => 'test-always-allowed',
-					'arguments' => array(
-						'a' => '',
-						'b' => 'null',
-						'c' => 'ok',
-						'd' => 0,
-					),
-				),
-			)
-		);
-
-		$this->assertArrayHasKey( 'content', $res );
-		$this->assertSame( 'text', $res['content'][0]['type'] );
-		$payload = json_decode( $res['content'][0]['text'], true );
-		$this->assertSame(
-			array(
-				'ok'   => true,
-				'echo' => array( 'c' => 'ok', 'd' => 0 ),
-			),
-			$payload
-		);
-	}
-
 	public function test_permission_denied_returns_error(): void {
 		$server  = $this->makeServer( array( 'test/permission-denied' ) );
 		$handler = new ToolsHandler( $server );


### PR DESCRIPTION
While using the adapter I found that `0` could not be sent as a parameter to the tools.

I am relaxing the check here to allow `0` and any other falsy value except from: `'null'`, `''` and `null`.

I can relax that even more but I am missing context on why those were added in first place.