### PR TITLE
Change type from library to wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "wordpress/mcp-adapter",
 	"description": "Adapter for Abilities API, letting WordPress abilities to be used as MCP tools, resources or prompts",
 	"license": "GPL-2.0-or-later",
-	"type": "library",
+	"type": "wordpress-plugin",
 	"keywords": [
 		"wordpress",
 		"mcp",


### PR DESCRIPTION
To use Composer for installing into the plugin folder, the type should be 'wordpress-plugin'.

In order to use Composer as described in the readme the type should be updated.

Docs:

#### With Composer

Until the plugin is available on Packagist, you will need to add the repository to your `composer.json` file.


```jsonc
{
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/WordPress/abilities-api.git"
    },
    {
      "type": "vcs",
      "url": "https://github.com/WordPress/mcp-adapter.git"
    }
    // ... other repositories.
  ],
  "extra": {
    "installer-paths": {
      // This should match your WordPress+Composer setup.
      "wp-content/plugins/{$name}/": [
          "type:wordpress-plugin"
      ]
      // .. other paths.
    }
  }
  // ... rest of your composer.json.
}
```

Then, require the package in your project:

```bash
composer require wordpress/abilities-api wordpress/mcp-adapter
```