### PR TITLE
Add `wp_` prefix to hook names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ The MCP Adapter automatically creates a default server that exposes all register
 
 ```php
 // Simply register a WordPress ability
-add_action( 'abilities_api_init', function() {
+add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/get-posts', [
         'label' => 'Get Posts',
         'description' => 'Retrieve WordPress posts with optional filtering',

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -37,7 +37,7 @@ Create a WordPress ability that will be exposed via MCP:
 
 ```php
 // Register a simple ability to get site information
-add_action( 'abilities_api_init', function() {
+add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/get-site-info', [
         'label' => 'Get Site Information',
         'description' => 'Retrieves basic information about the current WordPress site',
@@ -179,7 +179,7 @@ curl -X POST "https://yoursite.com/wp-json/mcp-adapter/v1/mcp" \
 - Check WordPress user authentication
 
 **Tool not appearing?**
-- Confirm ability is registered during `abilities_api_init`
+- Confirm ability is registered during `wp_abilities_api_init`
 - Verify ability name matches exactly in server configuration
 - Check permission callback allows current user
 

--- a/docs/getting-started/basic-examples.md
+++ b/docs/getting-started/basic-examples.md
@@ -9,7 +9,7 @@ Tools execute actions and return results. Here's a simple post creation tool:
 ```php
 <?php
 // Register the ability
-add_action( 'abilities_api_init', function() {
+add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/create-post', [
         'label' => 'Create Post',
         'description' => 'Creates a new WordPress post with the specified content',
@@ -122,7 +122,7 @@ Resources provide access to data. They require a `uri` in the ability meta:
 ```php
 <?php
 // Register the ability as a resource
-add_action( 'abilities_api_init', function() {
+add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/site-config', [
         'label' => 'Site Configuration',
         'description' => 'WordPress site configuration and settings',
@@ -175,7 +175,7 @@ Prompts generate structured messages for language models:
 ```php
 <?php
 // Register the ability as a prompt
-add_action( 'abilities_api_init', function() {
+add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/code-review', [
         'label' => 'Code Review Prompt',
         'description' => 'Generate a code review prompt with specific focus areas',

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -81,7 +81,7 @@ class MyMcpPlugin {
     }
     
     private function register_abilities() {
-        add_action( 'abilities_api_init', function() {
+        add_action( 'wp_abilities_api_init', function() {
             wp_register_ability( 'my-plugin/get-posts', [
                 'label' => 'Get Posts',
                 'description' => 'Retrieve WordPress posts',

--- a/docs/guides/default-server.md
+++ b/docs/guides/default-server.md
@@ -352,7 +352,7 @@ The default server uses structured error handling:
 ### No Abilities Returned
 - Check that abilities have `mcp.public=true` in their metadata
 - Verify user is authenticated and has required capabilities
-- Ensure abilities are properly registered during `abilities_api_init`
+- Ensure abilities are properly registered during `wp_abilities_api_init`
 
 ### Permission Denied Errors
 - Verify user authentication (logged in)
@@ -362,7 +362,7 @@ The default server uses structured error handling:
 ### Ability Not Found
 - Ensure ability is registered before MCP server initialization
 - Check ability name spelling and format
-- Verify ability registration happens during `abilities_api_init` action
+- Verify ability registration happens during `wp_abilities_api_init` action
 
 ## Next Steps
 

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -253,8 +253,8 @@ final class McpAdapter {
 		}
 
 		// Register category before abilities
-		add_action( 'abilities_api_categories_init', array( $this, 'register_default_category' ) );
-		add_action( 'abilities_api_init', array( $this, 'register_default_abilities' ) );
+		add_action( 'wp_abilities_api_categories_init', array( $this, 'register_default_category' ) );
+		add_action( 'wp_abilities_api_init', array( $this, 'register_default_abilities' ) );
 
 		add_action( 'mcp_adapter_init', array( DefaultServerFactory::class, 'create' ) );
 	}

--- a/tests/Fixtures/DummyAbility.php
+++ b/tests/Fixtures/DummyAbility.php
@@ -9,7 +9,7 @@ final class DummyAbility {
 	/**
 	 * Registers the 'test' category for dummy abilities.
 	 *
-	 * MUST be called during the 'abilities_api_categories_init' action.
+	 * MUST be called during the 'wp_abilities_api_categories_init' action.
 	 * Does not check if category already exists - if it does, test isolation has failed.
 	 *
 	 * @return void
@@ -28,8 +28,8 @@ final class DummyAbility {
 	 * Registers all dummy abilities for testing.
 	 *
 	 * Sets up action hooks to register category and abilities at the correct times:
-	 * - Category registration during 'abilities_api_categories_init'
-	 * - Abilities registration during 'abilities_api_init'
+	 * - Category registration during 'wp_abilities_api_categories_init'
+	 * - Abilities registration during 'wp_abilities_api_init'
 	 *
 	 * Then fires the hooks if they haven't been fired yet.
 	 * Does not check if abilities already exist - if they do, test isolation has failed.
@@ -38,28 +38,28 @@ final class DummyAbility {
 	 */
 	public static function register_all(): void {
 		// Hook category registration to the proper action
-		add_action( 'abilities_api_categories_init', array( self::class, 'register_category' ) );
+		add_action( 'wp_abilities_api_categories_init', array( self::class, 'register_category' ) );
 
 		// Fire categories init hook if not already fired
-		if ( ! did_action( 'abilities_api_categories_init' ) ) {
-			do_action( 'abilities_api_categories_init' );
+		if ( ! did_action( 'wp_abilities_api_categories_init' ) ) {
+			do_action( 'wp_abilities_api_categories_init' );
 		}
 
 		// Hook abilities registration to the proper action
-		add_action( 'abilities_api_init', array( self::class, 'register_abilities' ) );
+		add_action( 'wp_abilities_api_init', array( self::class, 'register_abilities' ) );
 
 		// Fire abilities init hook if not already fired
-		if ( did_action( 'abilities_api_init' ) ) {
+		if ( did_action( 'wp_abilities_api_init' ) ) {
 			return;
 		}
 
-		do_action( 'abilities_api_init' );
+		do_action( 'wp_abilities_api_init' );
 	}
 
 	/**
 	 * Registers all the dummy abilities.
 	 *
-	 * This method should be called during the 'abilities_api_init' action.
+	 * This method should be called during the 'wp_abilities_api_init' action.
 	 *
 	 * @return void
 	 */
@@ -258,8 +258,8 @@ final class DummyAbility {
 	 */
 	public static function unregister_all(): void {
 		// Remove action hooks to prevent re-registration
-		remove_action( 'abilities_api_categories_init', array( self::class, 'register_category' ) );
-		remove_action( 'abilities_api_init', array( self::class, 'register_abilities' ) );
+		remove_action( 'wp_abilities_api_categories_init', array( self::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( self::class, 'register_abilities' ) );
 
 		// Unregister all abilities
 		$names = array(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,7 +40,7 @@ abstract class TestCase extends PolyfillsTestCase {
 
 		// Register mcp-adapter category during the proper hook
 		add_action(
-			'abilities_api_categories_init',
+			'wp_abilities_api_categories_init',
 			static function () {
 				if ( \WP_Abilities_Category_Registry::get_instance()->is_registered( 'mcp-adapter' ) ) {
 					return;
@@ -57,19 +57,19 @@ abstract class TestCase extends PolyfillsTestCase {
 		);
 
 		// Use DummyAbility to register test category
-		add_action( 'abilities_api_categories_init', array( DummyAbility::class, 'register_category' ) );
+		add_action( 'wp_abilities_api_categories_init', array( DummyAbility::class, 'register_category' ) );
 
 		// Ensure categories API is initialized first
-		if ( ! did_action( 'abilities_api_categories_init' ) ) {
-			do_action( 'abilities_api_categories_init' );
+		if ( ! did_action( 'wp_abilities_api_categories_init' ) ) {
+			do_action( 'wp_abilities_api_categories_init' );
 		}
 
 		// Use DummyAbility to register test abilities
-		add_action( 'abilities_api_init', array( DummyAbility::class, 'register_abilities' ) );
+		add_action( 'wp_abilities_api_init', array( DummyAbility::class, 'register_abilities' ) );
 
 		// Ensure abilities API is initialized so MCP abilities can be registered
-		if ( ! did_action( 'abilities_api_init' ) ) {
-			do_action( 'abilities_api_init' );
+		if ( ! did_action( 'wp_abilities_api_init' ) ) {
+			do_action( 'wp_abilities_api_init' );
 		}
 
 		// Register the default MCP abilities directly for tests
@@ -93,7 +93,7 @@ abstract class TestCase extends PolyfillsTestCase {
 	 * Note: We intentionally do NOT unregister test abilities here.
 	 * Test fixtures from DummyAbility are designed to persist for the entire
 	 * test suite run. This is necessary because WordPress hooks
-	 * (abilities_api_init, abilities_api_categories_init) can only be fired
+	 * (wp_abilities_api_init, wp_abilities_api_categories_init) can only be fired
 	 * once during the test suite execution. Re-registering between test classes
 	 * would fail since the hooks have already been executed.
 	 *

--- a/tests/Unit/Core/McpAdapterConfigTest.php
+++ b/tests/Unit/Core/McpAdapterConfigTest.php
@@ -60,7 +60,7 @@ final class McpAdapterConfigTest extends TestCase {
 		);
 
 		// Ensure abilities API is initialized first
-		if ( ! did_action( 'abilities_api_init' ) ) {
+		if ( ! did_action( 'wp_abilities_api_init' ) ) {
 		}
 
 		// Reset the initialized flag to allow re-initialization


### PR DESCRIPTION
Adds the `wp_` prefix to code and docs.

Fixes #80.