### PR TITLE
fix: update plugin version to 0.3.1 for next release

### DIFF
--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -24,7 +24,7 @@ use WP\MCP\Servers\DefaultServerFactory;
  */
 final class McpAdapter {
 
-	public const VERSION = '0.1.0';
+	public const VERSION = '0.3.1';
 
 	/**
 	 * Registry instance

--- a/mcp-adapter.php
+++ b/mcp-adapter.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://github.com/WordPress/mcp-adapter
  * Description:       Adapter for Abilities API, letting the abilities to be used as MCP tools, resources or prompts.
  * Requires at least: 6.8
- * Version:           0.1.0
+ * Version:           0.3.1
  * Requires PHP:      7.4
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/WordPress/mcp-adapter/graphs/contributors
@@ -40,7 +40,7 @@ function constants(): void {
 	/**
 	 * Version of the plugin.
 	 */
-	define( 'WP_MCP_VERSION', '0.1.0' );
+	define( 'WP_MCP_VERSION', '0.3.1' );
 }
 
 constants();


### PR DESCRIPTION
The v0.3.0 release asset was shipped with outdated version numbers, causing WordPress to show incorrect version information during updates.

Fixes #98