### PR TITLE
Doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Configure MCP clients (Claude Desktop, Claude Code, VS Code, Cursor, etc.) to co
         "@automattic/mcp-wordpress-remote@latest"
       ],
       "env": {
-        "WP_API_URL": "http://your-site.test/wp-json/mcp-adapter/v1/mcp",
+        "WP_API_URL": "http://your-site.test/wp-json/mcp/mcp-adapter-default-server",
         "LOG_FILE": "/path/to/logs/mcp-adapter.log",
         "WP_API_USERNAME": "your-username",
         "WP_API_PASSWORD": "your-application-password"
@@ -461,10 +461,10 @@ add_action('mcp_adapter_init', function($adapter) {
             \WP\MCP\Transport\HttpTransport::class,  // Recommended: MCP 2025-06-18 compliant
         ],
         \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class, // Error handler
+        \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class // Observability handler
         ['my-plugin/my-ability'],         // Abilities to expose as tools
         [],                              // Resources (optional)
         [],                              // Prompts (optional)
-        \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class // Observability handler
     );
 });
 ```

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ The MCP Adapter automatically creates a default server that exposes all register
 - The default server supports both HTTP and STDIO transports with MCP 2025-06-18 compliance
 - Abilities are exposed as tools, resources, or prompts based on their characteristics
 - Built-in error handling and observability are included
-- Access via HTTP: `/wp-json/mcp-adapter/v1/mcp`
+- Access via HTTP: `/wp-json/mcp/mcp-adapter-default-server`
 - Access via STDIO: `wp mcp-adapter serve --server=mcp-adapter-default-server`
 
 <details>

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ add_action('mcp_adapter_init', function($adapter) {
             \WP\MCP\Transport\HttpTransport::class,  // Recommended: MCP 2025-06-18 compliant
         ],
         \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class, // Error handler
-        \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class // Observability handler
+        \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class, // Observability handler
         ['my-plugin/my-ability'],         // Abilities to expose as tools
         [],                              // Resources (optional)
         [],                              // Prompts (optional)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -142,7 +142,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"my-plugin-
 curl "https://yoursite.com/wp-json/"
 
 # Test MCP endpoint (requires authentication)
-curl -X POST "https://yoursite.com/wp-json/mcp-adapter/v1/mcp" \
+curl -X POST "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 ```

--- a/docs/getting-started/basic-examples.md
+++ b/docs/getting-started/basic-examples.md
@@ -244,7 +244,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}' | wp mcp-ada
 
 ### Default Server
 The MCP Adapter automatically creates a default server that exposes all registered abilities:
-- **Endpoint**: `/wp-json/mcp-adapter/v1/mcp`
+- **Endpoint**: `/wp-json/mcp/mcp-adapter-default-server`
 - **Server ID**: `mcp-adapter-default-server`
 - **Automatic Registration**: All abilities become available immediately
 

--- a/docs/getting-started/basic-examples.md
+++ b/docs/getting-started/basic-examples.md
@@ -106,7 +106,7 @@ add_action( 'wp_abilities_api_init', function() {
 });
 ```
 
-The ability is automatically available via the default MCP server at `/wp-json/mcp-adapter/v1/mcp`.
+The ability is automatically available via the default MCP server at `/wp-json/mcp/mcp-adapter-default-server`.
 
 ### Testing the Tool
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -164,7 +164,7 @@ Alternatively, you can install the MCP Adapter as a traditional WordPress plugin
    wp plugin activate mcp-adapter
    ```
 
-The plugin automatically initializes and creates a default MCP server at `/wp-json/wp-json/mcp/mcp-adapter-default-server`.
+The plugin automatically initializes and creates a default MCP server at `/wp-json/mcp/mcp-adapter-default-server`.
 
 ## Verifying Installation
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -183,7 +183,7 @@ The plugin automatically initializes and creates a default MCP server at `/wp-js
    curl "https://yoursite.com/wp-json/"
    
    # Test MCP endpoint (requires authentication)
-   curl -X POST "https://yoursite.com/wp-json/mcp-adapter/v1/mcp" \
+   curl -X POST "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
      -H "Content-Type: application/json" \
      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
    ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -164,7 +164,7 @@ Alternatively, you can install the MCP Adapter as a traditional WordPress plugin
    wp plugin activate mcp-adapter
    ```
 
-The plugin automatically initializes and creates a default MCP server at `/wp-json/mcp-adapter/v1/mcp`.
+The plugin automatically initializes and creates a default MCP server at `/wp-json/wp-json/mcp/mcp-adapter-default-server`.
 
 ## Verifying Installation
 

--- a/docs/guides/transport-permissions.md
+++ b/docs/guides/transport-permissions.md
@@ -16,10 +16,10 @@ $adapter->create_server(
     '1.0.0',
     [\WP\MCP\Transport\HttpTransport::class],
     \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,
+    \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class
     ['my-plugin/tool'], // tools
     [], // resources
     [], // prompts
-    \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class
     // No permission callback = uses is_user_logged_in()
 );
 ```
@@ -39,10 +39,10 @@ $adapter->create_server(
     '1.0.0',
     [\WP\MCP\Transport\HttpTransport::class],
     \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,
+    \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class,
     ['my-plugin/admin-tool'], // tools
     [], // resources
     [], // prompts
-    \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class,
     function(): bool {  // Permission callback
         return current_user_can('manage_options');
     }
@@ -157,10 +157,10 @@ $adapter->create_server(
     '1.0.0',
     [\WP\MCP\Transport\HttpTransport::class],
     \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,
+    \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class,
     ['my-plugin/edit-post', 'my-plugin/delete-post'],
     [], // resources
     [], // prompts
-    \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class,
     function(): bool {
         // Transport: Allow editors and admins
         return current_user_can('edit_posts');

--- a/docs/migration/v0.3.0.md
+++ b/docs/migration/v0.3.0.md
@@ -367,10 +367,10 @@ add_action('mcp_adapter_init', function($adapter) {
         '1.0.0',
         [ HttpTransport::class ],
         ErrorLogMcpErrorHandler::class,
+        NullMcpObservabilityHandler::class,
         ['my-plugin/ability'],
         [],  // resources
         [],  // prompts
-        NullMcpObservabilityHandler::class,
         function() {
             // Custom permission logic
             $api_key = $_SERVER['HTTP_X_API_KEY'] ?? '';

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -172,7 +172,7 @@ add_action( 'rest_api_init', function() {
 ### 401 Unauthorized
 ```bash
 # Test with authentication
-curl -X POST "https://yoursite.com/wp-json/mcp-adapter/v1/mcp" \
+curl -X POST "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
   --user "username:application_password" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'


### PR DESCRIPTION
- Updating default server REST API URLs
- Also includes the correct position of the Observability handler argument in the create_server examples (see https://github.com/WordPress/mcp-adapter/blob/f2f27181141d63e6d543fd29fb61b919cc9d7c60/includes/Core/McpAdapter.php#L88)

Fixes #82 