### PR TITLE
fix: Correct JSON-RPC error response structure and HTTP status codes

### DIFF
--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -211,11 +211,8 @@ class HttpRequestHandler {
 	 * @return \WP_REST_Response SSE response.
 	 */
 	private function handle_sse_request( HttpRequestContext $context ): \WP_REST_Response {
-		// SSE streaming not yet implemented
-		return new \WP_REST_Response(
-			McpErrorFactory::internal_error( 0, 'SSE streaming not yet implemented' ),
-			405
-		);
+		// SSE streaming not yet implemented - return HTTP 405 with no body
+		return new \WP_REST_Response( null, 405 );
 	}
 
 	/**

--- a/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/Transport/Infrastructure/RequestRouter.php
@@ -160,8 +160,8 @@ class RequestRouter {
 			$session_result = HttpSessionValidator::create_session( $params );
 
 			if ( is_array( $session_result ) ) {
-				// Session creation failed, return error
-				return array( 'error' => $session_result );
+				// Session creation failed - extract inner error from JSON-RPC response
+				return array( 'error' => $session_result['error'] ?? $session_result );
 			}
 
 			// Store session ID in result for HttpRequestHandler to add as header

--- a/tests/Integration/HttpTransportTest.php
+++ b/tests/Integration/HttpTransportTest.php
@@ -269,6 +269,57 @@ final class HttpTransportTest extends TestCase {
 		$this->assertStringContainsString( 'Missing Mcp-Session-Id header', $data['error']['message'] );
 	}
 
+	public function test_post_request_initialize_unauthenticated_returns_proper_json_rpc_error(): void {
+		// Set no user (unauthenticated)
+		wp_set_current_user( 0 );
+
+		$request = $this->createPostRequest(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 1,
+				'method'  => 'initialize',
+				'params'  => array(
+					'protocolVersion' => '2025-06-18',
+					'clientInfo'      => array(
+						'name'    => 'test-client',
+						'version' => '1.0.0',
+					),
+				),
+			)
+		);
+		$request->set_header( 'Accept', 'application/json, text/event-stream' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $this->transport->handle_request( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		// Should return HTTP 401 for unauthorized
+		$this->assertEquals( 401, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// Verify JSON-RPC 2.0 response structure
+		$this->assertArrayHasKey( 'jsonrpc', $data );
+		$this->assertEquals( '2.0', $data['jsonrpc'] );
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertEquals( 1, $data['id'] );
+		$this->assertArrayHasKey( 'error', $data );
+
+		// Verify error is NOT double-wrapped (no nested jsonrpc/id/error)
+		$this->assertArrayHasKey( 'code', $data['error'] );
+		$this->assertArrayHasKey( 'message', $data['error'] );
+		$this->assertArrayNotHasKey( 'jsonrpc', $data['error'] );
+		$this->assertArrayNotHasKey( 'id', $data['error'] );
+
+		// Verify correct error code
+		$this->assertEquals( McpErrorFactory::UNAUTHORIZED, $data['error']['code'] );
+		$this->assertStringContainsString( 'authentication', strtolower( $data['error']['message'] ) );
+
+		// Restore user
+		wp_set_current_user( 1 );
+	}
+
 	// ========== GET Request Tests ==========
 
 	public function test_get_request_for_sse_stream(): void {
@@ -278,12 +329,9 @@ final class HttpTransportTest extends TestCase {
 		$response = $this->transport->handle_request( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		// Currently returns 405 as SSE is not yet implemented
+		// SSE not implemented returns 405 with no body per HTTP standards
 		$this->assertEquals( 405, $response->get_status() );
-
-		$data = $response->get_data();
-		$this->assertArrayHasKey( 'error', $data );
-		$this->assertStringContainsString( 'SSE streaming not yet implemented', $data['error']['message'] );
+		$this->assertNull( $response->get_data() );
 	}
 
 

--- a/tests/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
+++ b/tests/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
@@ -270,10 +270,8 @@ final class HttpRequestHandlerTest extends TestCase {
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertEquals( 405, $response->get_status() );
-
-		$data = $response->get_data();
-		$this->assertArrayHasKey( 'error', $data );
-		$this->assertStringContainsString( 'SSE streaming not yet implemented', $data['error']['message'] );
+		// SSE not implemented returns 405 with no body per HTTP standards
+		$this->assertNull( $response->get_data() );
 	}
 
 	public function test_handle_request_delete_session(): void {

--- a/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -290,6 +290,81 @@ final class RequestRouterTest extends TestCase {
 		$this->assertEquals( 'test-transport', $first_success['tags']['transport'] );
 	}
 
+	public function test_route_request_initialize_unauthenticated_returns_correct_error_structure(): void {
+		// Set no user (unauthenticated)
+		wp_set_current_user( 0 );
+
+		$request      = new WP_REST_Request( 'POST', '/test-mcp' );
+		$http_context = new HttpRequestContext( $request );
+
+		$result = $this->router->route_request(
+			'initialize',
+			array(
+				'protocolVersion' => '2025-06-18',
+				'clientInfo'      => array(
+					'name'    => 'test-client',
+					'version' => '1.0.0',
+				),
+			),
+			1,
+			'test-transport',
+			$http_context
+		);
+
+		// Verify error response structure (not double-wrapped)
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+
+		// The error should be a proper error object with code and message
+		$this->assertArrayHasKey( 'code', $result['error'] );
+		$this->assertArrayHasKey( 'message', $result['error'] );
+
+		// Should NOT have nested jsonrpc/id/error (double-wrapping)
+		$this->assertArrayNotHasKey( 'jsonrpc', $result['error'] );
+		$this->assertArrayNotHasKey( 'id', $result['error'] );
+
+		// Verify the correct error code (unauthorized)
+		$this->assertEquals( McpErrorFactory::UNAUTHORIZED, $result['error']['code'] );
+		$this->assertStringContainsString( 'authentication', strtolower( $result['error']['message'] ) );
+
+		// Restore user
+		wp_set_current_user( $this->test_user_id );
+	}
+
+	public function test_route_request_initialize_session_error_has_correct_code(): void {
+		// Set no user (unauthenticated) to trigger session creation failure
+		wp_set_current_user( 0 );
+
+		$request      = new WP_REST_Request( 'POST', '/test-mcp' );
+		$http_context = new HttpRequestContext( $request );
+
+		$result = $this->router->route_request(
+			'initialize',
+			array(
+				'protocolVersion' => '2025-06-18',
+				'clientInfo'      => array(
+					'name'    => 'test-client',
+					'version' => '1.0.0',
+				),
+			),
+			1,
+			'test-transport',
+			$http_context
+		);
+
+		// Verify error has correct structure for HTTP status mapping
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertArrayHasKey( 'code', $result['error'] );
+
+		// The error code should map to HTTP 401
+		$http_status = McpErrorFactory::get_http_status_for_error( array( 'error' => $result['error'] ) );
+		$this->assertEquals( 401, $http_status );
+
+		// Restore user
+		wp_set_current_user( $this->test_user_id );
+	}
+
 	private function createTransportContext( McpServer $server ): McpTransportContext {
 		// Create handlers
 		$initialize_handler = new InitializeHandler( $server );


### PR DESCRIPTION
Fixes double-wrapped error responses when session creation fails during initialize requests. The McpErrorFactory methods return full JSON-RPC responses, but RequestRouter was wrapping the entire response again, causing nested error structures like:
{"jsonrpc":"2.0","id":1,"error":{"jsonrpc":"2.0","id":0,"error":{...}}}

Changes:
- Extract inner error object in RequestRouter::handle_initialize_with_session()
- Return HTTP 405 with no body for SSE requests per MCP specification
- Add unit tests for unauthenticated session creation error structure
- Add integration test for full JSON-RPC error response format

This ensures proper HTTP status code mapping (401 for unauthorized) and compliant JSON-RPC 2.0 error responses.

Fixes #104