### PR TITLE
Handle Flattened Input/Output Schemas from Abilities API

### DIFF
--- a/docs/guides/creating-abilities.md
+++ b/docs/guides/creating-abilities.md
@@ -40,7 +40,7 @@ If not specified, abilities default to `type: 'tool'`.
 wp_register_ability('my-plugin/my-ability', [
     'label' => 'My Ability',
     'description' => 'What this ability does',
-    'input_schema' => [...],      // For tools
+    'input_schema' => [...],      // For tools (supports both object and flattened schemas)
     'output_schema' => [...],     // Optional for tools
     'execute_callback' => 'my_callback',
     'permission_callback' => 'my_permission_check',
@@ -55,6 +55,193 @@ wp_register_ability('my-plugin/my-ability', [
     ]
 ]);
 ```
+
+## Input and Output Schemas
+
+The MCP Adapter supports two schema formats for `input_schema` and `output_schema`:
+
+### Object Schemas (Recommended)
+
+The standard format uses JSON Schema objects with properties:
+
+```php
+'input_schema' => [
+    'type' => 'object',
+    'properties' => [
+        'name' => [
+            'type' => 'string',
+            'description' => 'User name'
+        ],
+        'age' => [
+            'type' => 'number',
+            'minimum' => 0
+        ]
+    ],
+    'required' => ['name']
+]
+```
+
+### Flattened Schemas (Simplified)
+
+For simple single-value inputs, you can use flattened schemas. These are automatically converted to MCP-compatible object format:
+
+```php
+// Simple string input
+'input_schema' => [
+    'type' => 'string',
+    'description' => 'Post type to query',
+    'enum' => ['post', 'page', 'attachment']
+]
+
+// This is automatically transformed to:
+[
+    'type' => 'object',
+    'properties' => [
+        'input' => [
+            'type' => 'string',
+            'description' => 'Post type to query',
+            'enum' => ['post', 'page', 'attachment']
+        ]
+    ],
+    'required' => ['input']
+]
+```
+
+#### Supported Flattened Types
+
+All JSON Schema primitive types are supported:
+- `string` - text values
+- `number` - numeric values (including decimals)
+- `integer` - whole numbers
+- `boolean` - true/false values
+- `array` - lists of values
+
+#### Flattened Schema Examples
+
+```php
+// Number with constraints
+'input_schema' => [
+    'type' => 'number',
+    'description' => 'Maximum number of posts',
+    'minimum' => 1,
+    'maximum' => 100,
+    'default' => 10
+]
+
+// Boolean flag
+'input_schema' => [
+    'type' => 'boolean',
+    'description' => 'Include draft posts'
+]
+
+// Array of strings
+'input_schema' => [
+    'type' => 'array',
+    'description' => 'List of post IDs',
+    'items' => ['type' => 'integer'],
+    'minItems' => 1
+]
+```
+
+### Output Schemas
+
+Output schemas follow the same patterns as input schemas, supporting both object and flattened formats:
+
+#### Object Output Schemas
+
+```php
+'output_schema' => [
+    'type' => 'object',
+    'properties' => [
+        'post_id' => [
+            'type' => 'integer',
+            'description' => 'Created post ID'
+        ],
+        'url' => [
+            'type' => 'string',
+            'description' => 'Post permalink'
+        ],
+        'status' => [
+            'type' => 'string',
+            'description' => 'Post status'
+        ]
+    ]
+]
+```
+
+#### Flattened Output Schemas
+
+For simple single-value outputs, you can use flattened schemas. These are automatically converted to MCP-compatible object format using `"result"` as the wrapper property:
+
+```php
+// Simple string output
+'output_schema' => [
+    'type' => 'string',
+    'description' => 'Generated post slug'
+]
+
+// This is automatically transformed to:
+[
+    'type' => 'object',
+    'properties' => [
+        'result' => [
+            'type' => 'string',
+            'description' => 'Generated post slug'
+        ]
+    ],
+    'required' => ['result']
+]
+```
+
+#### Output Schema Examples
+
+```php
+// Number output
+'output_schema' => [
+    'type' => 'integer',
+    'description' => 'Total number of posts found'
+]
+
+// Boolean output
+'output_schema' => [
+    'type' => 'boolean',
+    'description' => 'Whether the operation succeeded'
+]
+
+// Array output
+'output_schema' => [
+    'type' => 'array',
+    'description' => 'List of post titles',
+    'items' => ['type' => 'string']
+]
+```
+
+**Important**: When using flattened output schemas, your callback should return the unwrapped value directly. The adapter automatically wraps it in `{result: <value>}` for MCP clients:
+
+```php
+// With flattened output schema: ['type' => 'string']
+'execute_callback' => function($input) {
+    return 'my-post-slug';  // Return unwrapped value
+}
+
+// MCP client receives: {result: 'my-post-slug'}
+```
+
+#### When to Use Each Format
+
+**Use Object Schemas when:**
+- Your ability accepts/returns multiple parameters or fields
+- You need complex validation or nested structures
+- You want descriptive parameter names
+- Your output contains multiple related values (e.g., `{post_id, url, status}`)
+
+**Use Flattened Schemas when:**
+- Your ability accepts/returns a single, simple value
+- The input/output is straightforward (e.g., a string, number, boolean, or array)
+- You want to simplify the API for basic operations
+- Your output is a single primitive value (e.g., a count, a slug, a boolean flag)
+
+**Note**: All schema metadata (descriptions, constraints, enums, etc.) is preserved during the automatic transformation from flattened to object format. Input schemas use `"input"` as the wrapper property, while output schemas use `"result"`.
 
 ## MCP Annotations
 
@@ -310,6 +497,49 @@ wp_register_ability('my-plugin/create-post', [
     ]
 ]);
 ```
+
+#### Tool with Flattened Schemas
+
+For simple tools that accept and return single values, you can use flattened schemas:
+
+```php
+wp_register_ability('my-plugin/count-posts', [
+    'label' => 'Count Posts',
+    'description' => 'Count posts of a specific type',
+    'input_schema' => [
+        'type' => 'string',
+        'description' => 'Post type to count',
+        'enum' => ['post', 'page', 'attachment']
+    ],
+    'output_schema' => [
+        'type' => 'integer',
+        'description' => 'Total number of posts found'
+    ],
+    'execute_callback' => function($input) {
+        // $input is the unwrapped string value (e.g., 'post')
+        $count = wp_count_posts($input);
+        // Return unwrapped integer value
+        return $count->publish;
+    },
+    'permission_callback' => function() {
+        return current_user_can('read');
+    },
+    'meta' => [
+        'annotations' => [
+            'readonly' => true,
+            'idempotent' => false  // Count may change over time
+        ],
+        'mcp' => [
+            'public' => true
+        ]
+    ]
+]);
+```
+
+**Note**: With flattened schemas:
+- The callback receives the unwrapped input value directly (e.g., `'post'` instead of `['input' => 'post']`)
+- The callback should return the unwrapped output value (e.g., `42` instead of `['result' => 42]`)
+- The adapter automatically handles wrapping/unwrapping for MCP clients
 
 ## Creating Resources
 

--- a/includes/Domain/Tools/McpTool.php
+++ b/includes/Domain/Tools/McpTool.php
@@ -72,6 +72,13 @@ class McpTool {
 	private array $annotations;
 
 	/**
+	 * Internal metadata used by the server (not exposed to MCP clients).
+	 *
+	 * @var array
+	 */
+	private array $metadata;
+
+	/**
 	 * The MCP server instance this tool belongs to.
 	 *
 	 * @var \WP\MCP\Core\McpServer|null
@@ -88,6 +95,7 @@ class McpTool {
 	 * @param string|null $title Optional human-readable name for display.
 	 * @param array|null  $output_schema Optional JSON Schema for output structure.
 	 * @param array       $annotations Optional properties describing tool behavior.
+	 * @param array       $metadata Internal metadata used by the server (not returned to clients).
 	 */
 	public function __construct(
 		string $ability,
@@ -96,7 +104,8 @@ class McpTool {
 		array $input_schema,
 		?string $title = null,
 		?array $output_schema = null,
-		array $annotations = array()
+		array $annotations = array(),
+		array $metadata = array()
 	) {
 		$this->ability       = $ability;
 		$this->name          = $name;
@@ -105,6 +114,7 @@ class McpTool {
 		$this->input_schema  = $input_schema;
 		$this->output_schema = $output_schema;
 		$this->annotations   = $annotations;
+		$this->metadata      = $metadata;
 	}
 
 	/**
@@ -182,6 +192,15 @@ class McpTool {
 	}
 
 	/**
+	 * Get internal metadata for server-side processing.
+	 *
+	 * @return array
+	 */
+	public function get_metadata(): array {
+		return $this->metadata;
+	}
+
+	/**
 	 * Set the tool title.
 	 *
 	 * @param string|null $title The title to set.
@@ -234,6 +253,17 @@ class McpTool {
 	 */
 	public function set_annotations( array $annotations ): void {
 		$this->annotations = $annotations;
+	}
+
+	/**
+	 * Set internal metadata.
+	 *
+	 * @param array $metadata Internal metadata values.
+	 *
+	 * @return void
+	 */
+	public function set_metadata( array $metadata ): void {
+		$this->metadata = $metadata;
 	}
 
 	/**
@@ -330,7 +360,8 @@ class McpTool {
 			$data['inputSchema'] ?? array(),
 			$data['title'] ?? null,
 			$data['outputSchema'] ?? null,
-			$data['annotations'] ?? array()
+			$data['annotations'] ?? array(),
+			$data['_metadata'] ?? array()
 		);
 		$tool->set_mcp_server( $mcp_server );
 

--- a/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -11,6 +11,7 @@ namespace WP\MCP\Domain\Tools;
 
 use WP\MCP\Core\McpServer;
 use WP\MCP\Domain\Utils\McpAnnotationMapper;
+use WP\MCP\Domain\Utils\SchemaTransformer;
 use WP_Ability;
 
 /**
@@ -66,21 +67,16 @@ class RegisterAbilityAsMcpTool {
 	 * @return array<string,mixed>
 	 */
 	private function get_data(): array {
-		$input_schema = $this->ability->get_input_schema();
-
-		// If ability has no input schema, use an empty object schema for MCP
-		if ( empty( $input_schema ) ) {
-			$input_schema = array(
-				'type'                 => 'object',
-				'additionalProperties' => false,
-			);
-		}
+		// Transform input schema to MCP-compatible object format
+		$input_transform = SchemaTransformer::transform_to_object_schema(
+			$this->ability->get_input_schema()
+		);
 
 		$tool_data = array(
 			'ability'     => $this->ability->get_name(),
 			'name'        => str_replace( '/', '-', trim( $this->ability->get_name() ) ),
 			'description' => trim( $this->ability->get_description() ),
-			'inputSchema' => $input_schema,
+			'inputSchema' => $input_transform['schema'],
 		);
 
 		// Add optional title from ability label.
@@ -90,10 +86,15 @@ class RegisterAbilityAsMcpTool {
 			$tool_data['title'] = $label;
 		}
 
-		// Add optional output schema.
-		$output_schema = $this->ability->get_output_schema();
+		// Add optional output schema, transformed to object format if needed.
+		$output_schema    = $this->ability->get_output_schema();
+		$output_transform = null;
 		if ( ! empty( $output_schema ) ) {
-			$tool_data['outputSchema'] = $output_schema;
+			$output_transform          = SchemaTransformer::transform_to_object_schema(
+				$output_schema,
+				'result'
+			);
+			$tool_data['outputSchema'] = $output_transform['schema'];
 		}
 
 		// Map annotations from ability meta to MCP format using unified mapper.
@@ -108,6 +109,21 @@ class RegisterAbilityAsMcpTool {
 		// Set annotations.title from label if annotations exist but don't have a title.
 		if ( ! empty( $label ) && isset( $tool_data['annotations'] ) && ! isset( $tool_data['annotations']['title'] ) ) {
 			$tool_data['annotations']['title'] = $label;
+		}
+
+		// Store transformation metadata as internal metadata (stripped before responding to clients).
+		if ( $input_transform['was_transformed'] || ( $output_transform && $output_transform['was_transformed'] ) ) {
+			$tool_data['_metadata'] = array();
+
+			if ( $input_transform['was_transformed'] ) {
+				$tool_data['_metadata']['_input_schema_transformed'] = true;
+				$tool_data['_metadata']['_input_schema_wrapper']     = $input_transform['wrapper_property'] ?? 'input';
+			}
+
+			if ( $output_transform && $output_transform['was_transformed'] ) {
+				$tool_data['_metadata']['_output_schema_transformed'] = true;
+				$tool_data['_metadata']['_output_schema_wrapper']     = $output_transform['wrapper_property'] ?? 'result';
+			}
 		}
 
 		return $tool_data;

--- a/includes/Domain/Utils/SchemaTransformer.php
+++ b/includes/Domain/Utils/SchemaTransformer.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * SchemaTransformer class for converting flattened schemas to MCP-compatible object schemas.
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Domain\Utils;
+
+/**
+ * SchemaTransformer class.
+ *
+ * This class transforms flattened JSON schemas (e.g., type: string, number, boolean, array)
+ * into MCP-compatible object schemas. MCP requires all tool input schemas to be of type "object".
+ *
+ * @package McpAdapter
+ */
+class SchemaTransformer {
+	/**
+	 * Transform a schema to MCP-compatible object format.
+	 *
+	 * If the schema is already an object type, it is returned unchanged.
+	 * If the schema is a flattened type (string, number, boolean, array), it is
+	 * wrapped in an object structure with a single property (defaults to "input").
+	 *
+	 * @param array<string,mixed>|null $schema       The JSON schema to transform.
+	 * @param string                   $wrapper_key  Property name to use when wrapping non-object schemas.
+	 *
+	 * @return array<string,mixed> Array containing 'schema', 'was_transformed' (bool), and 'wrapper_property' when transformed.
+	 */
+	public static function transform_to_object_schema( ?array $schema, string $wrapper_key = 'input' ): array {
+		// Handle null or empty schema - return minimal object schema
+		if ( empty( $schema ) ) {
+			return array(
+				'schema'           => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+				),
+				'was_transformed'  => false, // Empty schema wasn't really transformed
+				'wrapper_property' => null,
+			);
+		}
+
+		// If no type is specified, just return it as-is. It will fail MCP validation later because MCP requires an explicit type: "object"
+		if ( ! isset( $schema['type'] ) ) {
+			return array(
+				'schema'           => $schema,
+				'was_transformed'  => false,
+				'wrapper_property' => null,
+			);
+		}
+
+		// If already an object type, return as-is
+		if ( 'object' === $schema['type'] ) {
+			return array(
+				'schema'           => $schema,
+				'was_transformed'  => false,
+				'wrapper_property' => null,
+			);
+		}
+
+		// Transform flattened schema to object format
+		return array(
+			'schema'           => self::wrap_in_object( $schema, $wrapper_key ),
+			'was_transformed'  => true,
+			'wrapper_property' => $wrapper_key,
+		);
+	}
+
+	/**
+	 * Wrap a flattened schema in an object structure.
+	 *
+	 * Creates an object schema with a single property (named by $wrapper_key) that
+	 * contains the original flattened schema.
+	 *
+	 * @param array<string,mixed> $schema The flattened schema to wrap.
+	 * @param string              $wrapper_key Property name to wrap the value under.
+	 *
+	 * @return array<string,mixed> The wrapped object schema.
+	 */
+	private static function wrap_in_object( array $schema, string $wrapper_key ): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				$wrapper_key => $schema,
+			),
+			'required'   => array( $wrapper_key ),
+		);
+	}
+}

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -400,6 +400,11 @@ class ToolsHandler {
 				$result         = array( $output_wrapper => $result );
 			}
 
+			// Ensure $result is always an array before adding metadata.
+			if ( ! is_array( $result ) ) {
+				$result = array( 'result' => $result );
+			}
+
 			// Successful execution - add metadata.
 			$result['_metadata'] = array(
 				'component_type' => 'tool',

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -302,6 +302,15 @@ class ToolsHandler {
 			);
 		}
 
+		// Unwrap arguments if schema was transformed from flattened to object format
+		$tool_metadata = $tool->get_metadata();
+		$input_wrapped = ! empty( $tool_metadata['_input_schema_transformed'] );
+		if ( $input_wrapped ) {
+			// Unwrap: {input: "value"} → "value"
+			$input_wrapper = $tool_metadata['_input_schema_wrapper'] ?? 'input';
+			$args          = is_array( $args ) ? ( $args[ $input_wrapper ] ?? null ) : null;
+		}
+
 		// If ability has no input schema and args is empty, pass null instead
 		$ability_input_schema = $ability->get_input_schema();
 		if ( empty( $ability_input_schema ) && empty( $args ) ) {
@@ -381,6 +390,14 @@ class ToolsHandler {
 						'error_code'     => $result->get_error_code(),
 					),
 				);
+			}
+
+			// Wrap result if output schema was transformed from flattened to object format
+			$output_wrapped = ! empty( $tool_metadata['_output_schema_transformed'] );
+			if ( $output_wrapped ) {
+				// Wrap: "value" → {result: "value"}
+				$output_wrapper = $tool_metadata['_output_schema_wrapper'] ?? 'result';
+				$result         = array( $output_wrapper => $result );
 			}
 
 			// Successful execution - add metadata.

--- a/tests/Unit/Domain/Utils/SchemaTransformerTest.php
+++ b/tests/Unit/Domain/Utils/SchemaTransformerTest.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * Tests for SchemaTransformer class.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Domain\Utils;
+
+use WP\MCP\Domain\Utils\SchemaTransformer;
+use WP\MCP\Tests\TestCase;
+
+/**
+ * Test SchemaTransformer functionality.
+ */
+final class SchemaTransformerTest extends TestCase {
+
+	public function test_transform_string_schema_to_object(): void {
+		$string_schema = array(
+			'type'        => 'string',
+			'description' => 'A string parameter',
+			'minLength'   => 1,
+			'maxLength'   => 100,
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $string_schema );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'schema', $result );
+		$this->assertArrayHasKey( 'was_transformed', $result );
+		$this->assertTrue( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'properties', $schema );
+		$this->assertArrayHasKey( 'input', $schema['properties'] );
+		$this->assertEquals( $string_schema, $schema['properties']['input'] );
+		$this->assertArrayHasKey( 'required', $schema );
+		$this->assertContains( 'input', $schema['required'] );
+	}
+
+	public function test_transform_number_schema_to_object(): void {
+		$number_schema = array(
+			'type'        => 'number',
+			'description' => 'A number parameter',
+			'minimum'     => 0,
+			'maximum'     => 100,
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $number_schema );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'properties', $schema );
+		$this->assertArrayHasKey( 'input', $schema['properties'] );
+		$this->assertEquals( $number_schema, $schema['properties']['input'] );
+		$this->assertArrayHasKey( 'required', $schema );
+		$this->assertContains( 'input', $schema['required'] );
+	}
+
+	public function test_transform_integer_schema_to_object(): void {
+		$integer_schema = array(
+			'type'        => 'integer',
+			'description' => 'An integer parameter',
+			'minimum'     => 1,
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $integer_schema );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'properties', $schema );
+		$this->assertArrayHasKey( 'input', $schema['properties'] );
+		$this->assertEquals( $integer_schema, $schema['properties']['input'] );
+	}
+
+	public function test_transform_boolean_schema_to_object(): void {
+		$boolean_schema = array(
+			'type'        => 'boolean',
+			'description' => 'A boolean parameter',
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $boolean_schema );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'properties', $schema );
+		$this->assertArrayHasKey( 'input', $schema['properties'] );
+		$this->assertEquals( $boolean_schema, $schema['properties']['input'] );
+		$this->assertContains( 'input', $schema['required'] );
+	}
+
+	public function test_transform_array_schema_to_object(): void {
+		$array_schema = array(
+			'type'        => 'array',
+			'description' => 'An array parameter',
+			'items'       => array(
+				'type' => 'string',
+			),
+			'minItems'    => 1,
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $array_schema );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'properties', $schema );
+		$this->assertArrayHasKey( 'input', $schema['properties'] );
+		$this->assertEquals( $array_schema, $schema['properties']['input'] );
+		$this->assertContains( 'input', $schema['required'] );
+	}
+
+	public function test_object_schema_passes_through_unchanged(): void {
+		$object_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'name' => array(
+					'type'        => 'string',
+					'description' => 'User name',
+				),
+				'age'  => array(
+					'type'    => 'number',
+					'minimum' => 0,
+				),
+			),
+			'required'   => array( 'name' ),
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $object_schema );
+
+		$this->assertFalse( $result['was_transformed'] );
+		$this->assertEquals( $object_schema, $result['schema'] );
+	}
+
+	public function test_null_schema_returns_empty_object(): void {
+		$result = SchemaTransformer::transform_to_object_schema( null );
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'additionalProperties', $schema );
+		$this->assertFalse( $schema['additionalProperties'] );
+	}
+
+	public function test_empty_array_schema_returns_empty_object(): void {
+		$result = SchemaTransformer::transform_to_object_schema( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'additionalProperties', $schema );
+		$this->assertFalse( $schema['additionalProperties'] );
+	}
+
+	public function test_schema_without_type_passes_through(): void {
+		$schema_without_type = array(
+			'properties' => array(
+				'param1' => array( 'type' => 'string' ),
+			),
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $schema_without_type );
+
+		$this->assertFalse( $result['was_transformed'] );
+		$this->assertEquals( $schema_without_type, $result['schema'] );
+	}
+
+	public function test_string_schema_with_enum_preserves_constraints(): void {
+		$string_enum_schema = array(
+			'type'        => 'string',
+			'description' => 'Post type',
+			'enum'        => array( 'post', 'page', 'attachment' ),
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $string_enum_schema );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'input', $schema['properties'] );
+		$this->assertEquals( $string_enum_schema, $schema['properties']['input'] );
+		$this->assertArrayHasKey( 'enum', $schema['properties']['input'] );
+		$this->assertEquals( array( 'post', 'page', 'attachment' ), $schema['properties']['input']['enum'] );
+	}
+
+	public function test_number_schema_with_constraints_preserves_all_metadata(): void {
+		$number_schema = array(
+			'type'             => 'number',
+			'description'      => 'Age in years',
+			'minimum'          => 0,
+			'maximum'          => 150,
+			'exclusiveMinimum' => true,
+			'multipleOf'       => 0.5,
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $number_schema );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertEquals( $number_schema, $schema['properties']['input'] );
+		$this->assertEquals( 0, $schema['properties']['input']['minimum'] );
+		$this->assertEquals( 150, $schema['properties']['input']['maximum'] );
+		$this->assertTrue( $schema['properties']['input']['exclusiveMinimum'] );
+		$this->assertEquals( 0.5, $schema['properties']['input']['multipleOf'] );
+	}
+
+	public function test_complex_array_schema_with_nested_objects(): void {
+		$complex_array_schema = array(
+			'type'        => 'array',
+			'description' => 'List of users',
+			'items'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'   => array( 'type' => 'number' ),
+					'name' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'id', 'name' ),
+			),
+			'minItems'    => 1,
+			'maxItems'    => 10,
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $complex_array_schema );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertEquals( $complex_array_schema, $schema['properties']['input'] );
+		$this->assertArrayHasKey( 'items', $schema['properties']['input'] );
+		$this->assertEquals( 'object', $schema['properties']['input']['items']['type'] );
+	}
+
+	public function test_schema_with_additional_properties(): void {
+		$schema_with_additional = array(
+			'type'        => 'string',
+			'description' => 'A test string',
+			'pattern'     => '^[a-z]+$',
+			'format'      => 'email',
+			'default'     => 'test',
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $schema_with_additional );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['was_transformed'] );
+
+		$schema = $result['schema'];
+		$this->assertEquals( $schema_with_additional, $schema['properties']['input'] );
+		$this->assertArrayHasKey( 'pattern', $schema['properties']['input'] );
+		$this->assertArrayHasKey( 'format', $schema['properties']['input'] );
+		$this->assertArrayHasKey( 'default', $schema['properties']['input'] );
+	}
+
+	public function test_multiple_transformations_are_idempotent(): void {
+		$string_schema = array(
+			'type'        => 'string',
+			'description' => 'Test string',
+		);
+
+		$first_transform  = SchemaTransformer::transform_to_object_schema( $string_schema );
+		$second_transform = SchemaTransformer::transform_to_object_schema( $first_transform['schema'] );
+
+		// First transform should wrap it
+		$this->assertTrue( $first_transform['was_transformed'] );
+
+		// Second transformation should recognize it's already an object
+		$this->assertFalse( $second_transform['was_transformed'] );
+
+		// Schemas should be the same after idempotent transformation
+		$this->assertEquals( $first_transform['schema'], $second_transform['schema'] );
+	}
+
+	public function test_custom_wrapper_key_is_used_when_provided(): void {
+		$string_schema = array(
+			'type' => 'string',
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $string_schema, 'result' );
+
+		$this->assertTrue( $result['was_transformed'] );
+		$this->assertSame( 'result', $result['wrapper_property'] );
+
+		$schema = $result['schema'];
+		$this->assertArrayHasKey( 'properties', $schema );
+		$this->assertArrayHasKey( 'result', $schema['properties'] );
+		$this->assertContains( 'result', $schema['required'] );
+	}
+}

