### PR TITLE
[1/6] Add php-mcp-schema package dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,10 @@
 				"wpackagist-plugin/*",
 				"wpackagist-theme/*"
 			]
+		},
+		{
+			"type": "vcs",
+			"url": "https://github.com/WordPress/php-mcp-schema.git"
 		}
 	],
 	"extra": {
@@ -70,10 +74,13 @@
 		}
 	},
 	"require": {
-		"php": "^7.4 || ^8.0"
+		"php": "^7.4 || ^8.0",
+		"wordpress/php-mcp-schema": "dev-feat/mcp-schema-2025-11-25",
+		"ext-json": "*"
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^3.0",
+		"php-stubs/wordpress-stubs": "^6.9",
 		"php-stubs/wp-cli-stubs": "^2.12",
 		"phpcompatibility/php-compatibility": "10.x-dev as 9.99.99",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,67 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "242e822bd9a3c1b6d52d56a60de533c7",
-    "packages": [],
+    "content-hash": "23b92d843fddc9c75ebc03f4931206fa",
+    "packages": [
+        {
+            "name": "wordpress/php-mcp-schema",
+            "version": "dev-feat/mcp-schema-2025-11-25",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/php-mcp-schema.git",
+                "reference": "d31bbf5acc5e3cc9d32e9e17d819e1ca8d18ba76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/d31bbf5acc5e3cc9d32e9e17d819e1ca8d18ba76",
+                "reference": "d31bbf5acc5e3cc9d32e9e17d819e1ca8d18ba76",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WP\\McpSchema\\": "src/"
+                }
+            },
+            "scripts": {
+                "analyse": [
+                    "phpstan analyse"
+                ],
+                "phpstan": [
+                    "@analyse"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress",
+                    "homepage": "https://wordpress.org"
+                }
+            ],
+            "description": "PHP DTOs for the Model Context Protocol (MCP) specification",
+            "homepage": "https://github.com/WordPress/php-mcp-schema",
+            "keywords": [
+                "dto",
+                "mcp",
+                "model-context-protocol",
+                "php",
+                "schema"
+            ],
+            "support": {
+                "source": "https://github.com/WordPress/php-mcp-schema/tree/feat/mcp-schema-2025-11-25",
+                "issues": "https://github.com/WordPress/php-mcp-schema/issues"
+            },
+            "time": "2026-01-06T16:27:40+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
@@ -611,16 +670,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.8.2",
+            "version": "v6.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8"
+                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
-                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
+                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
                 "shasum": ""
             },
             "conflict": {
@@ -656,9 +715,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.0"
             },
-            "time": "2025-07-16T06:41:00+00:00"
+            "time": "2025-12-03T23:06:24+00:00"
         },
         {
             "name": "php-stubs/wp-cli-stubs",
@@ -3321,16 +3380,18 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "phpcompatibility/php-compatibility": 20
+        "phpcompatibility/php-compatibility": 20,
+        "wordpress/php-mcp-schema": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ^8.0"
+        "php": "^7.4 || ^8.0",
+        "ext-json": "*"
     },
     "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary

Adds the `wordpress/php-mcp-schema` package as a Composer dependency. This package provides PHP DTOs (Data Transfer Objects) for the MCP (Model Context Protocol) specification 2025-11-25.

## Changes

- **composer.json**: Added `wordpress/php-mcp-schema` requirement
- **composer.lock**: Updated lockfile with new dependency

## Why

The php-mcp-schema package provides:
- Type-safe DTOs for all MCP protocol types (Tools, Resources, Prompts, JSON-RPC)
- Validation and serialization helpers
- Alignment with the official MCP specification

This replaces manual array structures with strongly-typed objects, improving:
- IDE autocompletion and type checking
- PHPStan Level 8 compliance
- Protocol correctness guarantees

## Stacked PR

⚠️ **This is PR 1 of 6** in the MCP Schema integration series.

| # | Branch | Description |
|---|--------|-------------|
| **1** | **`01-composer-deps`** | **← You are here** |
| 2 | `02-infrastructure` | Error handling + observability |
| 3 | `03-domain-utils` | Domain contracts + utilities |
| 4 | `04-domain-components` | Tools, Resources, Prompts |
| 5 | `05-core` | Core + abilities + plugin |
| 6 | `06-handlers-transport` | Handlers + Transport + CLI |

**Merge order**: 1 → 2 → 3 → 4 → 5 → 6

## Testing

- [ ] `composer install` succeeds
- [ ] No conflicts with existing dependencies