### PR TITLE
Fix tool error handling to comply with MCP specification

### DIFF
--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -113,15 +113,41 @@ class ToolsHandler {
 			// Implement a tool calling logic here.
 			$result = $this->handle_tool_call( $request_params, $request_id );
 
-			// Check if the result contains a protocol error (tool not found, permission denied, etc.).
+			// Check if the result contains an error.
+			// Distinguish between protocol errors (JSON-RPC format) and tool execution errors (isError format).
 			if ( isset( $result['error'] ) ) {
-				return $result; // Return protocol error directly (already has _metadata).
-			}
+				$failure_reason = $result['_metadata']['failure_reason'] ?? '';
 
-			// Check if the result is a tool execution error (business logic failure).
-			if ( isset( $result['isError'] ) && true === $result['isError'] ) {
-				// Tool execution error - return as successful response with isError: true.
-				return $result; // Already has _metadata.
+				// Protocol errors (keep JSON-RPC error format):
+				// - not_found (tool doesn't exist)
+				// - ability_retrieval_failed (internal error getting ability)
+				$protocol_errors = array( 'not_found', 'ability_retrieval_failed' );
+
+				if ( in_array( $failure_reason, $protocol_errors, true ) ) {
+					// Return as JSON-RPC error
+					return $result;
+				}
+
+				// Tool execution errors (convert to isError: true format):
+				// - permission_denied, permission_check_failed
+				// - wp_error, execution_failed
+				$error_message = $result['error']['message'] ?? 'An error occurred while executing the tool.';
+				$response      = array(
+					'content' => array(
+						array(
+							'type' => 'text',
+							'text' => $error_message,
+						),
+					),
+					'isError' => true,
+				);
+
+				// Preserve metadata if present.
+				if ( isset( $result['_metadata'] ) ) {
+					$response['_metadata'] = $result['_metadata'];
+				}
+
+				return $response;
 			}
 
 			// Successful tool execution - format the response.
@@ -317,15 +343,11 @@ class ToolsHandler {
 					)
 				);
 
-				// Return tool execution error (not protocol error) according to MCP spec.
-				// This should be handled as a successful response with isError: true.
+				// Return error for conversion to isError format by call_tool().
 				return array(
-					'isError'   => true,
-					'content'   => array(
-						array(
-							'type' => 'text',
-							'text' => $result->get_error_message(),
-						),
+					'error'     => array(
+						'message' => $result->get_error_message(),
+						'code'    => $result->get_error_code(),
 					),
 					'_metadata' => array(
 						'component_type' => 'tool',
@@ -354,15 +376,10 @@ class ToolsHandler {
 				)
 			);
 
-			// Return tool execution error (not protocol error) according to MCP spec.
-			// This should be handled as a successful response with isError: true.
+			// Return error for conversion to isError format by call_tool().
 			return array(
-				'isError'   => true,
-				'content'   => array(
-					array(
-						'type' => 'text',
-						'text' => $e->getMessage(),
-					),
+				'error'     => array(
+					'message' => $e->getMessage(),
 				),
 				'_metadata' => array(
 					'component_type' => 'tool',

--- a/tests/Integration/ErrorHandlingIntegrationTest.php
+++ b/tests/Integration/ErrorHandlingIntegrationTest.php
@@ -99,7 +99,9 @@ final class ErrorHandlingIntegrationTest extends TestCase {
 		// This should trigger an error and log it
 		$result = $handler->call_tool( array( 'params' => array( 'name' => 'test-permission-exception' ) ) );
 
-		$this->assertArrayHasKey( 'error', $result );
+		// Permission exceptions are tool execution errors (isError: true)
+		$this->assertArrayHasKey( 'isError', $result );
+		$this->assertTrue( $result['isError'] );
 		$this->assertNotEmpty( DummyErrorHandler::$logs );
 
 		$log = DummyErrorHandler::$logs[0];

--- a/tests/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerCallTest.php
@@ -34,10 +34,13 @@ final class ToolsHandlerCallTest extends TestCase {
 				'params' => array( 'name' => 'test-permission-denied' ),
 			)
 		);
-		$this->assertArrayHasKey( 'error', $res );
-		$this->assertArrayHasKey( 'code', $res['error'] );
-		$this->assertArrayHasKey( 'message', $res['error'] );
-		$this->assertStringContainsString( 'Permission denied', $res['error']['message'] );
+		// Permission denied is now returned as isError: true (tool execution error)
+		$this->assertArrayHasKey( 'isError', $res );
+		$this->assertTrue( $res['isError'] );
+		$this->assertArrayHasKey( 'content', $res );
+		$this->assertIsArray( $res['content'] );
+		$this->assertArrayHasKey( 'text', $res['content'][0] );
+		$this->assertStringContainsString( 'Permission denied', $res['content'][0]['text'] );
 	}
 
 	public function test_permission_exception_logs_and_returns_error(): void {
@@ -48,7 +51,9 @@ final class ToolsHandlerCallTest extends TestCase {
 				'params' => array( 'name' => 'test-permission-exception' ),
 			)
 		);
-		$this->assertArrayHasKey( 'error', $res );
+		// Permission check exception is returned as isError: true (tool execution error)
+		$this->assertArrayHasKey( 'isError', $res );
+		$this->assertTrue( $res['isError'] );
 		$this->assertNotEmpty( DummyErrorHandler::$logs );
 	}
 


### PR DESCRIPTION
Implement proper distinction between protocol errors and tool execution errors according to MCP spec (https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling):

Protocol errors (JSON-RPC format with 'error' key):
- Tool not found
- Missing required parameters
- Internal errors (ability retrieval failures)

Tool execution errors (isError: true format):
- Permission denied
- Permission check failures
- Execution failures
- WP_Error from ability execution

Changes:
- ToolsHandler::call_tool() now distinguishes error types based on failure_reason metadata
- Permission denied, permission check failures, and execution errors now return {content: [{type: 'text', text: '...'}], isError: true}
- Protocol errors still return JSON-RPC error format
- Update 7 tests to expect isError format for tool execution errors
- Remove impossible is_wp_error() check (PHPStan was correct)

Fixes #69