### PR TITLE
Fix WP_Error handling in PromptsHandler and ResourcesHandler

### DIFF
--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -159,7 +159,33 @@ class PromptsHandler {
 				);
 			}
 
-			$result              = $ability->execute( $arguments );
+			$result = $ability->execute( $arguments );
+
+			// Handle WP_Error objects that weren't converted by the ability.
+			if ( is_wp_error( $result ) ) {
+				$this->mcp->error_handler->log(
+					'Ability returned WP_Error object',
+					array(
+						'ability'       => $ability->get_name(),
+						'error_code'    => $result->get_error_code(),
+						'error_message' => $result->get_error_message(),
+					)
+				);
+
+				return array(
+					'error'     => McpErrorFactory::internal_error( $request_id, $result->get_error_message() )['error'],
+					'_metadata' => array(
+						'component_type' => 'prompt',
+						'prompt_name'    => $prompt_name,
+						'ability_name'   => $ability->get_name(),
+						'failure_reason' => 'wp_error',
+						'error_code'     => $result->get_error_code(),
+						'is_builder'     => false,
+					),
+				);
+			}
+
+			// Successful execution - add metadata.
 			$result['_metadata'] = array(
 				'component_type' => 'prompt',
 				'prompt_name'    => $prompt_name,

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -130,6 +130,31 @@ class ResourcesHandler {
 
 			$contents = $ability->execute( $request_params );
 
+			// Handle WP_Error objects that weren't converted by the ability.
+			if ( is_wp_error( $contents ) ) {
+				$this->mcp->error_handler->log(
+					'Ability returned WP_Error object',
+					array(
+						'ability'       => $ability->get_name(),
+						'error_code'    => $contents->get_error_code(),
+						'error_message' => $contents->get_error_message(),
+					)
+				);
+
+				return array(
+					'error'     => McpErrorFactory::internal_error( $request_id, $contents->get_error_message() )['error'],
+					'_metadata' => array(
+						'component_type' => 'resource',
+						'resource_uri'   => $uri,
+						'resource_name'  => $resource->get_name(),
+						'ability_name'   => $ability->get_name(),
+						'failure_reason' => 'wp_error',
+						'error_code'     => $contents->get_error_code(),
+					),
+				);
+			}
+
+			// Successful execution - return contents.
 			return array(
 				'contents'  => $contents,
 				'_metadata' => array(


### PR DESCRIPTION
 ## Why

WordPress abilities can legitimately return `WP_Error` objects when validation fails or operations encounter errors. Currently, `PromptsHandler` and `ResourcesHandler` assume `ability->execute()` always returns arrays, causing type errors that crash the MCP server instead of returning graceful error responses.

## What

This PR adds proper `WP_Error` detection and handling in both handlers after `ability->execute()` calls:

  - **PromptsHandler.php**: Check for `WP_Error` after execution and return MCP-compliant error response
  - **ResourcesHandler.php**: Check for `WP_Error` after execution and return MCP-compliant error response

  Both handlers now:
  1. Detect `WP_Error` objects using `is_wp_error()`
  2. Log the error for debugging
  3. Return properly formatted MCP error responses with detailed metadata
  4. Only add metadata to successful results

  This matches the existing pattern already implemented in `ToolsHandler`.
  
Fixes #39
