### PR TITLE
Ensures init action fires before initializing in WP-CLI

### DIFF
--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -58,13 +58,7 @@ final class McpAdapter {
 
 			// In WP-CLI context, initialize immediately so commands have access to servers
 			if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
-				// Ensure init action has fired before initializing
-				if ( did_action( 'init' ) ) {
-					self::$instance->init();
-				} else {
-					// If init hasn't fired yet, hook into it
-					add_action( 'init', array( self::$instance, 'init' ), 20 );
-				}
+				add_action( 'init', array( self::$instance, 'init' ), 20 );
 			} else {
 				// Initialize for REST API requests with reasonable priority
 				add_action( 'rest_api_init', array( self::$instance, 'init' ), 15 );

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -58,7 +58,13 @@ final class McpAdapter {
 
 			// In WP-CLI context, initialize immediately so commands have access to servers
 			if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
-				self::$instance->init();
+				// Ensure init action has fired before initializing
+				if ( did_action( 'init' ) ) {
+					self::$instance->init();
+				} else {
+					// If init hasn't fired yet, hook into it
+					add_action( 'init', array( self::$instance, 'init' ), 20 );
+				}
 			} else {
 				// Initialize for REST API requests with reasonable priority
 				add_action( 'rest_api_init', array( self::$instance, 'init' ), 15 );
@@ -115,7 +121,7 @@ final class McpAdapter {
 			return new \WP_Error(
 				'invalid_error_handler',
 				sprintf(
-				/* translators: %s: error handler class name */
+					/* translators: %s: error handler class name */
 					esc_html__( 'Error handler class "%s" does not exist.', 'mcp-adapter' ),
 					esc_html( $error_handler )
 				)


### PR DESCRIPTION
Ensures that the `init` action has fired before initializing the adapter in WP-CLI context.

This prevents potential issues where commands might not have access to servers if the adapter initializes too early. It now hooks into the `init` action if it hasn't already fired.