### PR TITLE
Create `.gitattributes` to exclude development files from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for this repo using Composer, use `--prefer-source`.
+#
+# @see https://git-scm.com/docs/gitattributes
+# @see https://blog.madewithlove.be/post/gitattributes/
+#
+/.editorconfig           export-ignore
+/.gitattributes          export-ignore
+/.github/                export-ignore
+/.gitignore              export-ignore
+/.nvmrc                  export-ignore
+/.prettierignore         export-ignore
+/.prettierrc.js          export-ignore
+/.wp-env.json            export-ignore
+/CONTRIBUTING.md         export-ignore
+/docs/                   export-ignore
+/phpcs.xml.dist          export-ignore
+/phpstan.neon.dist       export-ignore
+/phpunit.xml.dist        export-ignore
+/README-INITIAL.md       export-ignore
+/tests/                  export-ignore


### PR DESCRIPTION
Currently, `composer install` installs the package with all its development files, `/tests/`, `.prettierrc.js` etc. which are unnecessary when installing the package in another project.

This PR adds `.gitattributes` file in the project root with a list of files marked `export-ignore`.

* https://git-scm.com/docs/gitattributes
* https://blog.madewithlove.be/post/gitattributes/
* https://github.com/WordPress/Requests/blob/v2.0.15/.gitattributes
* https://github.com/WordPress/wp-ai-client/blob/0.1.0/.gitattributes