### PR TITLE
Properly return error messages when using unnested error formats in `ToolsHandler`

### DIFF
--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -131,6 +131,9 @@ class ToolsHandler {
 				// Tool execution errors (convert to isError: true format):
 				// - permission_denied, permission_check_failed
 				// - wp_error, execution_failed
+				// Note: Error format varies by ability implementation. ExecuteAbilityAbility
+				// returns errors as plain strings, while other abilities return an array
+				// with a 'message' key. This handles both formats here for compatibility (#89).
 				if ( is_string( $result['error'] ) ) {
 					$error_message = $result['error'];
 				} else {

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -136,7 +136,7 @@ class ToolsHandler {
 				} else {
 					$error_message = $result['error']['message'] ?? 'An error occurred while executing the tool.';
 				}
-				$response      = array(
+				$response = array(
 					'content' => array(
 						array(
 							'type' => 'text',

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -131,7 +131,11 @@ class ToolsHandler {
 				// Tool execution errors (convert to isError: true format):
 				// - permission_denied, permission_check_failed
 				// - wp_error, execution_failed
-				$error_message = $result['error']['message'] ?? 'An error occurred while executing the tool.';
+				if ( is_string( $result['error'] ) ) {
+					$error_message = $result['error'];
+				} else {
+					$error_message = $result['error']['message'] ?? 'An error occurred while executing the tool.';
+				}
 				$response      = array(
 					'content' => array(
 						array(

--- a/tests/Unit/Handlers/ToolsHandlerTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerTest.php
@@ -323,4 +323,48 @@ final class ToolsHandlerTest extends TestCase {
 		$this->assertArrayNotHasKey( 'callback', $tool );
 		$this->assertArrayNotHasKey( 'permission_callback', $tool );
 	}
+
+	public function test_call_tool_with_string_error_from_execute(): void {
+		wp_set_current_user( 1 );
+
+		$this->register_ability_in_hook(
+			'test/string-error',
+			array(
+				'label'               => 'String Error',
+				'description'         => 'Returns string error from execute',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array(
+						'success' => false,
+						'error'   => 'Test string error',
+					);
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+					),
+				),
+			)
+		);
+
+		$server  = $this->makeServer( array( 'test/string-error' ), array(), array() );
+		$handler = new ToolsHandler( $server );
+
+		$res = $handler->call_tool(
+			array(
+				'params' => array(
+					'name' => 'test-string-error',
+				),
+			)
+		);
+
+		$this->assertTrue( $res['isError'] );
+		$this->assertEquals( 'Test string error', $res['content'][0]['text'] );
+
+		wp_unregister_ability( 'test/string-error' );
+	}
 }


### PR DESCRIPTION
Fixes #89, making `ToolsHandler` accept both nested (as seen in `handle_tool_call`) and unnested error formats.

However, this fix surfaces an inconsistency in error formatting and raises a bigger question: should `handle_tool_call`, `ExecuteAbilityAbility`, `DiscoverAbilitiesAbility`, and `GetAbilityInfoAbility` use the same format, either nested or not?