### PR TITLE
Fix: Apply WordPress PHP documentation standards

### DIFF
--- a/includes/Abilities/McpAbilityHelperTrait.php
+++ b/includes/Abilities/McpAbilityHelperTrait.php
@@ -17,7 +17,7 @@ namespace WP\MCP\Abilities;
 trait McpAbilityHelperTrait {
 
 	/**
-	 * Check if ability is publicly exposed via MCP.
+	 * Checks if ability is publicly exposed via MCP.
 	 *
 	 * Validates against the ability's mcp.public metadata flag.
 	 * Only abilities with mcp.public=true are accessible via default MCP server.
@@ -47,7 +47,7 @@ trait McpAbilityHelperTrait {
 	}
 
 	/**
-	 * Check if ability is publicly exposed via MCP (simple boolean version).
+	 * Checks if ability is publicly exposed via MCP (simple boolean version).
 	 *
 	 * This is a simplified version that returns only boolean values,
 	 * useful for filtering operations where WP_Error handling isn't needed.
@@ -62,7 +62,7 @@ trait McpAbilityHelperTrait {
 	}
 
 	/**
-	 * Get the MCP type of an ability.
+	 * Gets the MCP type of an ability.
 	 *
 	 * Returns the type specified in meta.mcp.type, defaulting to 'tool' if not specified.
 	 *

--- a/includes/Handlers/HandlerHelperTrait.php
+++ b/includes/Handlers/HandlerHelperTrait.php
@@ -16,7 +16,7 @@ use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
  */
 trait HandlerHelperTrait {
 	/**
-	 * Extract parameters from a request message.
+	 * Extracts parameters from a request message.
 	 *
 	 * Handles both direct params and nested params structure for backward compatibility.
 	 * This normalizes the dual parameter patterns found throughout handlers.
@@ -30,14 +30,14 @@ trait HandlerHelperTrait {
 	}
 
 	/**
-	 * Create a standardized error response.
+	 * Creates a standardized error response.
 	 *
 	 * This helper ensures all error responses follow the same format and
 	 * properly extract the error field from McpErrorFactory responses.
 	 *
-	 * @param int $code Error code.
-	 * @param string $message Error message.
-	 * @param int $request_id Request ID for JSON-RPC.
+	 * @param int    $code       Error code.
+	 * @param string $message    Error message.
+	 * @param int    $request_id Optional. Request ID for JSON-RPC. Default 0.
 	 *
 	 * @return array Error response array with 'error' key.
 	 */
@@ -52,7 +52,7 @@ trait HandlerHelperTrait {
 	}
 
 	/**
-	 * Extract error array from McpErrorFactory response.
+	 * Extracts error array from McpErrorFactory response.
 	 *
 	 * McpErrorFactory methods return ['error' => [...]] but handlers
 	 * often need just the error array itself.
@@ -66,10 +66,10 @@ trait HandlerHelperTrait {
 	}
 
 	/**
-	 * Create missing parameter error response.
+	 * Creates missing parameter error response.
 	 *
 	 * @param string $param_name Missing parameter name.
-	 * @param int $request_id Request ID for JSON-RPC.
+	 * @param int    $request_id Optional. Request ID for JSON-RPC. Default 0.
 	 *
 	 * @return array Error response array.
 	 */
@@ -78,10 +78,10 @@ trait HandlerHelperTrait {
 	}
 
 	/**
-	 * Create permission denied error response.
+	 * Creates permission denied error response.
 	 *
 	 * @param string $denied_resource Resource that was denied.
-	 * @param int $request_id Request ID for JSON-RPC.
+	 * @param int    $request_id      Optional. Request ID for JSON-RPC. Default 0.
 	 *
 	 * @return array Error response array.
 	 */
@@ -90,10 +90,10 @@ trait HandlerHelperTrait {
 	}
 
 	/**
-	 * Create internal error response.
+	 * Creates internal error response.
 	 *
-	 * @param string $message Error message.
-	 * @param int $request_id Request ID for JSON-RPC.
+	 * @param string $message    Error message.
+	 * @param int    $request_id Optional. Request ID for JSON-RPC. Default 0.
 	 *
 	 * @return array Error response array.
 	 */
@@ -102,7 +102,7 @@ trait HandlerHelperTrait {
 	}
 
 	/**
-	 * Create a standardized success response.
+	 * Creates a standardized success response.
 	 *
 	 * @param mixed $data Response data.
 	 *

--- a/includes/Handlers/Initialize/InitializeHandler.php
+++ b/includes/Handlers/Initialize/InitializeHandler.php
@@ -33,11 +33,11 @@ class InitializeHandler {
 	}
 
 	/**
-	 * Handle the initialize request.
+	 * Handles the initialize request.
 	 *
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param int $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with server capabilities and information.
 	 */
 	public function handle( int $request_id = 0 ): array {
 		$server_info = array(

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -37,11 +37,11 @@ class PromptsHandler {
 
 
 	/**
-	 * Handle the prompts/list request.
+	 * Handles the prompts/list request.
 	 *
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param int $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with prompts list and metadata.
 	 */
 	public function list_prompts( int $request_id = 0 ): array {
 		// Get the registered prompts from the MCP instance and extract only the args.
@@ -60,12 +60,12 @@ class PromptsHandler {
 	}
 
 	/**
-	 * Handle the prompts/get request.
+	 * Handles the prompts/get request.
 	 *
-	 * @param array $params Request parameters.
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param array $params     Request parameters.
+	 * @param int   $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with prompt execution results or error.
 	 */
 	public function get_prompt( array $params, int $request_id = 0 ): array {
 		// Extract parameters using helper method.

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -37,11 +37,11 @@ class ResourcesHandler {
 
 
 	/**
-	 * Handle the resources/list request.
+	 * Handles the resources/list request.
 	 *
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param int $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with resources list and metadata.
 	 */
 	public function list_resources( int $request_id = 0 ): array {
 		// Get the registered resources from the MCP instance and extract only the args.
@@ -60,12 +60,12 @@ class ResourcesHandler {
 	}
 
 	/**
-	 * Handle the resources/read request.
+	 * Handles the resources/read request.
 	 *
-	 * @param array $params Request parameters.
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param array $params     Request parameters.
+	 * @param int   $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with resource contents or error.
 	 */
 	public function read_resource( array $params, int $request_id = 0 ): array {
 		// Extract parameters using helper method.

--- a/includes/Handlers/System/SystemHandler.php
+++ b/includes/Handlers/System/SystemHandler.php
@@ -16,11 +16,11 @@ use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
  */
 class SystemHandler {
 	/**
-	 * Handle the ping request.
+	 * Handles the ping request.
 	 *
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param int $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Empty result array per MCP specification.
 	 */
 	public function ping( int $request_id = 0 ): array {
 		// According to MCP specification, ping returns an empty result.
@@ -28,12 +28,12 @@ class SystemHandler {
 	}
 
 	/**
-	 * Handle the logging/setLevel request.
+	 * Handles the logging/setLevel request.
 	 *
 	 * @param array $params     Request parameters.
-	 * @param int   $request_id The request ID for JSON-RPC.
+	 * @param int   $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with error if level parameter is missing, empty array otherwise.
 	 */
 	public function set_logging_level( array $params, int $request_id = 0 ): array {
 		if ( ! isset( $params['params']['level'] ) && ! isset( $params['level'] ) ) {
@@ -46,11 +46,11 @@ class SystemHandler {
 	}
 
 	/**
-	 * Handle the completion/complete request.
+	 * Handles the completion/complete request.
 	 *
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param int $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Completion response array.
 	 */
 	public function complete( int $request_id = 0 ): array {
 		// Implement completion logic here.
@@ -59,11 +59,11 @@ class SystemHandler {
 	}
 
 	/**
-	 * Handle the roots/list request.
+	 * Handles the roots/list request.
 	 *
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param int $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with roots list.
 	 */
 	public function list_roots( int $request_id = 0 ): array {
 		// Implement roots listing logic here.
@@ -75,12 +75,12 @@ class SystemHandler {
 	}
 
 	/**
-	 * Handle method not found errors.
+	 * Handles method not found errors.
 	 *
 	 * @param array $params     Request parameters.
-	 * @param int   $request_id The request ID for JSON-RPC.
+	 * @param int   $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with method not found error.
 	 */
 	public function method_not_found( array $params, int $request_id = 0 ): array {
 		$method = $params['method'] ?? 'unknown';

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -37,11 +37,11 @@ class ToolsHandler {
 	}
 
 	/**
-	 * Handle the tools/list request.
+	 * Handles the tools/list request.
 	 *
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param int $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with tools list and metadata.
 	 */
 	public function list_tools( int $request_id = 0 ): array {
 		$tools      = $this->mcp->get_tools();
@@ -61,11 +61,11 @@ class ToolsHandler {
 	}
 
 	/**
-	 * Handle the tools/list/all request.
+	 * Handles the tools/list/all request.
 	 *
-	 * @param int $request_id The request ID for JSON-RPC.
+	 * @param int $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with all tools including availability status and metadata.
 	 */
 	public function list_all_tools( int $request_id = 0 ): array {
 		// Return all tools with additional details.
@@ -88,12 +88,12 @@ class ToolsHandler {
 	}
 
 	/**
-	 * Handle the tools/call request.
+	 * Handles the tools/call request.
 	 *
 	 * @param array $message    Request message.
-	 * @param int   $request_id The request ID for JSON-RPC.
+	 * @param int   $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with tool execution results or error.
 	 */
 	public function call_tool( array $message, int $request_id = 0 ): array {
 		// Extract parameters using helper method.
@@ -203,7 +203,7 @@ class ToolsHandler {
 	}
 
 	/**
-	 * Sanitize tool data for JSON encoding by removing callback functions and other problematic data.
+	 * Sanitizes tool data for JSON encoding by removing callback functions and other problematic data.
 	 *
 	 * @param \WP\MCP\Domain\Tools\McpTool $tool Raw tool data.
 	 *
@@ -241,12 +241,12 @@ class ToolsHandler {
 	}
 
 	/**
-	 * Handle tool call request.
+	 * Handles tool call request.
 	 *
 	 * @param array $params     The request parameters.
-	 * @param int   $request_id The request ID for JSON-RPC.
+	 * @param int   $request_id Optional. The request ID for JSON-RPC. Default 0.
 	 *
-	 * @return array
+	 * @return array Response with tool execution results or error.
 	 */
 	public function handle_tool_call( array $params, int $request_id = 0 ): array {
 		$tool_name = $params['name'];

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -25,7 +25,9 @@ final class Plugin {
 	private static self $instance;
 
 	/**
-	 * {@inheritDoc}
+	 * Gets the singleton instance of the plugin.
+	 *
+	 * @return self The plugin instance.
 	 */
 	public static function instance(): self {
 		if ( ! isset( self::$instance ) ) {
@@ -44,7 +46,7 @@ final class Plugin {
 	}
 
 	/**
-	 * Setup the plugin.
+	 * Sets up the plugin.
 	 */
 	private function setup(): void {
 		// Bail if dependencies are not met.
@@ -56,7 +58,7 @@ final class Plugin {
 	}
 
 	/**
-	 * Check if all required dependencies are available.
+	 * Checks if all required dependencies are available.
 	 *
 	 * Will log an admin notice if dependencies are missing.
 	 *
@@ -85,7 +87,7 @@ final class Plugin {
 	}
 
 	/**
-	 * Prevent the class from being cloned.
+	 * Prevents the class from being cloned.
 	 */
 	public function __clone() {
 		_doing_it_wrong(
@@ -100,7 +102,7 @@ final class Plugin {
 	}
 
 	/**
-	 * Prevent the class from being deserialized.
+	 * Prevents the class from being deserialized.
 	 */
 	public function __wakeup() {
 		_doing_it_wrong(


### PR DESCRIPTION
## Changes

This PR updates inline documentation across the codebase to comply with WordPress PHP documentation standards.

### Key Updates

- **Third-person singular verbs**: Changed all method descriptions (e.g., "Get" → "Gets", "Handle" → "Handles")
- **Enhanced @return tags**: Added descriptive text to all @return tags instead of bare types
- **Improved @param formatting**: Added "Optional." prefix and "Default X." suffix for optional parameters
- **Better alignment**: Aligned multi-line @param tags for readability

Reference: [WordPress PHP Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)