### PR TITLE
Fix metadata appearing in tool response content

### DIFF
--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -133,6 +133,15 @@ class ToolsHandler {
 				),
 			);
 
+			// Extract and store metadata before adding result to response content.
+			$response['_metadata'] = $result['_metadata'] ?? array(
+				'component_type' => 'tool',
+				'tool_name'      => $request_params['name'],
+			);
+
+			// Remove metadata from result so it doesn't appear in content or structuredContent.
+			unset( $result['_metadata'] );
+
 			// @todo: add support for EmbeddedResource schema.ts:619.
 			if ( isset( $result['type'] ) && 'image' === $result['type'] ) {
 				$response['content'][0]['type'] = 'image';
@@ -144,12 +153,6 @@ class ToolsHandler {
 				$response['content'][0]['text'] = wp_json_encode( $result );
 				$response['structuredContent']  = $result;
 			}
-
-			// Add metadata from result if present, or create basic metadata.
-			$response['_metadata'] = $result['_metadata'] ?? array(
-				'component_type' => 'tool',
-				'tool_name'      => $request_params['name'],
-			);
 
 			return $response;
 		} catch ( \Throwable $exception ) {


### PR DESCRIPTION
## Why
  Internal `_metadata` fields were appearing in the client-facing response, showing up in both the `structuredContent` object and the JSON-encoded `content[0].text` field.
   This metadata is intended only for internal observability tracking and should not be exposed to MCP clients.

  ## What
  - Extract `_metadata` from the result **before** adding it to response content/structuredContent
  - Add `unset($result['_metadata'])` to ensure metadata is removed from the result
  - Reorder operations in `ToolsHandler::call_tool()` to:
    1. Extract metadata first
    2. Remove it from result
    3. Then add cleaned result to response

  This ensures metadata is only present at the top level of the response (where `RequestRouter` removes it) and never reaches the client.