### PR TITLE
Fix prompt parameter validation by converting input_schema to MCP arguments

### DIFF
--- a/docs/guides/creating-abilities.md
+++ b/docs/guides/creating-abilities.md
@@ -252,19 +252,54 @@ wp_register_ability('my-plugin/site-config', [
 
 ## Creating Prompts
 
-Prompts generate structured messages for language models and support two types of annotations. They should set `type: 'prompt'` in the MCP configuration:
+Prompts generate structured messages for language models. They use `input_schema` to define parameters, which are automatically converted to MCP prompt arguments format. Prompts should set `type: 'prompt'` in the MCP configuration.
 
-### 1. Template-Level Annotations
-Describe the prompt template's behavior characteristics:
+### Input Schema for Prompts
+
+Prompts use standard JSON Schema `input_schema` to define their parameters. The MCP Adapter automatically converts this to the MCP prompt `arguments` format:
+
+```php
+// Your definition (JSON Schema):
+'input_schema' => [
+    'type' => 'object',
+    'properties' => [
+        'code' => ['type' => 'string', 'description' => 'Code to review']
+    ],
+    'required' => ['code']
+]
+
+// Automatically converted to MCP format:
+'arguments' => [
+    ['name' => 'code', 'description' => 'Code to review', 'required' => true]
+]
+```
+
+### Complete Prompt Example
 
 ```php
 wp_register_ability('my-plugin/code-review', [
     'label' => 'Code Review Prompt',
     'description' => 'Generate a code review prompt with specific focus areas',
+    'input_schema' => [
+        'type' => 'object',
+        'properties' => [
+            'code' => [
+                'type' => 'string',
+                'description' => 'Code to review'
+            ],
+            'focus' => [
+                'type' => 'array',
+                'description' => 'Areas to focus on during review',
+                'items' => ['type' => 'string'],
+                'default' => ['security', 'performance']
+            ]
+        ],
+        'required' => ['code']
+    ],
     'execute_callback' => function($input) {
-        $code = $input['code'] ?? '';
+        $code = $input['code'];
         $focus = $input['focus'] ?? ['security', 'performance'];
-        
+
         return [
             'messages' => [
                 [
@@ -277,22 +312,10 @@ wp_register_ability('my-plugin/code-review', [
             ]
         ];
     },
-    'permission_callback' => function() {
+    'permission_callback' => function($input) {
         return current_user_can('edit_posts');
     },
     'meta' => [
-        'arguments' => [
-            [
-                'name' => 'code',
-                'description' => 'Code to review',
-                'required' => true
-            ],
-            [
-                'name' => 'focus',
-                'description' => 'Areas to focus on during review',
-                'required' => false
-            ]
-        ],
         'annotations' => [
             'readOnlyHint' => true,      // Template doesn't modify data
             'idempotentHint' => true     // Consistent prompt generation
@@ -305,16 +328,27 @@ wp_register_ability('my-plugin/code-review', [
 ]);
 ```
 
-### 2. Message Content Annotations (MCP Specification)
-Annotate the generated message content according to the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#promptmessage):
+### Message Content Annotations (MCP Specification)
+
+You can also annotate the generated message content according to the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#promptmessage):
 
 ```php
 wp_register_ability('my-plugin/analysis-prompt', [
     'label' => 'Analysis Prompt',
     'description' => 'Generate analysis prompts with content annotations',
+    'input_schema' => [
+        'type' => 'object',
+        'properties' => [
+            'data' => [
+                'type' => 'string',
+                'description' => 'Data to analyze'
+            ]
+        ],
+        'required' => ['data']
+    ],
     'execute_callback' => function($input) {
-        $data = $input['data'] ?? '';
-        
+        $data = $input['data'];
+
         return [
             'messages' => [
                 [
@@ -343,13 +377,10 @@ wp_register_ability('my-plugin/analysis-prompt', [
             ]
         ];
     },
-    'permission_callback' => function() {
+    'permission_callback' => function($input) {
         return current_user_can('read');
     },
     'meta' => [
-        'arguments' => [
-            ['name' => 'data', 'description' => 'Data to analyze', 'required' => true]
-        ],
         'annotations' => [
             'readOnlyHint' => true,
             'openWorldHint' => true              // Can handle any data type
@@ -362,12 +393,24 @@ wp_register_ability('my-plugin/analysis-prompt', [
 ]);
 ```
 
-### Content Annotation Types
+### Prompt Annotations Summary
 
-According to the MCP specification, message content supports these annotations:
-- `audience` (array): Intended audience (`["user", "assistant"]`)
-- `priority` (float): Content importance (0.0 to 1.0)
-- `lastModified` (string): ISO 8601 timestamp
+**Template-Level Annotations** (in `meta.annotations`):
+- Apply to the prompt template itself
+- Describe the prompt's behavior characteristics
+- Support all standard MCP annotations (readOnlyHint, idempotentHint, etc.)
+
+**Message Content Annotations** (in message `content.annotations`):
+- Apply to individual messages within the prompt
+- Provide metadata for specific message content
+- Support: `audience`, `priority`, `lastModified`
+
+### Key Points for Prompts
+
+1. **Use `input_schema`** instead of `meta.arguments` - it provides validation and is automatically converted to MCP format
+2. **Callbacks receive validated input** - the Abilities API validates against your schema
+3. **Return MCP message format** - prompts must return `{ messages: [...] }` structure
+4. **Set `type: 'prompt'`** in `meta.mcp` for proper auto-discovery
 
 ## Permission and Security
 

--- a/docs/guides/creating-abilities.md
+++ b/docs/guides/creating-abilities.md
@@ -347,7 +347,7 @@ wp_register_ability('my-plugin/analysis-prompt', [
         'required' => ['data']
     ],
     'execute_callback' => function($input) {
-        $data = $input['data'];
+        $data = $input['data'] ?? '';
 
         return [
             'messages' => [

--- a/docs/guides/creating-abilities.md
+++ b/docs/guides/creating-abilities.md
@@ -312,7 +312,7 @@ wp_register_ability('my-plugin/code-review', [
             ]
         ];
     },
-    'permission_callback' => function($input) {
+    'permission_callback' => function() {
         return current_user_can('edit_posts');
     },
     'meta' => [

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -13,16 +13,31 @@ use WP_Ability;
 /**
  * Converts WordPress abilities to MCP prompts according to the specification.
  *
- * This class extracts prompt data and arguments from ability metadata.
- * The ability meta can contain prompt-specific information like arguments.
+ * This class extracts prompt data from ability properties and converts the JSON Schema
+ * input_schema to MCP prompt arguments format.
  *
- * Example ability meta structure:
- * array(
- *     'arguments' => array(
- *         array('name' => 'code', 'description' => 'Code to review', 'required' => true)
- *     ),
- *     'annotations' => array(...)
- * )
+ * The ability must have an input_schema defined using JSON Schema format, which will
+ * be automatically converted to MCP prompt arguments.
+ *
+ * Example ability registration:
+ * wp_register_ability(
+ *     'prompts/code-review',
+ *     array(
+ *         'label' => 'Code Review Prompt',
+ *         'description' => 'Generate code review prompt',
+ *         'input_schema' => array(
+ *             'type' => 'object',
+ *             'properties' => array(
+ *                 'code' => array('type' => 'string', 'description' => 'Code to review'),
+ *             ),
+ *             'required' => array('code'),
+ *         ),
+ *         'meta' => array(
+ *             'mcp' => array('public' => true, 'type' => 'prompt'),
+ *             'annotations' => array(...)
+ *         )
+ *     )
+ * );
  */
 class RegisterAbilityAsMcpPrompt {
 	/**
@@ -89,18 +104,82 @@ class RegisterAbilityAsMcpPrompt {
 			$prompt_data['description'] = $description;
 		}
 
-		// Get arguments from ability meta
-		$ability_meta = $this->ability->get_meta();
-		if ( ! empty( $ability_meta['arguments'] ) && is_array( $ability_meta['arguments'] ) ) {
-			$prompt_data['arguments'] = $ability_meta['arguments'];
+		// Convert input_schema to MCP prompt arguments format
+		// MCP expects: [{"name": "x", "description": "...", "required": true}, ...]
+		// Abilities use JSON Schema: {"type": "object", "properties": {...}, "required": [...]}
+		$input_schema = $this->ability->get_input_schema();
+		if ( ! empty( $input_schema ) && is_array( $input_schema ) ) {
+			$arguments = $this->convert_input_schema_to_arguments( $input_schema );
+			if ( ! empty( $arguments ) ) {
+				$prompt_data['arguments'] = $arguments;
+			}
 		}
 
 		// Get annotations from ability meta
+		$ability_meta = $this->ability->get_meta();
 		if ( ! empty( $ability_meta['annotations'] ) && is_array( $ability_meta['annotations'] ) ) {
 			$prompt_data['annotations'] = $ability_meta['annotations'];
 		}
 
 		return $prompt_data;
+	}
+
+	/**
+	 * Convert JSON Schema input_schema to MCP prompt arguments format.
+	 *
+	 * Converts from WordPress Abilities JSON Schema format:
+	 * {
+	 *   "type": "object",
+	 *   "properties": {
+	 *     "topic": {"type": "string", "description": "..."},
+	 *     "tone": {"type": "string", "description": "..."}
+	 *   },
+	 *   "required": ["topic"]
+	 * }
+	 *
+	 * To MCP prompt arguments format:
+	 * [
+	 *   {"name": "topic", "description": "...", "required": true},
+	 *   {"name": "tone", "description": "...", "required": false}
+	 * ]
+	 *
+	 * @param array<string,mixed> $input_schema The JSON Schema from ability.
+	 * @return array<int,array<string,mixed>> MCP-formatted arguments array.
+	 */
+	private function convert_input_schema_to_arguments( array $input_schema ): array {
+		$arguments = array();
+
+		// Ensure we have properties to convert
+		if ( empty( $input_schema['properties'] ) || ! is_array( $input_schema['properties'] ) ) {
+			return $arguments;
+		}
+
+		// Get the list of required properties
+		$required_fields = array();
+		if ( isset( $input_schema['required'] ) && is_array( $input_schema['required'] ) ) {
+			$required_fields = $input_schema['required'];
+		}
+
+		// Convert each property to an MCP argument
+		foreach ( $input_schema['properties'] as $property_name => $property_schema ) {
+			if ( ! is_array( $property_schema ) ) {
+				continue;
+			}
+
+			$argument = array(
+				'name'     => $property_name,
+				'required' => in_array( $property_name, $required_fields, true ),
+			);
+
+			// Add description if available
+			if ( ! empty( $property_schema['description'] ) ) {
+				$argument['description'] = $property_schema['description'];
+			}
+
+			$arguments[] = $argument;
+		}
+
+		return $arguments;
 	}
 
 	/**

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -108,7 +108,7 @@ class RegisterAbilityAsMcpPrompt {
 		// MCP expects: [{"name": "x", "description": "...", "required": true}, ...]
 		// Abilities use JSON Schema: {"type": "object", "properties": {...}, "required": [...]}
 		$input_schema = $this->ability->get_input_schema();
-		if ( ! empty( $input_schema ) && is_array( $input_schema ) ) {
+		if ( ! empty( $input_schema ) ) {
 			$arguments = $this->convert_input_schema_to_arguments( $input_schema );
 			if ( ! empty( $arguments ) ) {
 				$prompt_data['arguments'] = $arguments;

--- a/tests/Fixtures/DummyAbility.php
+++ b/tests/Fixtures/DummyAbility.php
@@ -216,7 +216,16 @@ final class DummyAbility {
 				'label'               => 'Prompt',
 				'description'         => 'A sample prompt',
 				'category'            => 'test',
-				'input_schema'        => array( 'type' => 'object' ),
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'code' => array(
+							'type'        => 'string',
+							'description' => 'Code to review',
+						),
+					),
+					'required'   => array( 'code' ),
+				),
 				'execute_callback'    => static function ( array $input ) {
 					return array(
 						'messages' => array(
@@ -234,14 +243,7 @@ final class DummyAbility {
 					return true;
 				},
 				'meta'                => array(
-					'arguments' => array(
-						array(
-							'name'        => 'code',
-							'description' => 'Code to review',
-							'required'    => true,
-						),
-					),
-					'mcp'       => array(
+					'mcp' => array(
 						'public' => true, // Expose via MCP for testing
 						'type'   => 'prompt', // Explicitly mark as prompt
 					),


### PR DESCRIPTION
## Why

Prompts that accept input parameters were failing validation because they lacked the proper MCP arguments format. While abilities use JSON Schema input_schema for validation, MCP prompts require a specific arguments array format for their interface. This mismatch caused validation failures when prompts received input parameters.

## What

  - Add automatic conversion from JSON Schema input_schema to MCP prompt arguments format in RegisterAbilityAsMcpPrompt
  - Implement the convert_input_schema_to_arguments() method that transforms schema properties to MCP arguments
  - Update documentation with comprehensive examples showing the new input_schema approach

This is a breaking change.
