### PR TITLE
Docs: Fix missing comma in transport permissions example

### DIFF
--- a/docs/guides/transport-permissions.md
+++ b/docs/guides/transport-permissions.md
@@ -16,7 +16,7 @@ $adapter->create_server(
     '1.0.0',
     [\WP\MCP\Transport\HttpTransport::class],
     \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,
-    \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class
+    \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class,
     ['my-plugin/tool'], // tools
     [], // resources
     [], // prompts


### PR DESCRIPTION
## Description
Fixes a syntax error in the transport permissions documentation where a comma was missing after the `NullMcpObservabilityHandler::class` parameter.

Fixes: https://github.com/WordPress/mcp-adapter/issues/84

## Changes
- Added missing comma in the "Default Behavior" code example in `docs/guides/transport-permissions.md`

## Issue
The code example in the "Default Behavior (Logged-in Users)" section had a syntax error that would prevent the code from running if copied directly.

### Before:
```php
\WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class
['my-plugin/tool'], // tools

```

### After:

```php
\WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class,
['my-plugin/tool'], // tools

```