### PR TITLE
Fix missing type definition in ExecuteAbilityAbility output schema

### DIFF
--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -56,6 +56,7 @@ final class ExecuteAbilityAbility {
 					'properties' => array(
 						'success' => array( 'type' => 'boolean' ),
 						'data'    => array(
+							'type'        => array( 'object', 'array', 'string', 'number', 'integer', 'boolean', 'null' ),
 							'description' => 'The result data from the ability execution',
 						),
 						'error'   => array(

--- a/tests/Unit/Abilities/ExecuteAbilityAbilityTest.php
+++ b/tests/Unit/Abilities/ExecuteAbilityAbilityTest.php
@@ -421,7 +421,48 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 		$this->assertEquals( 'object', $output_schema['type'] );
 		$this->assertArrayHasKey( 'properties', $output_schema );
 		$this->assertArrayHasKey( 'success', $output_schema['properties'] );
+		$this->assertArrayHasKey( 'data', $output_schema['properties'] );
+		$this->assertArrayHasKey( 'error', $output_schema['properties'] );
 		$this->assertEquals( array( 'success' ), $output_schema['required'] );
+	}
+
+	/**
+	 * Test that output schema data property has type defined to prevent PHP warnings.
+	 *
+	 * Regression test for https://github.com/WordPress/mcp-adapter/issues/109
+	 * WordPress REST API expects 'type' key to be defined in schema properties.
+	 */
+	public function test_output_schema_data_property_has_type_defined(): void {
+		$ability       = wp_get_ability( 'mcp-adapter/execute-ability' );
+		$output_schema = $ability->get_output_schema();
+
+		$data_schema = $output_schema['properties']['data'];
+
+		// Verify 'type' key exists (fixes PHP Warning: Undefined array key "type")
+		$this->assertArrayHasKey( 'type', $data_schema, 'Data property must have type defined to prevent PHP warnings in REST API' );
+	}
+
+	/**
+	 * Test that output schema data property accepts any JSON type for flexibility.
+	 *
+	 * The data property can return different types depending on the executed ability,
+	 * so it must accept objects, arrays, strings, numbers, booleans, and null.
+	 */
+	public function test_output_schema_data_property_accepts_all_json_types(): void {
+		$ability       = wp_get_ability( 'mcp-adapter/execute-ability' );
+		$output_schema = $ability->get_output_schema();
+
+		$data_schema = $output_schema['properties']['data'];
+		$type        = $data_schema['type'];
+
+		// Type should be an array for union types (JSON Schema 2020-12)
+		$this->assertIsArray( $type, 'Data type should be an array to support multiple types' );
+
+		// Verify all JSON primitive types are allowed
+		$expected_types = array( 'object', 'array', 'string', 'number', 'integer', 'boolean', 'null' );
+		foreach ( $expected_types as $expected_type ) {
+			$this->assertContains( $expected_type, $type, "Data property should accept type: {$expected_type}" );
+		}
 	}
 
 	public function test_ability_has_correct_annotations(): void {


### PR DESCRIPTION
 ## What

  Adds a `type` definition to the `data` property in the `output_schema` of `ExecuteAbilityAbility`. The type is defined as a JSON Schema union type array allowing all valid JSON types: `object`, `array`, `string`, `number`, `integer`, `boolean`, and `null`.

  **Changes:**
  - Added `'type' => array('object', 'array', 'string', 'number', 'integer', 'boolean', 'null')` to the `data` property schema
  - Added regression tests to ensure the `type` key is always present
  - Added tests to verify all JSON types are accepted

  ## Why

  The WordPress REST API expects all schema properties to have a `type` key defined. When missing,  `rest_validate_value_from_schema()` in `wp-includes/rest-api.php` triggers PHP warnings:

  PHP Warning: Undefined array key "type" in wp-includes/rest-api.php on line 2203
  PHP Warning: Undefined array key "type" in wp-includes/rest-api.php on line 2218
  PHP Warning: Undefined array key "type" in wp-includes/rest-api.php on line 2227

  The `data` property uses a union type array (valid per JSON Schema spec) because `execute-ability` is a generic executor that can run any registered WordPress ability, each potentially returning different data types.

  ## Testing

  - [x] Unit tests pass (21 tests, 85 assertions)
  - [x] MCP Inspector `tools/list` returns valid schema
  - [x] MCP Inspector `tools/call` executes successfully
  - [x] No PHP warnings in debug log after fix
  - [x] Schema complies with MCP specification 2025-06-18

  Fixes #109
