### PR TITLE
Fix null parameter handling in Prompts and Resources handlers

### DIFF
--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -135,7 +135,14 @@ class PromptsHandler {
 			 *
 			 * @var \WP_Ability $ability
 			 */
-			$ability        = $prompt->get_ability();
+			$ability = $prompt->get_ability();
+
+			// If ability has no input schema and arguments is empty, pass null
+			// This is required by WP_Ability::validate_input() which expects null when no schema
+			$ability_input_schema = $ability->get_input_schema();
+			if ( empty( $ability_input_schema ) && empty( $arguments ) ) {
+				$arguments = null;
+			}
 			$has_permission = $ability->check_permissions( $arguments );
 			if ( true !== $has_permission ) {
 				// Extract detailed error message and code if WP_Error was returned

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -105,7 +105,7 @@ class ResourcesHandler {
 		$ability = $resource->get_ability();
 
 		try {
-			$has_permission = $ability->check_permissions( $request_params );
+			$has_permission = $ability->check_permissions( null );
 			if ( true !== $has_permission ) {
 				// Extract detailed error message and code if WP_Error was returned
 				$error_message  = 'Access denied for resource: ' . $resource->get_name();
@@ -128,7 +128,7 @@ class ResourcesHandler {
 				);
 			}
 
-			$contents = $ability->execute( $request_params );
+			$contents = $ability->execute( null );
 
 			return array(
 				'contents'  => $contents,

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -105,7 +105,7 @@ class ResourcesHandler {
 		$ability = $resource->get_ability();
 
 		try {
-			$has_permission = $ability->check_permissions( null );
+			$has_permission = $ability->check_permissions();
 			if ( true !== $has_permission ) {
 				// Extract detailed error message and code if WP_Error was returned
 				$error_message  = 'Access denied for resource: ' . $resource->get_name();
@@ -128,7 +128,7 @@ class ResourcesHandler {
 				);
 			}
 
-			$contents = $ability->execute( null );
+			$contents = $ability->execute();
 
 			return array(
 				'contents'  => $contents,

--- a/tests/Fixtures/DummyAbility.php
+++ b/tests/Fixtures/DummyAbility.php
@@ -191,11 +191,10 @@ final class DummyAbility {
 				'label'               => 'Resource',
 				'description'         => 'A text resource',
 				'category'            => 'test',
-				'input_schema'        => array( 'type' => 'object' ),
-				'execute_callback'    => static function ( array $input ) {
+				'execute_callback'    => static function () {
 					return 'content';
 				},
-				'permission_callback' => static function ( array $input ) {
+				'permission_callback' => static function () {
 					return true;
 				},
 				'meta'                => array(


### PR DESCRIPTION
## Why

Following the fix applied to the tools handler, prompts and resources handlers also need to pass null instead of empty arrays to abilities without input schemas. This ensures consistency across all MCP component types and matches WP_Ability::validate_input() expectations.

## What

  - Update PromptsHandler to pass null when abilities have no input schema and arguments are empty
  - Update ResourcesHandler to pass null for all resource reads (resources don't accept parameters)