### PR TITLE
Fix missing type in execute-ability output schema

### DIFF
--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -56,6 +56,7 @@ final class ExecuteAbilityAbility {
 					'properties' => array(
 						'success' => array( 'type' => 'boolean' ),
 						'data'    => array(
+							'type'        => array( 'object', 'array', 'string', 'number', 'integer', 'boolean', 'null' ),
 							'description' => 'The result data from the ability execution',
 						),
 						'error'   => array(


### PR DESCRIPTION
## Summary
- add explicit `type` for the `data` field in the `mcp-adapter/execute-ability` output schema

## Problem
`rest_validate_value_from_schema()` warns when a schema field lacks a `type`. The execute-ability output schema defines `data` with only a description, which triggers "Undefined array key \"type\"" warnings in `wp-includes/rest-api.php` when abilities return data.

## Fix
Provide an explicit multi-type declaration for `data` so schema validation is satisfied (object/array/string/number/integer/boolean/null).

## Test
- Ran `tools/call` -> `mcp-adapter/execute-ability` (e.g. `content/list-posts`) via `wp mcp-adapter serve` on a WP 6.9 site; warnings no longer appear and output validates.