--- a/tests/Unit/Handlers/ToolsHandlerTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerTest.php
@@ -380,4 +380,60 @@ final class ToolsHandlerTest extends TestCase {
 		$this->assertArrayNotHasKey( 'callback', $tool );
 		$this->assertArrayNotHasKey( 'permission_callback', $tool );
 	}
+
+	public function test_call_tool_wraps_scalar_return_values(): void {
+		wp_set_current_user( 1 );
+
+		// Register an ability that returns a scalar (string) value
+		$this->register_ability_in_hook(
+			'test/scalar-return',
+			array(
+				'label'               => 'Scalar Return Test',
+				'description'         => 'Returns a scalar string value',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'hello-world';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+					),
+				),
+			)
+		);
+
+		$server  = $this->makeServer( array( 'test/scalar-return' ), array(), array() );
+		$handler = new ToolsHandler( $server );
+
+		$res = $handler->call_tool(
+			array(
+				'params' => array(
+					'name' => 'test-scalar-return',
+				),
+			)
+		);
+
+		// Should not have an error
+		$this->assertArrayNotHasKey( 'error', $res );
+		$this->assertArrayNotHasKey( 'isError', $res );
+
+		// Should have content
+		$this->assertArrayHasKey( 'content', $res );
+		$this->assertArrayHasKey( 'structuredContent', $res );
+
+		// The scalar value should be wrapped in an array with 'result' key
+		$this->assertArrayHasKey( 'result', $res['structuredContent'] );
+		$this->assertSame( 'hello-world', $res['structuredContent']['result'] );
+
+		// Should have metadata at the top level (not inside structuredContent)
+		$this->assertArrayHasKey( '_metadata', $res );
+		$this->assertArrayNotHasKey( '_metadata', $res['structuredContent'] );
+		$this->assertSame( 'tool', $res['_metadata']['component_type'] );
+		$this->assertSame( 'test-scalar-return', $res['_metadata']['tool_name'] );
+
+		wp_unregister_ability( 'test/scalar-return' );
+	}
 }

