### PR TITLE
Fix parameter handling for abilities without input schemas on `ExecuteAbilityAbility`

### DIFF
--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -114,7 +114,7 @@ final class ExecuteAbilityAbility {
 		}
 
 		// Check if the user has permission to execute the target ability
-		$parameters        = $input['parameters'] ?? array();
+		$parameters        = empty( $input['parameters'] ) ? null : $input['parameters'];
 		$permission_result = $ability->check_permissions( $parameters );
 
 		// Return WP_Error as-is, or convert other values to boolean
@@ -160,7 +160,7 @@ final class ExecuteAbilityAbility {
 	 */
 	public static function execute( $input = array() ): array {
 		$ability_name = $input['ability_name'] ?? '';
-		$parameters   = $input['parameters'] ?? array();
+		$parameters   = empty( $input['parameters'] ) ? null : $input['parameters'];
 
 		if ( empty( $ability_name ) ) {
 			return array(

--- a/tests/Fixtures/DummyAbility.php
+++ b/tests/Fixtures/DummyAbility.php
@@ -72,15 +72,14 @@ final class DummyAbility {
 				'label'               => 'Always Allowed',
 				'description'         => 'Returns a simple payload',
 				'category'            => 'test',
-				'input_schema'        => array( 'type' => 'object' ),
 				'output_schema'       => array(),
-				'execute_callback'    => static function ( array $input ) {
+				'execute_callback'    => static function () {
 					return array(
 						'ok'   => true,
-						'echo' => $input,
+						'echo' => array(),
 					);
 				},
-				'permission_callback' => static function ( array $input ) {
+				'permission_callback' => static function () {
 					return true;
 				},
 				'meta'                => array(
@@ -99,11 +98,10 @@ final class DummyAbility {
 				'label'               => 'Permission Denied',
 				'description'         => 'Permission denied ability',
 				'category'            => 'test',
-				'input_schema'        => array( 'type' => 'object' ),
-				'execute_callback'    => static function ( array $input ) {
+				'execute_callback'    => static function () {
 					return array( 'should' => 'not run' );
 				},
-				'permission_callback' => static function ( array $input ) {
+				'permission_callback' => static function () {
 					return false;
 				},
 				'meta'                => array(

--- a/tests/Unit/Abilities/ExecuteAbilityAbilityTest.php
+++ b/tests/Unit/Abilities/ExecuteAbilityAbilityTest.php
@@ -133,7 +133,6 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 				'label'               => 'WP Error Permission Test',
 				'description'         => 'Returns WP_Error for permission',
 				'category'            => 'test',
-				'input_schema'        => array( 'type' => 'object' ),
 				'execute_callback'    => static function () {
 					return array( 'test' => 'result' ); },
 				'permission_callback' => static function () {
@@ -269,7 +268,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 		$result = ExecuteAbilityAbility::execute(
 			array(
 				'ability_name' => 'test/always-allowed',
-				'parameters'   => array( 'test_param' => 'test_value' ),
+				'parameters'   => array(),
 			)
 		);
 
@@ -282,7 +281,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 		$this->assertArrayHasKey( 'ok', $data );
 		$this->assertArrayHasKey( 'echo', $data );
 		$this->assertTrue( $data['ok'] );
-		$this->assertEquals( array( 'test_param' => 'test_value' ), $data['echo'] );
+		$this->assertEquals( array(), $data['echo'] );
 	}
 
 	public function test_execute_with_missing_ability_name(): void {
@@ -338,7 +337,6 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 				'label'               => 'WP Error Execution Test',
 				'description'         => 'Returns WP_Error for execution',
 				'category'            => 'test',
-				'input_schema'        => array( 'type' => 'object' ),
 				'execute_callback'    => static function () {
 					return new \WP_Error( 'execution_failed', 'Custom execution error' );
 				},
@@ -377,7 +375,6 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 				'label'               => 'Exception Execution Test',
 				'description'         => 'Throws exception for execution',
 				'category'            => 'test',
-				'input_schema'        => array( 'type' => 'object' ),
 				'execute_callback'    => static function () {
 					throw new \RuntimeException( 'Test execution exception' );
 				},


### PR DESCRIPTION
Convert empty parameters to null instead of defaulting to empty array when executing abilities. This fixes an issue where abilities without defined input schemas would fail validation when called with empty parameter objects from MCP clients.

The previous implementation used `?? array()` which always passed an empty array to the Abilities API, even when no parameters were provided. The Abilities API expects `null` for abilities without input schemas, causing validation to fail.

Changed parameter handling in `check_permission()` and `execute()` methods to properly convert empty/missing parameters to `null`.

Fixes #75