### PR TITLE
Fix tools/call error masking and preserve empty parameters

### DIFF
--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -114,8 +114,10 @@ final class ExecuteAbilityAbility {
 			return new \WP_Error( 'ability_not_found', "Ability '{$ability_name}' not found" );
 		}
 
-		// Check if the user has permission to execute the target ability
-		$parameters        = empty( $input['parameters'] ) ? null : $input['parameters'];
+		// Check if the user has permission to execute the target ability.
+		// Preserve empty objects {} instead of converting them to null. Some abilities
+		// require an object (type: object) and will fail if passed null.
+		$parameters        = array_key_exists( 'parameters', $input ) ? $input['parameters'] : null;
 		$permission_result = $ability->check_permissions( $parameters );
 
 		// Return WP_Error as-is, or convert other values to boolean
@@ -161,7 +163,8 @@ final class ExecuteAbilityAbility {
 	 */
 	public static function execute( $input = array() ): array {
 		$ability_name = $input['ability_name'] ?? '';
-		$parameters   = empty( $input['parameters'] ) ? null : $input['parameters'];
+		// Same logic as in check_permission: preserve {} when provided.
+		$parameters   = array_key_exists( 'parameters', $input ) ? $input['parameters'] : null;
 
 		if ( empty( $ability_name ) ) {
 			return array(

--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -117,7 +117,7 @@ final class ExecuteAbilityAbility {
 		// Check if the user has permission to execute the target ability.
 		// Preserve empty objects {} instead of converting them to null. Some abilities
 		// require an object (type: object) and will fail if passed null.
-		$parameters = array_key_exists( 'parameters', $input ) ? $input['parameters'] : null;
+		$parameters        = array_key_exists( 'parameters', $input ) ? $input['parameters'] : null;
 		$permission_result = $ability->check_permissions( $parameters );
 
 		// Return WP_Error as-is, or convert other values to boolean

--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -117,7 +117,7 @@ final class ExecuteAbilityAbility {
 		// Check if the user has permission to execute the target ability.
 		// Preserve empty objects {} instead of converting them to null. Some abilities
 		// require an object (type: object) and will fail if passed null.
-		$parameters        = array_key_exists( 'parameters', $input ) ? $input['parameters'] : null;
+		$parameters = array_key_exists( 'parameters', $input ) ? $input['parameters'] : null;
 		$permission_result = $ability->check_permissions( $parameters );
 
 		// Return WP_Error as-is, or convert other values to boolean
@@ -164,7 +164,7 @@ final class ExecuteAbilityAbility {
 	public static function execute( $input = array() ): array {
 		$ability_name = $input['ability_name'] ?? '';
 		// Same logic as in check_permission: preserve {} when provided.
-		$parameters   = array_key_exists( 'parameters', $input ) ? $input['parameters'] : null;
+		$parameters = array_key_exists( 'parameters', $input ) ? $input['parameters'] : null;
 
 		if ( empty( $ability_name ) ) {
 			return array(

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -116,7 +116,7 @@ class ToolsHandler {
 			// Check if the result contains a *reserved* error.
 			// We only treat it as a tools/call failure when it comes from our internal error paths
 			// (which always set _metadata.failure_reason). This avoids masking legitimate tool outputs
-			// that include a top‑level "error" field as part of their schema (e.g. ExecuteAbilityAbility).
+			// that include a top-level "error" field as part of their schema (e.g. ExecuteAbilityAbility).
 			if ( isset( $result['error'] ) && isset( $result['_metadata']['failure_reason'] ) ) {
 				$failure_reason = $result['_metadata']['failure_reason'] ?? '';
 

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -113,9 +113,11 @@ class ToolsHandler {
 			// Implement a tool calling logic here.
 			$result = $this->handle_tool_call( $request_params, $request_id );
 
-			// Check if the result contains an error.
-			// Distinguish between protocol errors (JSON-RPC format) and tool execution errors (isError format).
-			if ( isset( $result['error'] ) ) {
+			// Check if the result contains a *reserved* error.
+			// We only treat it as a tools/call failure when it comes from our internal error paths
+			// (which always set _metadata.failure_reason). This avoids masking legitimate tool outputs
+			// that include a top‑level "error" field as part of their schema (e.g. ExecuteAbilityAbility).
+			if ( isset( $result['error'] ) && isset( $result['_metadata']['failure_reason'] ) ) {
 				$failure_reason = $result['_metadata']['failure_reason'] ?? '';
 
 				// Protocol errors (keep JSON-RPC error format):


### PR DESCRIPTION
## Context

* Plugin: **WordPress/mcp-adapter** (latest release, default server)
* WordPress **6.9+** with **Abilities API**
* MCP clients call tools via **tools/list** and **tools/call**

## Problems

### 1) `tools/call` incorrectly treats any top-level `error` key in a tool result as an MCP failure

* Some abilities legitimately return arrays containing `error` as part of their own schema.
* `ToolsHandler::call_tool()` currently checks `isset($result['error'])` and converts the response to `isError: true`, masking the structured payload and producing a generic client error message.

**Expected**

* Only internal MCP/JSON-RPC errors should be treated as failures.
* Legitimate ability outputs containing an `error` field should be returned normally.

### 2) `ExecuteAbilityAbility` turns empty `parameters` objects `{}` into `null`

* `empty($input['parameters'])` makes `{}` become `null`.
* Abilities requiring an object then fail validation.

**Expected**

* Preserve `{}` when the key exists.
* Use `null` only when the key is absent.

## Fix

* **ToolsHandler**: treat top-level `error` as reserved only when `_metadata.failure_reason` is present.
* **ExecuteAbilityAbility**: replace `empty()` checks with `array_key_exists()` to preserve `{}`.

## Notes / impact

* Prevents masking legitimate tool outputs and avoids generic MCP client errors.
* Restores correct behavior for tools that accept empty objects.
* No behavior change for genuine internal errors or `WP_Error` paths.

---