--- a/tests/Unit/Handlers/ToolsHandlerTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerTest.php
@@ -304,6 +304,66 @@ final class ToolsHandlerTest extends TestCase {
 		$this->assertEquals( 'permission_denied', $res['_metadata']['failure_reason'] );
 	}
 
+	public function test_call_tool_uses_metadata_flags_without_exposing_them(): void {
+		wp_set_current_user( 1 );
+		$captured_input = null;
+
+		$this->register_ability_in_hook(
+			'test/flat-transform-call',
+			array(
+				'label'               => 'Flat Transform Call',
+				'description'         => 'Uses flat schemas',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'string' ),
+				'output_schema'       => array( 'type' => 'string' ),
+				'execute_callback'    => static function ( $input ) use ( &$captured_input ) {
+					$captured_input = $input;
+					return $input;
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array( 'public' => true ),
+				),
+			)
+		);
+
+		$server  = $this->makeServer( array( 'test/flat-transform-call' ), array(), array() );
+		$handler = new ToolsHandler( $server );
+
+		$list       = $handler->list_tools();
+		$tool_entry = null;
+		foreach ( $list['tools'] as $tool ) {
+			if ( 'test-flat-transform-call' === $tool['name'] ) {
+				$tool_entry = $tool;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $tool_entry );
+		$this->assertArrayNotHasKey( '_metadata', $tool_entry );
+
+		$res = $handler->call_tool(
+			array(
+				'params' => array(
+					'name'      => 'test-flat-transform-call',
+					'arguments' => array( 'input' => 'hello-world' ),
+				),
+			)
+		);
+
+		$this->assertSame( 'hello-world', $captured_input, 'Ability should receive unwrapped argument from metadata flag.' );
+		$this->assertArrayHasKey( 'structuredContent', $res );
+		$this->assertArrayNotHasKey( '_metadata', $res['structuredContent'] );
+		$this->assertSame( 'hello-world', $captured_input, 'Ability should receive unwrapped argument from metadata flag.' );
+		$this->assertArrayHasKey( 'structuredContent', $res );
+		$this->assertArrayNotHasKey( '_metadata', $res['structuredContent'] );
+		$this->assertSame( array( 'result' => 'hello-world' ), $res['structuredContent'] );
+
+		wp_unregister_ability( 'test/flat-transform-call' );
+	}
+
 	public function test_list_tools_sanitizes_tool_data(): void {
 		wp_set_current_user( 1 );
 

--- a/tests/Unit/Handlers/ToolsHandlerTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerTest.php
@@ -356,9 +356,6 @@ final class ToolsHandlerTest extends TestCase {
 		$this->assertSame( 'hello-world', $captured_input, 'Ability should receive unwrapped argument from metadata flag.' );
 		$this->assertArrayHasKey( 'structuredContent', $res );
 		$this->assertArrayNotHasKey( '_metadata', $res['structuredContent'] );
-		$this->assertSame( 'hello-world', $captured_input, 'Ability should receive unwrapped argument from metadata flag.' );
-		$this->assertArrayHasKey( 'structuredContent', $res );
-		$this->assertArrayNotHasKey( '_metadata', $res['structuredContent'] );
 		$this->assertSame( array( 'result' => 'hello-world' ), $res['structuredContent'] );
 
 		wp_unregister_ability( 'test/flat-transform-call' );

--- a/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
+++ b/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
@@ -12,8 +12,8 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 	public function test_make_builds_tool_from_ability(): void {
 		$ability = wp_get_ability( 'test/always-allowed' );
 		$this->assertNotNull( $ability, 'Ability test/always-allowed should be registered' );
-		$tool    = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$arr     = $tool->to_array();
+		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
+		$arr  = $tool->to_array();
 		$this->assertSame( 'test-always-allowed', $arr['name'] );
 		$this->assertArrayHasKey( 'inputSchema', $arr );
 	}
@@ -188,5 +188,41 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertArrayNotHasKey( 'readonly', $arr['annotations'] );
 		$this->assertArrayNotHasKey( 'destructive', $arr['annotations'] );
 		$this->assertArrayNotHasKey( 'idempotent', $arr['annotations'] );
+	}
+
+	public function test_transformation_flags_are_stored_in_metadata(): void {
+		$this->register_ability_in_hook(
+			'test/flat-transformed-tool',
+			array(
+				'label'               => 'Flat Transformed Tool',
+				'description'         => 'Uses flat schemas',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'string' ),
+				'output_schema'       => array( 'type' => 'string' ),
+				'execute_callback'    => static function ( $input ) {
+					return $input;
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array( 'public' => true ),
+				),
+			)
+		);
+
+		$ability = wp_get_ability( 'test/flat-transformed-tool' );
+		$this->assertNotNull( $ability, 'Ability test/flat-transformed-tool should be registered' );
+		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
+
+		$this->assertInstanceOf( \WP\MCP\Domain\Tools\McpTool::class, $tool );
+
+		$metadata = $tool->get_metadata();
+		$this->assertTrue( $metadata['_input_schema_transformed'] ?? false );
+		$this->assertTrue( $metadata['_output_schema_transformed'] ?? false );
+		$this->assertSame( 'input', $metadata['_input_schema_wrapper'] ?? '' );
+		$this->assertSame( 'result', $metadata['_output_schema_wrapper'] ?? '' );
+
+		wp_unregister_ability( 'test/flat-transformed-tool' );
 	}
 }


### PR DESCRIPTION
## WHY

The Abilities API supports both object-based and flattened schemas, but the MCP specification requires all tool input schemas to be of type `"object"`. Without this transformation, abilities using flattened schemas would fail MCP validation. This change ensures full MCP specification compliance while maintaining backward compatibility with existing object-based schemas.

## WHAT

This PR adds automatic transformation of flattened schemas (string, number, boolean, array) to MCP-compatible object schemas for both input and output schemas. The adapter now detects when an ability uses a flattened schema and wraps it in an object structure with a single property (`"input"` for inputs, `"result"` for outputs).

The implementation uses a `SchemaTransformer` utility class that automatically wraps flattened schemas during tool registration and unwraps them during execution, ensuring abilities receive and return values in their original format while MCP clients see compliant object schemas.

## Changes

- Added `SchemaTransformer` utility class for schema transformation
- Modified `RegisterAbilityAsMcpTool` to transform input and output schemas
- Added metadata support to `McpTool` to track transformation state
- Updated `ToolsHandler` to unwrap input arguments and wrap output results
- Added comprehensive test coverage for all schema types
- Updated documentation with examples of both schema formats

Closes #88