### PR TITLE
[2/6] Refactor infrastructure layer for MCP schema DTOs

### DIFF
--- a/includes/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php
+++ b/includes/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php
@@ -21,7 +21,7 @@ interface McpErrorHandlerInterface {
 	 * Log an error message with optional context and type.
 	 *
 	 * @param string $message The log message.
-	 * @param array  $context Additional context data.
+	 * @param array $context Additional context data.
 	 * @param string $type The log type (e.g., 'error', 'info', 'debug').
 	 *
 	 * @return void

--- a/includes/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php
+++ b/includes/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php
@@ -22,7 +22,7 @@ class ErrorLogMcpErrorHandler implements Contracts\McpErrorHandlerInterface {
 	 * Log with context.
 	 *
 	 * @param string $message The log message.
-	 * @param array  $context Additional context data.
+	 * @param array $context Additional context data.
 	 * @param string $type The type of log (e.g., 'error', 'info', etc.). Default is 'error'.
 	 *
 	 * @return void

--- a/includes/Infrastructure/ErrorHandling/McpErrorFactory.php
+++ b/includes/Infrastructure/ErrorHandling/McpErrorFactory.php
@@ -9,22 +9,27 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Infrastructure\ErrorHandling;
 
+use WP\McpSchema\Common\JsonRpc\DTO\Error;
+use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
+use WP\McpSchema\Common\McpConstants;
+
 /**
  * Factory for creating standardized MCP error responses.
  *
  * This class provides static methods for creating various types of JSON-RPC
- * error responses according to the MCP specification.
+ * error responses according to the MCP specification. All methods return
+ * typed DTOs from php-mcp-schema for type safety and protocol compliance.
  */
 class McpErrorFactory {
 
 	/**
 	 * Standard JSON-RPC error codes as defined in the specification.
 	 */
-	public const PARSE_ERROR      = -32700;
-	public const INVALID_REQUEST  = -32600;
-	public const METHOD_NOT_FOUND = -32601;
-	public const INVALID_PARAMS   = -32602;
-	public const INTERNAL_ERROR   = -32603;
+	public const PARSE_ERROR      = McpConstants::PARSE_ERROR;
+	public const INVALID_REQUEST  = McpConstants::INVALID_REQUEST;
+	public const METHOD_NOT_FOUND = McpConstants::METHOD_NOT_FOUND;
+	public const INVALID_PARAMS   = McpConstants::INVALID_PARAMS;
+	public const INTERNAL_ERROR   = McpConstants::INTERNAL_ERROR;
 
 	/**
 	 * Implementation-defined server error codes (in -32000 to -32099 range as per JSON-RPC spec).
@@ -39,41 +44,14 @@ class McpErrorFactory {
 	public const UNAUTHORIZED       = -32010; // Authentication required
 
 	/**
-	 * Create a standardized JSON-RPC error response.
-	 *
-	 * @param int    $id The request ID.
-	 * @param int    $code The error code.
-	 * @param string $message The error message.
-	 * @param mixed|null $data Optional additional error data.
-	 *
-	 * @return array
-	 */
-	public static function create_error_response( int $id, int $code, string $message, $data = null ): array {
-		$response = array(
-			'jsonrpc' => '2.0',
-			'id'      => $id,
-			'error'   => array(
-				'code'    => $code,
-				'message' => $message,
-			),
-		);
-
-		if ( null !== $data ) {
-			$response['error']['data'] = $data;
-		}
-
-		return $response;
-	}
-
-	/**
 	 * Create a parse error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function parse_error( int $id, string $details = '' ): array {
+	public static function parse_error( $id, string $details = '' ): JSONRPCErrorResponse {
 		$message = __( 'Parse error', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -83,36 +61,58 @@ class McpErrorFactory {
 	}
 
 	/**
-	 * Create an invalid request error response.
+	 * Create a standardized JSON-RPC error response DTO.
 	 *
-	 * @param int    $id The request ID.
-	 * @param string $details Optional additional details.
+	 * @param string|int|null $id The request ID (JSON-RPC allows string, int, or null).
+	 * @param int $code The error code.
+	 * @param string $message The error message.
+	 * @param mixed|null $data Optional additional error data.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function invalid_request( int $id, string $details = '' ): array {
-		$message = __( 'Invalid Request', 'mcp-adapter' );
-		if ( $details ) {
-			$message .= ': ' . $details;
-		}
+	public static function create_error_response( $id, int $code, string $message, $data = null ): JSONRPCErrorResponse {
+		return JSONRPCErrorResponse::fromArray(
+			array(
+				'jsonrpc' => McpConstants::JSONRPC_VERSION,
+				'error'   => self::create_error( $code, $message, $data ),
+				'id'      => $id,
+			)
+		);
+	}
 
-		return self::create_error_response( $id, self::INVALID_REQUEST, $message );
+	/**
+	 * Create an Error DTO.
+	 *
+	 * @param int $code The error code.
+	 * @param string $message The error message.
+	 * @param mixed|null $data Optional additional error data.
+	 *
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\Error
+	 */
+	public static function create_error( int $code, string $message, $data = null ): Error {
+		return Error::fromArray(
+			array(
+				'code'    => $code,
+				'message' => $message,
+				'data'    => $data,
+			)
+		);
 	}
 
 	/**
 	 * Create a method not found error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $method The method that was not found.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function method_not_found( int $id, string $method ): array {
+	public static function method_not_found( $id, string $method ): JSONRPCErrorResponse {
 		return self::create_error_response(
 			$id,
 			self::METHOD_NOT_FOUND,
 			sprintf(
-				/* translators: %s: method name */
+			/* translators: %s: method name */
 				__( 'Method not found: %s', 'mcp-adapter' ),
 				$method
 			)
@@ -122,12 +122,12 @@ class McpErrorFactory {
 	/**
 	 * Create an invalid params error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function invalid_params( int $id, string $details = '' ): array {
+	public static function invalid_params( $id, string $details = '' ): JSONRPCErrorResponse {
 		$message = __( 'Invalid params', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -139,12 +139,12 @@ class McpErrorFactory {
 	/**
 	 * Create an internal error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function internal_error( int $id, string $details = '' ): array {
+	public static function internal_error( $id, string $details = '' ): JSONRPCErrorResponse {
 		$message = __( 'Internal error', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -156,11 +156,11 @@ class McpErrorFactory {
 	/**
 	 * Create an MCP disabled error response.
 	 *
-	 * @param int $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function mcp_disabled( int $id ): array {
+	public static function mcp_disabled( $id ): JSONRPCErrorResponse {
 		return self::create_error_response(
 			$id,
 			self::SERVER_ERROR,
@@ -171,17 +171,17 @@ class McpErrorFactory {
 	/**
 	 * Create a validation error response (uses standard invalid params error).
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $details Validation error details.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function validation_error( int $id, string $details ): array {
+	public static function validation_error( $id, string $details ): JSONRPCErrorResponse {
 		return self::create_error_response(
 			$id,
 			self::INVALID_PARAMS,
 			sprintf(
-				/* translators: %s: validation details */
+			/* translators: %s: validation details */
 				__( 'Validation error: %s', 'mcp-adapter' ),
 				$details
 			)
@@ -191,17 +191,17 @@ class McpErrorFactory {
 	/**
 	 * Create a missing parameter error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $parameter The missing parameter name.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function missing_parameter( int $id, string $parameter ): array {
+	public static function missing_parameter( $id, string $parameter ): JSONRPCErrorResponse {
 		return self::create_error_response(
 			$id,
 			self::INVALID_PARAMS,
 			sprintf(
-				/* translators: %s: parameter name */
+			/* translators: %s: parameter name */
 				__( 'Missing required parameter: %s', 'mcp-adapter' ),
 				$parameter
 			)
@@ -211,17 +211,17 @@ class McpErrorFactory {
 	/**
 	 * Create a resource not found error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $resource_uri The resource identifier.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function resource_not_found( int $id, string $resource_uri ): array {
+	public static function resource_not_found( $id, string $resource_uri ): JSONRPCErrorResponse {
 		return self::create_error_response(
 			$id,
 			self::RESOURCE_NOT_FOUND,
 			sprintf(
-				/* translators: %s: resource identifier */
+			/* translators: %s: resource identifier */
 				__( 'Resource not found: %s', 'mcp-adapter' ),
 				$resource_uri
 			)
@@ -231,17 +231,17 @@ class McpErrorFactory {
 	/**
 	 * Create a tool not found error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $tool The tool name.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function tool_not_found( int $id, string $tool ): array {
+	public static function tool_not_found( $id, string $tool ): JSONRPCErrorResponse {
 		return self::create_error_response(
 			$id,
 			self::TOOL_NOT_FOUND,
 			sprintf(
-				/* translators: %s: tool name */
+			/* translators: %s: tool name */
 				__( 'Tool not found: %s', 'mcp-adapter' ),
 				$tool
 			)
@@ -249,19 +249,19 @@ class McpErrorFactory {
 	}
 
 	/**
-	 * Create a tool not found error response.
+	 * Create an ability not found error response.
 	 *
-	 * @param int    $id The request ID.
-	 * @param string $ability The tool name.
+	 * @param string|int|null $id The request ID.
+	 * @param string $ability The ability name.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function ability_not_found( int $id, string $ability ): array {
+	public static function ability_not_found( $id, string $ability ): JSONRPCErrorResponse {
 		return self::create_error_response(
 			$id,
 			self::TOOL_NOT_FOUND,
 			sprintf(
-				/* translators: %s: tool name */
+			/* translators: %s: ability name */
 				__( 'Ability not found: %s', 'mcp-adapter' ),
 				$ability
 			)
@@ -271,17 +271,17 @@ class McpErrorFactory {
 	/**
 	 * Create a prompt not found error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $prompt The prompt name.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function prompt_not_found( int $id, string $prompt ): array {
+	public static function prompt_not_found( $id, string $prompt ): JSONRPCErrorResponse {
 		return self::create_error_response(
 			$id,
 			self::PROMPT_NOT_FOUND,
 			sprintf(
-				/* translators: %s: prompt name */
+			/* translators: %s: prompt name */
 				__( 'Prompt not found: %s', 'mcp-adapter' ),
 				$prompt
 			)
@@ -291,12 +291,12 @@ class McpErrorFactory {
 	/**
 	 * Create a permission denied error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function permission_denied( int $id, string $details = '' ): array {
+	public static function permission_denied( $id, string $details = '' ): JSONRPCErrorResponse {
 		$message = __( 'Permission denied', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -308,12 +308,12 @@ class McpErrorFactory {
 	/**
 	 * Create an unauthorized error response.
 	 *
-	 * @param int    $id The request ID.
+	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return array
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
-	public static function unauthorized( int $id, string $details = '' ): array {
+	public static function unauthorized( $id, string $details = '' ): JSONRPCErrorResponse {
 		$message = __( 'Unauthorized', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -323,19 +323,46 @@ class McpErrorFactory {
 	}
 
 	/**
+	 * Determine if an MCP error should return HTTP 200 or an HTTP error status.
+	 *
+	 * This method helps distinguish between transport-level errors (which should
+	 * return HTTP error codes) and application-level errors (which should return
+	 * HTTP 200 with a JSON-RPC error response).
+	 *
+	 * @param \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse|array $error_response The MCP error response (DTO or array).
+	 *
+	 * @return int The appropriate HTTP status code.
+	 */
+	public static function get_http_status_for_error( $error_response ): int {
+		// Handle DTO
+		if ( $error_response instanceof JSONRPCErrorResponse ) {
+			return self::mcp_error_to_http_status( $error_response->getError()->getCode() );
+		}
+
+		// Handle legacy array format
+		if ( ! isset( $error_response['error']['code'] ) ) {
+			return 500; // Invalid error response structure
+		}
+
+		return self::mcp_error_to_http_status( $error_response['error']['code'] );
+	}
+
+	/**
 	 * Translate MCP error code to appropriate HTTP status code.
 	 *
 	 * Maps JSON-RPC error codes to HTTP status codes according to best practices:
 	 * - Transport-level errors (malformed JSON-RPC) → HTTP 4xx
 	 * - Application-level errors (business logic) → HTTP 200 with JSON-RPC error
 	 *
-	 * @param int|string $mcp_error_code The MCP/JSON-RPC error code (integer or string).
+	 * @param int|string|float $mcp_error_code The MCP/JSON-RPC error code (integer, float, or string).
 	 *
 	 * @return int The appropriate HTTP status code.
 	 */
 	public static function mcp_error_to_http_status( $mcp_error_code ): int {
-		// Handle integer error codes (existing logic)
-		switch ( $mcp_error_code ) {
+		// Cast to integer for comparison (handles float from DTOs)
+		$code = is_numeric( $mcp_error_code ) ? (int) $mcp_error_code : 0;
+
+		switch ( $code ) {
 			// Transport-level errors - these indicate malformed requests
 			case self::PARSE_ERROR:      // Invalid JSON - syntactic error
 				return 400;
@@ -373,39 +400,27 @@ class McpErrorFactory {
 	}
 
 	/**
-	 * Determine if an MCP error should return HTTP 200 or an HTTP error status.
-	 *
-	 * This method helps distinguish between transport-level errors (which should
-	 * return HTTP error codes) and application-level errors (which should return
-	 * HTTP 200 with a JSON-RPC error response).
-	 *
-	 * @param array $error_response The MCP error response array.
-	 *
-	 * @return int The appropriate HTTP status code.
-	 */
-	public static function get_http_status_for_error( array $error_response ): int {
-		if ( ! isset( $error_response['error']['code'] ) ) {
-			return 500; // Invalid error response structure
-		}
-
-		return self::mcp_error_to_http_status( $error_response['error']['code'] );
-	}
-
-	/**
 	 * Validate JSON-RPC message structure.
 	 *
 	 * @param mixed $message The message to validate.
 	 *
-	 * @return bool|array Returns true if valid, or error array if invalid.
+	 * @return true|\WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse Returns true if valid, or JSONRPCErrorResponse DTO if invalid.
 	 */
 	public static function validate_jsonrpc_message( $message ) {
 		if ( ! is_array( $message ) ) {
-			return self::invalid_request( 0, __( 'Message must be a JSON object', 'mcp-adapter' ) );
+			return self::invalid_request( null, __( 'Message must be a JSON object', 'mcp-adapter' ) );
 		}
 
 		// Must have jsonrpc field with value "2.0".
-		if ( ! isset( $message['jsonrpc'] ) || '2.0' !== $message['jsonrpc'] ) {
-			return self::invalid_request( 0, __( 'jsonrpc version must be "2.0"', 'mcp-adapter' ) );
+		if ( ! isset( $message['jsonrpc'] ) || McpConstants::JSONRPC_VERSION !== $message['jsonrpc'] ) {
+			return self::invalid_request(
+				null,
+				sprintf(
+				/* translators: %s: JSON-RPC version */
+					__( 'jsonrpc version must be "%s"', 'mcp-adapter' ),
+					McpConstants::JSONRPC_VERSION
+				)
+			);
 		}
 
 		// Must be either a request/notification (has method) or a response (has result/error).
@@ -413,14 +428,31 @@ class McpErrorFactory {
 		$is_response                = isset( $message['result'] ) || isset( $message['error'] );
 
 		if ( ! $is_request_or_notification && ! $is_response ) {
-			return self::invalid_request( 0, __( 'Message must have either method or result/error field', 'mcp-adapter' ) );
+			return self::invalid_request( null, __( 'Message must have either method or result/error field', 'mcp-adapter' ) );
 		}
 
 		// Responses must have an id field.
 		if ( $is_response && ! isset( $message['id'] ) ) {
-			return self::invalid_request( 0, __( 'Response messages must have an id field', 'mcp-adapter' ) );
+			return self::invalid_request( null, __( 'Response messages must have an id field', 'mcp-adapter' ) );
 		}
 
 		return true;
+	}
+
+	/**
+	 * Create an invalid request error response.
+	 *
+	 * @param string|int|null $id The request ID.
+	 * @param string $details Optional additional details.
+	 *
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 */
+	public static function invalid_request( $id, string $details = '' ): JSONRPCErrorResponse {
+		$message = __( 'Invalid Request', 'mcp-adapter' );
+		if ( $details ) {
+			$message .= ': ' . $details;
+		}
+
+		return self::create_error_response( $id, self::INVALID_REQUEST, $message );
 	}
 }

--- a/includes/Infrastructure/ErrorHandling/NullMcpErrorHandler.php
+++ b/includes/Infrastructure/ErrorHandling/NullMcpErrorHandler.php
@@ -24,7 +24,7 @@ class NullMcpErrorHandler implements Contracts\McpErrorHandlerInterface {
 	 * This method does nothing and is used when no error handling is desired.
 	 *
 	 * @param string $message The log message.
-	 * @param array  $context Additional context data.
+	 * @param array $context Additional context data.
 	 * @param string $type The type of log (e.g., 'error', 'info', etc.). Default is 'error'.
 	 *
 	 * @return void

--- a/includes/Infrastructure/Observability/ConsoleObservabilityHandler.php
+++ b/includes/Infrastructure/Observability/ConsoleObservabilityHandler.php
@@ -25,8 +25,8 @@ class ConsoleObservabilityHandler implements McpObservabilityHandlerInterface {
 	/**
 	 * Record an event with formatted output.
 	 *
-	 * @param string     $event The event name.
-	 * @param array      $tags Tags to attach.
+	 * @param string $event The event name.
+	 * @param array $tags Tags to attach.
 	 * @param float|null $duration_ms Duration in milliseconds.
 	 *
 	 * @return void

--- a/includes/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php
+++ b/includes/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php
@@ -21,8 +21,8 @@ interface McpObservabilityHandlerInterface {
 	/**
 	 * Emit a countable event for tracking with optional timing data.
 	 *
-	 * @param string     $event The event name to record.
-	 * @param array      $tags Optional tags to attach to the event.
+	 * @param string $event The event name to record.
+	 * @param array $tags Optional tags to attach to the event.
 	 * @param float|null $duration_ms Optional duration in milliseconds for timing measurements.
 	 *
 	 * @return void

--- a/includes/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php
+++ b/includes/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php
@@ -24,8 +24,8 @@ class ErrorLogMcpObservabilityHandler implements Contracts\McpObservabilityHandl
 	/**
 	 * Emit a countable event for tracking with optional timing data.
 	 *
-	 * @param string     $event The event name to record.
-	 * @param array      $tags Optional tags to attach to the event.
+	 * @param string $event The event name to record.
+	 * @param array $tags Optional tags to attach to the event.
 	 * @param float|null $duration_ms Optional duration in milliseconds for timing measurements.
 	 *
 	 * @return void

--- a/includes/Infrastructure/Observability/FailureReason.php
+++ b/includes/Infrastructure/Observability/FailureReason.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Centralized failure reason taxonomy for observability.
+ *
+ * This class defines a stable, documented vocabulary of failure reasons
+ * used in observability events and error metadata. Using constants ensures
+ * consistent categorization across all MCP adapter components.
+ *
+ * @package McpAdapter
+ * @since   n.e.x.t
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Infrastructure\Observability;
+
+/**
+ * Failure reason taxonomy for observability events.
+ *
+ * Categories:
+ * - Registration failures: Occur during component registration at boot time
+ * - Permission failures: Occur when permission checks fail at execution time
+ * - Execution failures: Occur during component execution
+ *
+ * @since n.e.x.t
+ */
+final class FailureReason {
+
+	// =========================================================================
+	// Registration Failures
+	// =========================================================================
+
+	/**
+	 * WordPress ability was not found in the registry.
+	 *
+	 * Occurs when an ability name is passed to register_tools/resources/prompts
+	 * but wp_get_ability() returns null.
+	 */
+	public const ABILITY_NOT_FOUND = 'ability_not_found';
+
+	/**
+	 * A resource with the same URI is already registered.
+	 *
+	 * MCP resources must have unique URIs. This failure occurs when
+	 * attempting to register a duplicate.
+	 */
+	public const DUPLICATE_URI = 'duplicate_uri';
+
+	/**
+	 * Prompt builder threw an exception during instantiation or build.
+	 *
+	 * Occurs when a class implementing McpPromptBuilderInterface throws
+	 * during construction or the build() method.
+	 */
+	public const BUILDER_EXCEPTION = 'builder_exception';
+
+	/**
+	 * Component was created without a permission callback.
+	 *
+	 * Domain components (McpTool, McpResource, McpPrompt) require a permission
+	 * callback. This failure occurs when check_permission() is called but
+	 * no callback was configured.
+	 */
+	public const NO_PERMISSION_STRATEGY = 'no_permission_strategy';
+
+	/**
+	 * Ability conversion returned a WP_Error.
+	 *
+	 * Occurs when McpTool::fromAbility(), McpResource::fromAbility(), or
+	 * McpPrompt::fromAbility() fails due to invalid ability configuration.
+	 */
+	public const ABILITY_CONVERSION_FAILED = 'ability_conversion_failed';
+
+	// =========================================================================
+	// Permission Failures
+	// =========================================================================
+
+	/**
+	 * Generic permission denied without specific reason.
+	 *
+	 * Used when a permission callback returns false without providing
+	 * a WP_Error with more specific context.
+	 */
+	public const PERMISSION_DENIED = 'permission_denied';
+
+	/**
+	 * Permission callback returned a WP_Error.
+	 *
+	 * When the permission callback returns a WP_Error, the WP_Error code
+	 * is logged separately in the 'wp_error_code' tag while this failure
+	 * reason indicates the permission check explicitly failed.
+	 */
+	public const PERMISSION_CHECK_FAILED = 'permission_check_failed';
+
+	// =========================================================================
+	// Execution Failures
+	// =========================================================================
+
+	/**
+	 * Component not found at execution time.
+	 *
+	 * Occurs when tools/call, resources/read, or prompts/get targets a
+	 * component that doesn't exist. Different from ABILITY_NOT_FOUND which
+	 * occurs at registration time.
+	 */
+	public const NOT_FOUND = 'not_found';
+
+	/**
+	 * Component execution returned a WP_Error.
+	 *
+	 * Occurs when the execute() or read() method returns a WP_Error.
+	 * The WP_Error code is logged separately in 'wp_error_code'.
+	 */
+	public const EXECUTION_FAILED = 'execution_failed';
+
+	/**
+	 * Component execution threw an exception.
+	 *
+	 * Occurs when execute(), read(), or handle() throws an exception.
+	 * The exception type is logged separately in 'exception_type'.
+	 */
+	public const EXECUTION_EXCEPTION = 'execution_exception';
+
+	// =========================================================================
+	// Validation Failures
+	// =========================================================================
+
+	/**
+	 * Required parameter was missing from the request.
+	 *
+	 * JSON-RPC requests require certain parameters (e.g., 'name' for tools/call).
+	 */
+	public const MISSING_PARAMETER = 'missing_parameter';
+
+	/**
+	 * Parameter validation failed (wrong type, out of range, etc.).
+	 *
+	 * Occurs when input validation against schema or business rules fails.
+	 */
+	public const INVALID_PARAMETER = 'invalid_parameter';
+
+	// =========================================================================
+	// Helper Methods
+	// =========================================================================
+
+	/**
+	 * Get all valid failure reason values.
+	 *
+	 * Useful for validation and documentation generation.
+	 *
+	 * @return array<string> List of all valid failure reason constants.
+	 */
+	public static function all(): array {
+		return array(
+			// Registration.
+			self::ABILITY_NOT_FOUND,
+			self::DUPLICATE_URI,
+			self::BUILDER_EXCEPTION,
+			self::NO_PERMISSION_STRATEGY,
+			self::ABILITY_CONVERSION_FAILED,
+			// Permission.
+			self::PERMISSION_DENIED,
+			self::PERMISSION_CHECK_FAILED,
+			// Execution.
+			self::NOT_FOUND,
+			self::EXECUTION_FAILED,
+			self::EXECUTION_EXCEPTION,
+			// Validation.
+			self::MISSING_PARAMETER,
+			self::INVALID_PARAMETER,
+		);
+	}
+
+	/**
+	 * Check if a value is a valid failure reason.
+	 *
+	 * @param string $value The value to check.
+	 *
+	 * @return bool True if valid, false otherwise.
+	 */
+	public static function is_valid( string $value ): bool {
+		return in_array( $value, self::all(), true );
+	}
+}

--- a/includes/Infrastructure/Observability/McpObservabilityHelperTrait.php
+++ b/includes/Infrastructure/Observability/McpObservabilityHelperTrait.php
@@ -20,7 +20,7 @@ trait McpObservabilityHelperTrait {
 	 * Error categories keyed by throwable class name.
 	 *
 	 * @used-by ::categorize_error() method.
-	*/
+	 */
 	private static array $error_categories = array(
 		\ArgumentCountError::class       => 'arguments',
 		\Error::class                    => 'system',
@@ -31,53 +31,42 @@ trait McpObservabilityHelperTrait {
 	);
 
 	/**
-	 * Get default tags that should be included with all metrics.
+	 * Patterns that indicate sensitive data in keys or values.
 	 *
-	 * @return array
+	 * These patterns are designed to match both camelCase and snake_case variants:
+	 * - apiKey, api_key, API_KEY
+	 * - authToken, auth_token, AUTH_TOKEN
+	 * - secretKey, secret_key, SECRET_KEY
+	 *
+	 * @var string[]
 	 */
-	public static function get_default_tags(): array {
-		return array(
-			'site_id'   => function_exists( 'get_current_blog_id' ) ? get_current_blog_id() : 0,
-			'user_id'   => function_exists( 'get_current_user_id' ) ? get_current_user_id() : 0,
-			'timestamp' => time(),
-		);
-	}
-
-	/**
-	 * Sanitize tags to ensure they are safe for logging and don't contain sensitive data.
-	 *
-	 * @param array $tags The tags to sanitize.
-	 *
-	 * @return array
-	 */
-	public static function sanitize_tags( array $tags ): array {
-		$sanitized = array();
-
-		foreach ( $tags as $key => $value ) {
-			// Convert to string and limit length to prevent log bloat.
-			$key = substr( (string) $key, 0, 64 );
-
-			// Convert value to string, handling null specially.
-			if ( null === $value ) {
-				$value = '';
-			} elseif ( is_scalar( $value ) ) {
-				$value = (string) $value;
-			} else {
-				$value = wp_json_encode( $value );
-				// wp_json_encode can return false on failure, ensure we have a string.
-				if ( false === $value ) {
-					$value = '';
-				}
-			}
-
-			// Remove potentially sensitive information patterns.
-			$value = preg_replace( '/\b(?:password|token|key|secret|auth)\b/i', '[REDACTED]', $value );
-
-			$sanitized[ $key ] = $value;
-		}
-
-		return $sanitized;
-	}
+	private static array $sensitive_patterns = array(
+		'password',
+		'passwd',
+		'pwd',
+		'secret',
+		'token',
+		'bearer',
+		'credential',
+		'private',
+		'apikey',
+		'api_key',
+		'authtoken',
+		'auth_token',
+		'accesstoken',
+		'access_token',
+		'refreshtoken',
+		'refresh_token',
+		'clientsecret',
+		'client_secret',
+		'privatekey',
+		'private_key',
+		'secretkey',
+		'secret_key',
+		'authorization',
+		'authenticate',
+		'encryption',
+	);
 
 	/**
 	 * Format metric name to follow consistent naming conventions.
@@ -113,6 +102,108 @@ trait McpObservabilityHelperTrait {
 		$merged_tags  = array_merge( $default_tags, $tags );
 
 		return self::sanitize_tags( $merged_tags );
+	}
+
+	/**
+	 * Get default tags that should be included with all metrics.
+	 *
+	 * @return array
+	 */
+	public static function get_default_tags(): array {
+		return array(
+			'site_id'   => function_exists( 'get_current_blog_id' ) ? get_current_blog_id() : 0,
+			'user_id'   => function_exists( 'get_current_user_id' ) ? get_current_user_id() : 0,
+			'timestamp' => time(),
+		);
+	}
+
+	/**
+	 * Sanitize tags to ensure they are safe for logging and don't contain sensitive data.
+	 *
+	 * @param array $tags The tags to sanitize.
+	 *
+	 * @return array
+	 */
+	public static function sanitize_tags( array $tags ): array {
+		$sanitized = array();
+
+		foreach ( $tags as $key => $value ) {
+			// Convert key to string and limit length to prevent log bloat.
+			$key = substr( (string) $key, 0, 64 );
+
+			// Check if the key itself indicates sensitive data.
+			if ( self::is_sensitive_key( $key ) ) {
+				$sanitized[ $key ] = '[REDACTED]';
+				continue;
+			}
+
+			// Convert value to string, handling null specially.
+			if ( null === $value ) {
+				$value = '';
+			} elseif ( is_scalar( $value ) ) {
+				$value = (string) $value;
+			} else {
+				$value = wp_json_encode( $value );
+				// wp_json_encode can return false on failure, ensure we have a string.
+				if ( false === $value ) {
+					$value = '';
+				}
+			}
+
+			// Limit value length to prevent log bloat.
+			if ( strlen( $value ) > 1024 ) {
+				$value = substr( $value, 0, 1024 ) . '...[truncated]';
+			}
+
+			// Remove potentially sensitive information patterns from values.
+			$value = self::redact_sensitive_values( $value );
+
+			$sanitized[ $key ] = $value;
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Check if a key name indicates sensitive data.
+	 *
+	 * Matches patterns in camelCase, snake_case, and SCREAMING_CASE.
+	 *
+	 * @param string $key The key name to check.
+	 *
+	 * @return bool True if the key appears to contain sensitive data.
+	 */
+	public static function is_sensitive_key( string $key ): bool {
+		// Normalize: lowercase and remove underscores/hyphens for pattern matching.
+		$normalized = strtolower( str_replace( array( '_', '-' ), '', $key ) );
+
+		foreach ( self::$sensitive_patterns as $pattern ) {
+			// Remove underscores from pattern for normalized comparison.
+			$normalized_pattern = str_replace( '_', '', $pattern );
+
+			if ( str_contains( $normalized, $normalized_pattern ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Redact sensitive values from a string.
+	 *
+	 * Uses a more comprehensive pattern that catches compound words.
+	 *
+	 * @param string $value The value to redact.
+	 *
+	 * @return string The value with sensitive patterns redacted.
+	 */
+	public static function redact_sensitive_values( string $value ): string {
+		// Build a regex pattern that matches sensitive words as substrings.
+		// This catches camelCase (apiKey), snake_case (api_key), and standalone words.
+		$pattern = '/(?:' . implode( '|', array_map( 'preg_quote', self::$sensitive_patterns ) ) . ')/i';
+
+		return (string) preg_replace( $pattern, '[REDACTED]', $value );
 	}
 
 	/**

--- a/includes/Infrastructure/Observability/NullMcpObservabilityHandler.php
+++ b/includes/Infrastructure/Observability/NullMcpObservabilityHandler.php
@@ -24,8 +24,8 @@ class NullMcpObservabilityHandler implements Contracts\McpObservabilityHandlerIn
 	 *
 	 * This method does nothing and is used when no observability tracking is desired.
 	 *
-	 * @param string     $event The event name to record.
-	 * @param array      $tags Optional tags to attach to the event.
+	 * @param string $event The event name to record.
+	 * @param array $tags Optional tags to attach to the event.
 	 * @param float|null $duration_ms Optional duration in milliseconds for timing measurements.
 	 *
 	 * @return void

--- a/tests/Unit/ErrorHandlers/ErrorEnvelopeTest.php
+++ b/tests/Unit/ErrorHandlers/ErrorEnvelopeTest.php
@@ -6,16 +6,35 @@ namespace WP\MCP\Tests\Unit\ErrorHandlers;
 
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
 
+/**
+ * Tests for McpErrorFactory error envelope structure.
+ *
+ * Note: McpErrorFactory now returns typed DTOs (JSONRPCErrorResponse) instead of arrays.
+ * These tests verify that the DTOs contain the correct data and can be serialized properly.
+ */
 final class ErrorEnvelopeTest extends TestCase {
 
 	public function test_error_envelopes_have_consistent_shape(): void {
 		$err = McpErrorFactory::missing_parameter( 0, 'name' );
-		$this->assertArrayHasKey( 'jsonrpc', $err );
-		$this->assertSame( '2.0', $err['jsonrpc'] );
-		$this->assertArrayHasKey( 'error', $err );
-		$this->assertArrayHasKey( 'code', $err['error'] );
-		$this->assertArrayHasKey( 'message', $err['error'] );
+
+		// Verify it's a DTO
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+
+		// Verify DTO properties
+		$this->assertSame( '2.0', $err->getJsonrpc() );
+		$this->assertNotNull( $err->getError() );
+		$this->assertNotNull( $err->getError()->getCode() );
+		$this->assertNotNull( $err->getError()->getMessage() );
+
+		// Verify toArray() produces consistent structure
+		$arr = $err->toArray();
+		$this->assertArrayHasKey( 'jsonrpc', $arr );
+		$this->assertSame( '2.0', $arr['jsonrpc'] );
+		$this->assertArrayHasKey( 'error', $arr );
+		$this->assertArrayHasKey( 'code', $arr['error'] );
+		$this->assertArrayHasKey( 'message', $arr['error'] );
 	}
 
 	/**
@@ -25,81 +44,91 @@ final class ErrorEnvelopeTest extends TestCase {
 	public function test_missing_parameter_error(): void {
 		$err = McpErrorFactory::missing_parameter( 123, 'test_param' );
 
-		$this->assertSame( 123, $err['id'] );
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $err['error']['code'] );
-		$this->assertStringContainsString( 'test_param', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 123, $err->getId() );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'test_param', $err->getError()->getMessage() );
 	}
 
 	public function test_method_not_found_error(): void {
 		$err = McpErrorFactory::method_not_found( 456, 'test/method' );
 
-		$this->assertSame( 456, $err['id'] );
-		$this->assertSame( McpErrorFactory::METHOD_NOT_FOUND, $err['error']['code'] );
-		$this->assertStringContainsString( 'test/method', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 456, $err->getId() );
+		$this->assertSame( McpErrorFactory::METHOD_NOT_FOUND, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'test/method', $err->getError()->getMessage() );
 	}
 
 	public function test_internal_error(): void {
 		$err = McpErrorFactory::internal_error( 789, 'Something went wrong' );
 
-		$this->assertSame( 789, $err['id'] );
-		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $err['error']['code'] );
-		$this->assertStringContainsString( 'Something went wrong', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 789, $err->getId() );
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'Something went wrong', $err->getError()->getMessage() );
 	}
 
 	public function test_tool_not_found_error(): void {
 		$err = McpErrorFactory::tool_not_found( 101, 'missing-tool' );
 
-		$this->assertSame( 101, $err['id'] );
-		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $err['error']['code'] );
-		$this->assertStringContainsString( 'missing-tool', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 101, $err->getId() );
+		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'missing-tool', $err->getError()->getMessage() );
 	}
 
 	public function test_resource_not_found_error(): void {
 		$err = McpErrorFactory::resource_not_found( 102, 'missing-resource' );
 
-		$this->assertSame( 102, $err['id'] );
-		$this->assertSame( McpErrorFactory::RESOURCE_NOT_FOUND, $err['error']['code'] );
-		$this->assertStringContainsString( 'missing-resource', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 102, $err->getId() );
+		$this->assertSame( McpErrorFactory::RESOURCE_NOT_FOUND, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'missing-resource', $err->getError()->getMessage() );
 	}
 
 	public function test_prompt_not_found_error(): void {
 		$err = McpErrorFactory::prompt_not_found( 103, 'missing-prompt' );
 
-		$this->assertSame( 103, $err['id'] );
-		$this->assertSame( McpErrorFactory::PROMPT_NOT_FOUND, $err['error']['code'] );
-		$this->assertStringContainsString( 'missing-prompt', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 103, $err->getId() );
+		$this->assertSame( McpErrorFactory::PROMPT_NOT_FOUND, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'missing-prompt', $err->getError()->getMessage() );
 	}
 
 	public function test_permission_denied_error(): void {
 		$err = McpErrorFactory::permission_denied( 104, 'Access denied' );
 
-		$this->assertSame( 104, $err['id'] );
-		$this->assertSame( McpErrorFactory::PERMISSION_DENIED, $err['error']['code'] );
-		$this->assertStringContainsString( 'Access denied', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 104, $err->getId() );
+		$this->assertSame( McpErrorFactory::PERMISSION_DENIED, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'Access denied', $err->getError()->getMessage() );
 	}
 
 	public function test_unauthorized_error(): void {
 		$err = McpErrorFactory::unauthorized( 105, 'Not logged in' );
 
-		$this->assertSame( 105, $err['id'] );
-		$this->assertSame( McpErrorFactory::UNAUTHORIZED, $err['error']['code'] );
-		$this->assertStringContainsString( 'Not logged in', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 105, $err->getId() );
+		$this->assertSame( McpErrorFactory::UNAUTHORIZED, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'Not logged in', $err->getError()->getMessage() );
 	}
 
 	public function test_parse_error(): void {
 		$err = McpErrorFactory::parse_error( 106, 'Invalid JSON' );
 
-		$this->assertSame( 106, $err['id'] );
-		$this->assertSame( McpErrorFactory::PARSE_ERROR, $err['error']['code'] );
-		$this->assertStringContainsString( 'Invalid JSON', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 106, $err->getId() );
+		$this->assertSame( McpErrorFactory::PARSE_ERROR, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'Invalid JSON', $err->getError()->getMessage() );
 	}
 
 	public function test_invalid_request_error(): void {
 		$err = McpErrorFactory::invalid_request( 107, 'Missing field' );
 
-		$this->assertSame( 107, $err['id'] );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $err['error']['code'] );
-		$this->assertStringContainsString( 'Missing field', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 107, $err->getId() );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'Missing field', $err->getError()->getMessage() );
 	}
 
 	/**
@@ -109,9 +138,10 @@ final class ErrorEnvelopeTest extends TestCase {
 	public function test_invalid_params_error(): void {
 		$err = McpErrorFactory::invalid_params( 108, 'Wrong type' );
 
-		$this->assertSame( 108, $err['id'] );
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $err['error']['code'] );
-		$this->assertStringContainsString( 'Wrong type', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 108, $err->getId() );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'Wrong type', $err->getError()->getMessage() );
 	}
 
 	/**
@@ -121,9 +151,10 @@ final class ErrorEnvelopeTest extends TestCase {
 	public function test_mcp_disabled_error(): void {
 		$err = McpErrorFactory::mcp_disabled( 109 );
 
-		$this->assertSame( 109, $err['id'] );
-		$this->assertSame( McpErrorFactory::SERVER_ERROR, $err['error']['code'] );
-		$this->assertStringContainsString( 'disabled', $err['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
+		$this->assertSame( 109, $err->getId() );
+		$this->assertSame( McpErrorFactory::SERVER_ERROR, $err->getError()->getCode() );
+		$this->assertStringContainsString( 'disabled', $err->getError()->getMessage() );
 	}
 
 	public function test_jsonrpc_message_validation_valid(): void {
@@ -145,8 +176,9 @@ final class ErrorEnvelopeTest extends TestCase {
 		);
 
 		$result = McpErrorFactory::validate_jsonrpc_message( $invalid_message );
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'error', $result );
+		// Now returns a DTO on error, not an array
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertNotNull( $result->getError() );
 	}
 
 	public function test_jsonrpc_message_validation_missing_method(): void {
@@ -156,7 +188,8 @@ final class ErrorEnvelopeTest extends TestCase {
 		);
 
 		$result = McpErrorFactory::validate_jsonrpc_message( $invalid_message );
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'error', $result );
+		// Now returns a DTO on error, not an array
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertNotNull( $result->getError() );
 	}
 }

--- a/tests/Unit/ErrorHandling/ErrorResponseConsistencyTest.php
+++ b/tests/Unit/ErrorHandling/ErrorResponseConsistencyTest.php
@@ -12,6 +12,7 @@ use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
 
 final class ErrorResponseConsistencyTest extends TestCase {
 
@@ -38,10 +39,11 @@ final class ErrorResponseConsistencyTest extends TestCase {
 
 		$resources_handler = new ResourcesHandler( $this->server );
 
-		// Test parameter validation errors (INVALID_PARAMS) from all handlers
-		$tools_error     = $tools_handler->call_tool( array( 'params' => array() ) ); // Missing 'name'
-		$prompts_error   = $prompts_handler->get_prompt( array( 'params' => array() ) ); // Missing 'name'
-		$resources_error = $resources_handler->read_resource( array( 'params' => array() ) ); // Missing 'uri'
+		// Test parameter validation errors (INVALID_PARAMS) from all handlers.
+		// All handlers now return DTOs, convert to array for consistent testing.
+		$tools_error     = $tools_handler->call_tool( array( 'params' => array() ) )->toArray(); // Missing 'name'
+		$prompts_error   = $prompts_handler->get_prompt( array( 'params' => array() ) )->toArray(); // Missing 'name'
+		$resources_error = $resources_handler->read_resource( array( 'params' => array() ) )->toArray(); // Missing 'uri'
 
 		$errors = array( $tools_error, $prompts_error, $resources_error );
 
@@ -49,7 +51,8 @@ final class ErrorResponseConsistencyTest extends TestCase {
 			$this->assertArrayHasKey( 'error', $error );
 			$this->assertArrayHasKey( 'code', $error['error'] );
 			$this->assertArrayHasKey( 'message', $error['error'] );
-			$this->assertIsInt( $error['error']['code'] );
+			// Note: Error codes are now float (from DTOs) for JSON number compatibility.
+			$this->assertIsNumeric( $error['error']['code'] );
 			$this->assertIsString( $error['error']['message'] );
 		}
 	}
@@ -80,7 +83,8 @@ final class ErrorResponseConsistencyTest extends TestCase {
 			$this->assertArrayHasKey( 'error', $error );
 			$this->assertArrayHasKey( 'code', $error['error'] );
 			$this->assertArrayHasKey( 'message', $error['error'] );
-			$this->assertIsInt( $error['error']['code'] );
+			// Note: Error codes are now float (from DTOs) for JSON number compatibility
+			$this->assertIsNumeric( $error['error']['code'] );
 			$this->assertIsString( $error['error']['message'] );
 			$this->assertNotEmpty( $error['error']['message'] );
 		}
@@ -96,7 +100,8 @@ final class ErrorResponseConsistencyTest extends TestCase {
 
 		// Test parameter validation error from both factory and helper
 		// Note: missing_parameter() is a convenience wrapper that returns INVALID_PARAMS error code
-		$factory_error = McpErrorFactory::missing_parameter( 100, 'test_param' );
+		// Factory now returns a DTO, convert it to array for comparison
+		$factory_error = McpErrorFactory::missing_parameter( 100, 'test_param' )->toArray();
 		$helper_error  = $invalid_param_method->invoke( $tools_handler, 'test_param', 100 );
 
 		// Both should have the same structure
@@ -104,8 +109,8 @@ final class ErrorResponseConsistencyTest extends TestCase {
 		$this->assertArrayHasKey( 'error', $helper_error );
 
 		// Error codes should match (both use INVALID_PARAMS)
-		$this->assertSame( $factory_error['error']['code'], $helper_error['error']['code'] );
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $factory_error['error']['code'] );
+		$this->assertEquals( $factory_error['error']['code'], $helper_error['error']['code'] );
+		$this->assertEquals( (float) McpErrorFactory::INVALID_PARAMS, $factory_error['error']['code'] );
 
 		// Both should contain the parameter name
 		$this->assertStringContainsString( 'test_param', $factory_error['error']['message'] );
@@ -120,15 +125,17 @@ final class ErrorResponseConsistencyTest extends TestCase {
 		$extract_error_method = $reflection->getMethod( 'extract_error' );
 		$extract_error_method->setAccessible( true );
 
-		// Test with McpErrorFactory response
+		// Test with McpErrorFactory response (now returns DTO)
 		$factory_response = McpErrorFactory::tool_not_found( 200, 'test_tool' );
-		$extracted_error  = $extract_error_method->invoke( $tools_handler, $factory_response );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $factory_response );
+
+		$extracted_error = $extract_error_method->invoke( $tools_handler, $factory_response );
 
 		$this->assertArrayHasKey( 'code', $extracted_error );
 		$this->assertArrayHasKey( 'message', $extracted_error );
-		$this->assertSame( $factory_response['error'], $extracted_error );
+		$this->assertEquals( $factory_response->getError()->toArray(), $extracted_error );
 
-		// Test with plain error array
+		// Test with plain error array (backwards compatibility)
 		$plain_error     = array(
 			'code'    => 300,
 			'message' => 'Plain error',
@@ -143,10 +150,11 @@ final class ErrorResponseConsistencyTest extends TestCase {
 		$prompts_handler   = new PromptsHandler( $this->server );
 		$resources_handler = new ResourcesHandler( $this->server );
 
-		// Test "not found" errors from all handlers
-		$tool_not_found     = $tools_handler->call_tool( array( 'params' => array( 'name' => 'nonexistent_tool' ) ) );
-		$prompt_not_found   = $prompts_handler->get_prompt( array( 'params' => array( 'name' => 'nonexistent_prompt' ) ) );
-		$resource_not_found = $resources_handler->read_resource( array( 'params' => array( 'uri' => 'nonexistent://resource' ) ) );
+		// Test "not found" errors from all handlers.
+		// All handlers now return DTOs, convert to array for consistent testing.
+		$tool_not_found     = $tools_handler->call_tool( array( 'params' => array( 'name' => 'nonexistent_tool' ) ) )->toArray();
+		$prompt_not_found   = $prompts_handler->get_prompt( array( 'params' => array( 'name' => 'nonexistent_prompt' ) ) )->toArray();
+		$resource_not_found = $resources_handler->read_resource( array( 'params' => array( 'uri' => 'nonexistent://resource' ) ) )->toArray();
 
 		$errors = array( $tool_not_found, $prompt_not_found, $resource_not_found );
 
@@ -154,10 +162,11 @@ final class ErrorResponseConsistencyTest extends TestCase {
 			$this->assertArrayHasKey( 'error', $error );
 			$this->assertArrayHasKey( 'code', $error['error'] );
 			$this->assertArrayHasKey( 'message', $error['error'] );
-			$this->assertIsInt( $error['error']['code'] );
+			// Note: Error codes are now float (from DTOs) for JSON number compatibility.
+			$this->assertIsNumeric( $error['error']['code'] );
 			$this->assertIsString( $error['error']['message'] );
 
-			// All "not found" errors should have negative codes (MCP convention)
+			// All "not found" errors should have negative codes (MCP convention).
 			$this->assertLessThan( 0, $error['error']['code'] );
 		}
 	}
@@ -253,22 +262,23 @@ final class ErrorResponseConsistencyTest extends TestCase {
 		$prompts_handler   = new PromptsHandler( $this->server );
 		$resources_handler = new ResourcesHandler( $this->server );
 
-		// Test parameter validation error messages (INVALID_PARAMS error code)
+		// Test parameter validation error messages (INVALID_PARAMS error code).
+		// All handlers now return DTOs, convert to array for consistent testing.
 		$errors = array(
-			$tools_handler->call_tool( array( 'params' => array() ) ), // Missing name
-			$prompts_handler->get_prompt( array( 'params' => array() ) ), // Missing name
-			$resources_handler->read_resource( array( 'params' => array() ) ), // Missing uri
+			$tools_handler->call_tool( array( 'params' => array() ) )->toArray(), // Missing name
+			$prompts_handler->get_prompt( array( 'params' => array() ) )->toArray(), // Missing name
+			$resources_handler->read_resource( array( 'params' => array() ) )->toArray(), // Missing uri
 		);
 
 		foreach ( $errors as $error ) {
 			$message = $error['error']['message'];
 
-			// Error messages should be informative
+			// Error messages should be informative.
 			$this->assertNotEmpty( $message );
 			$this->assertGreaterThan( 10, strlen( $message ) ); // Not too short
 			$this->assertLessThan( 200, strlen( $message ) ); // Not too long
 
-			// Should mention what's missing or invalid
+			// Should mention what's missing or invalid.
 			$this->assertTrue(
 				strpos( $message, 'missing' ) !== false ||
 				strpos( $message, 'required' ) !== false ||

--- a/tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php
+++ b/tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php
@@ -6,232 +6,418 @@ namespace WP\MCP\Tests\Unit\Infrastructure\ErrorHandling;
 
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Common\JsonRpc\DTO\Error;
+use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
 
 final class McpErrorFactoryTest extends TestCase {
 
-	public function test_create_error_response_creates_valid_structure(): void {
+	/**
+	 * Test that create_error_response returns a JSONRPCErrorResponse DTO.
+	 */
+	public function test_create_error_response_returns_dto(): void {
 		$response = McpErrorFactory::create_error_response( 1, -32603, 'Test error' );
 
-		$this->assertArrayHasKey( 'jsonrpc', $response );
-		$this->assertSame( '2.0', $response['jsonrpc'] );
-		$this->assertArrayHasKey( 'id', $response );
-		$this->assertSame( 1, $response['id'] );
-		$this->assertArrayHasKey( 'error', $response );
-		$this->assertArrayHasKey( 'code', $response['error'] );
-		$this->assertArrayHasKey( 'message', $response['error'] );
-		$this->assertSame( -32603, $response['error']['code'] );
-		$this->assertSame( 'Test error', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( '2.0', $response->getJsonrpc() );
+		$this->assertSame( 1, $response->getId() );
+		$this->assertInstanceOf( Error::class, $response->getError() );
+		$this->assertSame( -32603, $response->getError()->getCode() );
+		$this->assertSame( 'Test error', $response->getError()->getMessage() );
 	}
 
+	/**
+	 * Test that create_error_response toArray produces valid structure.
+	 */
+	public function test_create_error_response_to_array_creates_valid_structure(): void {
+		$response = McpErrorFactory::create_error_response( 1, -32603, 'Test error' );
+		$array    = $response->toArray();
+
+		$this->assertArrayHasKey( 'jsonrpc', $array );
+		$this->assertSame( '2.0', $array['jsonrpc'] );
+		$this->assertArrayHasKey( 'id', $array );
+		$this->assertSame( 1, $array['id'] );
+		$this->assertArrayHasKey( 'error', $array );
+		$this->assertArrayHasKey( 'code', $array['error'] );
+		$this->assertArrayHasKey( 'message', $array['error'] );
+		$this->assertSame( -32603, $array['error']['code'] );
+		$this->assertSame( 'Test error', $array['error']['message'] );
+	}
+
+	/**
+	 * Test that create_error_response includes data when provided.
+	 */
 	public function test_create_error_response_includes_data_when_provided(): void {
 		$data     = array( 'key' => 'value' );
 		$response = McpErrorFactory::create_error_response( 1, -32603, 'Test error', $data );
 
-		$this->assertArrayHasKey( 'data', $response['error'] );
-		$this->assertSame( $data, $response['error']['data'] );
+		$this->assertSame( $data, $response->getError()->getData() );
+
+		$array = $response->toArray();
+		$this->assertArrayHasKey( 'data', $array['error'] );
+		$this->assertSame( $data, $array['error']['data'] );
 	}
 
+	/**
+	 * Test that create_error_response excludes data when null.
+	 */
 	public function test_create_error_response_excludes_data_when_null(): void {
 		$response = McpErrorFactory::create_error_response( 1, -32603, 'Test error', null );
 
-		$this->assertArrayNotHasKey( 'data', $response['error'] );
+		$this->assertNull( $response->getError()->getData() );
+
+		$array = $response->toArray();
+		$this->assertArrayNotHasKey( 'data', $array['error'] );
 	}
 
-	public function test_parse_error_creates_correct_error(): void {
+	/**
+	 * Test that create_error_response accepts string IDs.
+	 */
+	public function test_create_error_response_accepts_string_id(): void {
+		$response = McpErrorFactory::create_error_response( 'request-123', -32603, 'Test error' );
+
+		$this->assertSame( 'request-123', $response->getId() );
+	}
+
+	/**
+	 * Test that create_error_response accepts null IDs.
+	 */
+	public function test_create_error_response_accepts_null_id(): void {
+		$response = McpErrorFactory::create_error_response( null, -32603, 'Test error' );
+
+		$this->assertNull( $response->getId() );
+
+		$array = $response->toArray();
+		$this->assertArrayNotHasKey( 'id', $array );
+	}
+
+	/**
+	 * Test parse_error returns a DTO with correct error code.
+	 */
+	public function test_parse_error_returns_dto(): void {
 		$response = McpErrorFactory::parse_error( 1, 'Invalid JSON' );
 
-		$this->assertSame( McpErrorFactory::PARSE_ERROR, $response['error']['code'] );
-		$this->assertStringContainsString( 'Parse error', $response['error']['message'] );
-		$this->assertStringContainsString( 'Invalid JSON', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::PARSE_ERROR, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Parse error', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'Invalid JSON', $response->getError()->getMessage() );
 	}
 
+	/**
+	 * Test parse_error without details.
+	 */
 	public function test_parse_error_without_details(): void {
 		$response = McpErrorFactory::parse_error( 1 );
 
-		$this->assertSame( McpErrorFactory::PARSE_ERROR, $response['error']['code'] );
-		$this->assertStringContainsString( 'Parse error', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::PARSE_ERROR, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Parse error', $response->getError()->getMessage() );
 	}
 
-	public function test_invalid_request_creates_correct_error(): void {
+	/**
+	 * Test invalid_request returns a DTO with correct error code.
+	 */
+	public function test_invalid_request_returns_dto(): void {
 		$response = McpErrorFactory::invalid_request( 1, 'Missing method' );
 
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $response['error']['code'] );
-		$this->assertStringContainsString( 'Invalid Request', $response['error']['message'] );
-		$this->assertStringContainsString( 'Missing method', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Invalid Request', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'Missing method', $response->getError()->getMessage() );
 	}
 
-	public function test_method_not_found_creates_correct_error(): void {
+	/**
+	 * Test method_not_found returns a DTO with correct error code.
+	 */
+	public function test_method_not_found_returns_dto(): void {
 		$response = McpErrorFactory::method_not_found( 1, 'test/method' );
 
-		$this->assertSame( McpErrorFactory::METHOD_NOT_FOUND, $response['error']['code'] );
-		$this->assertStringContainsString( 'test/method', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::METHOD_NOT_FOUND, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'test/method', $response->getError()->getMessage() );
 	}
 
-	public function test_invalid_params_creates_correct_error(): void {
+	/**
+	 * Test invalid_params returns a DTO with correct error code.
+	 */
+	public function test_invalid_params_returns_dto(): void {
 		$response = McpErrorFactory::invalid_params( 1, 'Parameter validation failed' );
 
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response['error']['code'] );
-		$this->assertStringContainsString( 'Invalid params', $response['error']['message'] );
-		$this->assertStringContainsString( 'Parameter validation failed', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Invalid params', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'Parameter validation failed', $response->getError()->getMessage() );
 	}
 
-	public function test_internal_error_creates_correct_error(): void {
+	/**
+	 * Test internal_error returns a DTO with correct error code.
+	 */
+	public function test_internal_error_returns_dto(): void {
 		$response = McpErrorFactory::internal_error( 1, 'Database connection failed' );
 
-		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $response['error']['code'] );
-		$this->assertStringContainsString( 'Internal error', $response['error']['message'] );
-		$this->assertStringContainsString( 'Database connection failed', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Internal error', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'Database connection failed', $response->getError()->getMessage() );
 	}
 
-	public function test_mcp_disabled_creates_correct_error(): void {
+	/**
+	 * Test mcp_disabled returns a DTO with correct error code.
+	 */
+	public function test_mcp_disabled_returns_dto(): void {
 		$response = McpErrorFactory::mcp_disabled( 1 );
 
-		$this->assertSame( McpErrorFactory::SERVER_ERROR, $response['error']['code'] );
-		$this->assertStringContainsString( 'MCP functionality is currently disabled', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::SERVER_ERROR, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'MCP functionality is currently disabled', $response->getError()->getMessage() );
 	}
 
-	public function test_validation_error_creates_correct_error(): void {
+	/**
+	 * Test validation_error returns a DTO with correct error code.
+	 */
+	public function test_validation_error_returns_dto(): void {
 		$response = McpErrorFactory::validation_error( 1, 'Tool name is required' );
 
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response['error']['code'] );
-		$this->assertStringContainsString( 'Validation error', $response['error']['message'] );
-		$this->assertStringContainsString( 'Tool name is required', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Validation error', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'Tool name is required', $response->getError()->getMessage() );
 	}
 
-	public function test_missing_parameter_creates_correct_error(): void {
+	/**
+	 * Test missing_parameter returns a DTO with correct error code.
+	 */
+	public function test_missing_parameter_returns_dto(): void {
 		$response = McpErrorFactory::missing_parameter( 1, 'tool_name' );
 
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response['error']['code'] );
-		$this->assertStringContainsString( 'Missing required parameter', $response['error']['message'] );
-		$this->assertStringContainsString( 'tool_name', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Missing required parameter', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'tool_name', $response->getError()->getMessage() );
 	}
 
-	public function test_resource_not_found_creates_correct_error(): void {
+	/**
+	 * Test resource_not_found returns a DTO with correct error code.
+	 */
+	public function test_resource_not_found_returns_dto(): void {
 		$response = McpErrorFactory::resource_not_found( 1, 'mcp://resource/test' );
 
-		$this->assertSame( McpErrorFactory::RESOURCE_NOT_FOUND, $response['error']['code'] );
-		$this->assertStringContainsString( 'Resource not found', $response['error']['message'] );
-		$this->assertStringContainsString( 'mcp://resource/test', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::RESOURCE_NOT_FOUND, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Resource not found', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'mcp://resource/test', $response->getError()->getMessage() );
 	}
 
-	public function test_tool_not_found_creates_correct_error(): void {
+	/**
+	 * Test tool_not_found returns a DTO with correct error code.
+	 */
+	public function test_tool_not_found_returns_dto(): void {
 		$response = McpErrorFactory::tool_not_found( 1, 'test-tool' );
 
-		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $response['error']['code'] );
-		$this->assertStringContainsString( 'Tool not found', $response['error']['message'] );
-		$this->assertStringContainsString( 'test-tool', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Tool not found', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'test-tool', $response->getError()->getMessage() );
 	}
 
-	public function test_ability_not_found_creates_correct_error(): void {
+	/**
+	 * Test ability_not_found returns a DTO with correct error code.
+	 */
+	public function test_ability_not_found_returns_dto(): void {
 		$response = McpErrorFactory::ability_not_found( 1, 'test-ability' );
 
-		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $response['error']['code'] );
-		$this->assertStringContainsString( 'Ability not found', $response['error']['message'] );
-		$this->assertStringContainsString( 'test-ability', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Ability not found', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'test-ability', $response->getError()->getMessage() );
 	}
 
-	public function test_prompt_not_found_creates_correct_error(): void {
+	/**
+	 * Test prompt_not_found returns a DTO with correct error code.
+	 */
+	public function test_prompt_not_found_returns_dto(): void {
 		$response = McpErrorFactory::prompt_not_found( 1, 'test-prompt' );
 
-		$this->assertSame( McpErrorFactory::PROMPT_NOT_FOUND, $response['error']['code'] );
-		$this->assertStringContainsString( 'Prompt not found', $response['error']['message'] );
-		$this->assertStringContainsString( 'test-prompt', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::PROMPT_NOT_FOUND, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Prompt not found', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'test-prompt', $response->getError()->getMessage() );
 	}
 
-	public function test_permission_denied_creates_correct_error(): void {
+	/**
+	 * Test permission_denied returns a DTO with correct error code.
+	 */
+	public function test_permission_denied_returns_dto(): void {
 		$response = McpErrorFactory::permission_denied( 1, 'User lacks required capability' );
 
-		$this->assertSame( McpErrorFactory::PERMISSION_DENIED, $response['error']['code'] );
-		$this->assertStringContainsString( 'Permission denied', $response['error']['message'] );
-		$this->assertStringContainsString( 'User lacks required capability', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::PERMISSION_DENIED, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Permission denied', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'User lacks required capability', $response->getError()->getMessage() );
 	}
 
+	/**
+	 * Test permission_denied without details.
+	 */
 	public function test_permission_denied_without_details(): void {
 		$response = McpErrorFactory::permission_denied( 1 );
 
-		$this->assertSame( McpErrorFactory::PERMISSION_DENIED, $response['error']['code'] );
-		$this->assertStringContainsString( 'Permission denied', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::PERMISSION_DENIED, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Permission denied', $response->getError()->getMessage() );
 	}
 
-	public function test_unauthorized_creates_correct_error(): void {
+	/**
+	 * Test unauthorized returns a DTO with correct error code.
+	 */
+	public function test_unauthorized_returns_dto(): void {
 		$response = McpErrorFactory::unauthorized( 1, 'Authentication required' );
 
-		$this->assertSame( McpErrorFactory::UNAUTHORIZED, $response['error']['code'] );
-		$this->assertStringContainsString( 'Unauthorized', $response['error']['message'] );
-		$this->assertStringContainsString( 'Authentication required', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::UNAUTHORIZED, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Unauthorized', $response->getError()->getMessage() );
+		$this->assertStringContainsString( 'Authentication required', $response->getError()->getMessage() );
 	}
 
+	/**
+	 * Test unauthorized without details.
+	 */
 	public function test_unauthorized_without_details(): void {
 		$response = McpErrorFactory::unauthorized( 1 );
 
-		$this->assertSame( McpErrorFactory::UNAUTHORIZED, $response['error']['code'] );
-		$this->assertStringContainsString( 'Unauthorized', $response['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
+		$this->assertSame( McpErrorFactory::UNAUTHORIZED, $response->getError()->getCode() );
+		$this->assertStringContainsString( 'Unauthorized', $response->getError()->getMessage() );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with parse error.
+	 */
 	public function test_mcp_error_to_http_status_parse_error(): void {
 		$this->assertSame( 400, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::PARSE_ERROR ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with invalid request.
+	 */
 	public function test_mcp_error_to_http_status_invalid_request(): void {
 		$this->assertSame( 400, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::INVALID_REQUEST ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with unauthorized.
+	 */
 	public function test_mcp_error_to_http_status_unauthorized(): void {
 		$this->assertSame( 401, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::UNAUTHORIZED ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with permission denied.
+	 */
 	public function test_mcp_error_to_http_status_permission_denied(): void {
 		$this->assertSame( 403, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::PERMISSION_DENIED ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with resource not found.
+	 */
 	public function test_mcp_error_to_http_status_resource_not_found(): void {
 		$this->assertSame( 404, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::RESOURCE_NOT_FOUND ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with tool not found.
+	 */
 	public function test_mcp_error_to_http_status_tool_not_found(): void {
 		$this->assertSame( 404, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::TOOL_NOT_FOUND ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with prompt not found.
+	 */
 	public function test_mcp_error_to_http_status_prompt_not_found(): void {
 		$this->assertSame( 404, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::PROMPT_NOT_FOUND ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with method not found.
+	 */
 	public function test_mcp_error_to_http_status_method_not_found(): void {
 		$this->assertSame( 404, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::METHOD_NOT_FOUND ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with internal error.
+	 */
 	public function test_mcp_error_to_http_status_internal_error(): void {
 		$this->assertSame( 500, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::INTERNAL_ERROR ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with server error.
+	 */
 	public function test_mcp_error_to_http_status_server_error(): void {
 		$this->assertSame( 500, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::SERVER_ERROR ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with timeout error.
+	 */
 	public function test_mcp_error_to_http_status_timeout_error(): void {
 		$this->assertSame( 504, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::TIMEOUT_ERROR ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with invalid params returns 200.
+	 */
 	public function test_mcp_error_to_http_status_invalid_params_returns_200(): void {
 		$this->assertSame( 200, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::INVALID_PARAMS ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with unknown code returns 200.
+	 */
 	public function test_mcp_error_to_http_status_unknown_code_returns_200(): void {
 		$this->assertSame( 200, McpErrorFactory::mcp_error_to_http_status( -99999 ) );
 	}
 
+	/**
+	 * Test mcp_error_to_http_status with string code.
+	 */
 	public function test_mcp_error_to_http_status_string_code(): void {
 		// Test with string code (should default to 200)
 		$this->assertSame( 200, McpErrorFactory::mcp_error_to_http_status( 'invalid' ) );
 	}
 
-	public function test_get_http_status_for_error_with_valid_error_response(): void {
+	/**
+	 * Test get_http_status_for_error with a DTO.
+	 */
+	public function test_get_http_status_for_error_with_dto(): void {
 		$error_response = McpErrorFactory::parse_error( 1 );
 		$status         = McpErrorFactory::get_http_status_for_error( $error_response );
 
 		$this->assertSame( 400, $status );
 	}
 
+	/**
+	 * Test get_http_status_for_error with an array (legacy support).
+	 */
+	public function test_get_http_status_for_error_with_array(): void {
+		$error_response = array(
+			'jsonrpc' => '2.0',
+			'id'      => 1,
+			'error'   => array(
+				'code'    => McpErrorFactory::PARSE_ERROR,
+				'message' => 'Parse error',
+			),
+		);
+
+		$status = McpErrorFactory::get_http_status_for_error( $error_response );
+		$this->assertSame( 400, $status );
+	}
+
+	/**
+	 * Test get_http_status_for_error with missing code returns 500.
+	 */
 	public function test_get_http_status_for_error_with_missing_code_returns_500(): void {
 		$error_response = array(
 			'jsonrpc' => '2.0',
@@ -246,6 +432,9 @@ final class McpErrorFactoryTest extends TestCase {
 		$this->assertSame( 500, $status );
 	}
 
+	/**
+	 * Test get_http_status_for_error with missing error key returns 500.
+	 */
 	public function test_get_http_status_for_error_with_missing_error_key_returns_500(): void {
 		$error_response = array(
 			'jsonrpc' => '2.0',
@@ -257,6 +446,9 @@ final class McpErrorFactoryTest extends TestCase {
 		$this->assertSame( 500, $status );
 	}
 
+	/**
+	 * Test validate_jsonrpc_message with valid request.
+	 */
 	public function test_validate_jsonrpc_message_valid_request(): void {
 		$message = array(
 			'jsonrpc' => '2.0',
@@ -268,6 +460,9 @@ final class McpErrorFactoryTest extends TestCase {
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * Test validate_jsonrpc_message with valid notification.
+	 */
 	public function test_validate_jsonrpc_message_valid_notification(): void {
 		$message = array(
 			'jsonrpc' => '2.0',
@@ -279,6 +474,9 @@ final class McpErrorFactoryTest extends TestCase {
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * Test validate_jsonrpc_message with valid response.
+	 */
 	public function test_validate_jsonrpc_message_valid_response(): void {
 		$message = array(
 			'jsonrpc' => '2.0',
@@ -290,6 +488,9 @@ final class McpErrorFactoryTest extends TestCase {
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * Test validate_jsonrpc_message with valid error response.
+	 */
 	public function test_validate_jsonrpc_message_valid_error_response(): void {
 		$message = array(
 			'jsonrpc' => '2.0',
@@ -304,16 +505,21 @@ final class McpErrorFactoryTest extends TestCase {
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_jsonrpc_message_not_array(): void {
+	/**
+	 * Test validate_jsonrpc_message returns DTO for non-array.
+	 */
+	public function test_validate_jsonrpc_message_not_array_returns_dto(): void {
 		$result = McpErrorFactory::validate_jsonrpc_message( 'not an array' );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
-		$this->assertStringContainsString( 'JSON object', $result['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
+		$this->assertStringContainsString( 'JSON object', $result->getError()->getMessage() );
 	}
 
-	public function test_validate_jsonrpc_message_missing_jsonrpc_version(): void {
+	/**
+	 * Test validate_jsonrpc_message returns DTO for missing jsonrpc version.
+	 */
+	public function test_validate_jsonrpc_message_missing_jsonrpc_version_returns_dto(): void {
 		$message = array(
 			'method' => 'test/method',
 			'id'     => 1,
@@ -321,13 +527,15 @@ final class McpErrorFactoryTest extends TestCase {
 
 		$result = McpErrorFactory::validate_jsonrpc_message( $message );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
-		$this->assertStringContainsString( 'jsonrpc version', $result['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
+		$this->assertStringContainsString( 'jsonrpc version', $result->getError()->getMessage() );
 	}
 
-	public function test_validate_jsonrpc_message_wrong_jsonrpc_version(): void {
+	/**
+	 * Test validate_jsonrpc_message returns DTO for wrong jsonrpc version.
+	 */
+	public function test_validate_jsonrpc_message_wrong_jsonrpc_version_returns_dto(): void {
 		$message = array(
 			'jsonrpc' => '1.0',
 			'method'  => 'test/method',
@@ -336,12 +544,14 @@ final class McpErrorFactoryTest extends TestCase {
 
 		$result = McpErrorFactory::validate_jsonrpc_message( $message );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
 	}
 
-	public function test_validate_jsonrpc_message_missing_method_and_result_error(): void {
+	/**
+	 * Test validate_jsonrpc_message returns DTO for missing method and result/error.
+	 */
+	public function test_validate_jsonrpc_message_missing_method_and_result_error_returns_dto(): void {
 		$message = array(
 			'jsonrpc' => '2.0',
 			'id'      => 1,
@@ -350,13 +560,15 @@ final class McpErrorFactoryTest extends TestCase {
 
 		$result = McpErrorFactory::validate_jsonrpc_message( $message );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
-		$this->assertStringContainsString( 'method or result/error field', $result['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
+		$this->assertStringContainsString( 'method or result/error field', $result->getError()->getMessage() );
 	}
 
-	public function test_validate_jsonrpc_message_response_missing_id(): void {
+	/**
+	 * Test validate_jsonrpc_message returns DTO for response missing id.
+	 */
+	public function test_validate_jsonrpc_message_response_missing_id_returns_dto(): void {
 		$message = array(
 			'jsonrpc' => '2.0',
 			'result'  => array( 'success' => true ),
@@ -365,10 +577,115 @@ final class McpErrorFactoryTest extends TestCase {
 
 		$result = McpErrorFactory::validate_jsonrpc_message( $message );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
-		$this->assertStringContainsString( 'id field', $result['error']['message'] );
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
+		$this->assertStringContainsString( 'id field', $result->getError()->getMessage() );
+	}
+
+	/**
+	 * Test validate_jsonrpc_message returns null ID for non-array input.
+	 *
+	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
+	 */
+	public function test_validate_jsonrpc_message_not_array_returns_null_id(): void {
+		$result = McpErrorFactory::validate_jsonrpc_message( 'not an array' );
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertNull( $result->getId() );
+
+		$array = $result->toArray();
+		$this->assertArrayNotHasKey( 'id', $array );
+	}
+
+	/**
+	 * Test validate_jsonrpc_message returns null ID for missing jsonrpc version.
+	 *
+	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
+	 */
+	public function test_validate_jsonrpc_message_missing_version_returns_null_id(): void {
+		$message = array(
+			'method' => 'test/method',
+			'id'     => 1,
+		);
+
+		$result = McpErrorFactory::validate_jsonrpc_message( $message );
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertNull( $result->getId() );
+	}
+
+	/**
+	 * Test validate_jsonrpc_message returns null ID for wrong jsonrpc version.
+	 *
+	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
+	 */
+	public function test_validate_jsonrpc_message_wrong_version_returns_null_id(): void {
+		$message = array(
+			'jsonrpc' => '1.0',
+			'method'  => 'test/method',
+			'id'      => 1,
+		);
+
+		$result = McpErrorFactory::validate_jsonrpc_message( $message );
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertNull( $result->getId() );
+	}
+
+	/**
+	 * Test validate_jsonrpc_message returns null ID for missing method/result/error.
+	 *
+	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
+	 */
+	public function test_validate_jsonrpc_message_missing_method_returns_null_id(): void {
+		$message = array(
+			'jsonrpc' => '2.0',
+			'id'      => 1,
+		);
+
+		$result = McpErrorFactory::validate_jsonrpc_message( $message );
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertNull( $result->getId() );
+	}
+
+	/**
+	 * Test validate_jsonrpc_message returns null ID for response missing id.
+	 *
+	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
+	 */
+	public function test_validate_jsonrpc_message_response_missing_id_returns_null_id(): void {
+		$message = array(
+			'jsonrpc' => '2.0',
+			'result'  => array( 'success' => true ),
+		);
+
+		$result = McpErrorFactory::validate_jsonrpc_message( $message );
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertNull( $result->getId() );
+	}
+
+	/**
+	 * Test create_error helper method returns Error DTO.
+	 */
+	public function test_create_error_returns_dto(): void {
+		$error = McpErrorFactory::create_error( -32603, 'Test error' );
+
+		$this->assertInstanceOf( Error::class, $error );
+		$this->assertSame( -32603, $error->getCode() );
+		$this->assertSame( 'Test error', $error->getMessage() );
+		$this->assertNull( $error->getData() );
+	}
+
+	/**
+	 * Test create_error with data.
+	 */
+	public function test_create_error_with_data(): void {
+		$data  = array( 'key' => 'value' );
+		$error = McpErrorFactory::create_error( -32603, 'Test error', $data );
+
+		$this->assertInstanceOf( Error::class, $error );
+		$this->assertSame( $data, $error->getData() );
 	}
 }
-

--- a/tests/Unit/Infrastructure/Observability/FailureReasonTest.php
+++ b/tests/Unit/Infrastructure/Observability/FailureReasonTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Tests for FailureReason class.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Infrastructure\Observability;
+
+use WP\MCP\Infrastructure\Observability\FailureReason;
+use WP\MCP\Tests\TestCase;
+
+/**
+ * Test FailureReason taxonomy functionality.
+ */
+final class FailureReasonTest extends TestCase {
+
+	/**
+	 * Test that all() returns all defined constants.
+	 */
+	public function test_all_returns_all_constants(): void {
+		$all = FailureReason::all();
+
+		$this->assertIsArray( $all );
+		$this->assertNotEmpty( $all );
+
+		// Verify key constants are included.
+		$this->assertContains( FailureReason::ABILITY_NOT_FOUND, $all );
+		$this->assertContains( FailureReason::DUPLICATE_URI, $all );
+		$this->assertContains( FailureReason::BUILDER_EXCEPTION, $all );
+		$this->assertContains( FailureReason::NO_PERMISSION_STRATEGY, $all );
+		$this->assertContains( FailureReason::PERMISSION_DENIED, $all );
+		$this->assertContains( FailureReason::PERMISSION_CHECK_FAILED, $all );
+		$this->assertContains( FailureReason::NOT_FOUND, $all );
+		$this->assertContains( FailureReason::EXECUTION_FAILED, $all );
+	}
+
+	/**
+	 * Test that is_valid() returns true for valid values.
+	 */
+	public function test_is_valid_returns_true_for_valid_values(): void {
+		$this->assertTrue( FailureReason::is_valid( FailureReason::ABILITY_NOT_FOUND ) );
+		$this->assertTrue( FailureReason::is_valid( FailureReason::DUPLICATE_URI ) );
+		$this->assertTrue( FailureReason::is_valid( FailureReason::PERMISSION_DENIED ) );
+		$this->assertTrue( FailureReason::is_valid( 'not_found' ) );
+		$this->assertTrue( FailureReason::is_valid( 'execution_failed' ) );
+	}
+
+	/**
+	 * Test that is_valid() returns false for invalid values.
+	 */
+	public function test_is_valid_returns_false_for_invalid_values(): void {
+		$this->assertFalse( FailureReason::is_valid( 'unknown_reason' ) );
+		$this->assertFalse( FailureReason::is_valid( 'some_random_string' ) );
+		$this->assertFalse( FailureReason::is_valid( '' ) );
+		$this->assertFalse( FailureReason::is_valid( 'ABILITY_NOT_FOUND' ) ); // Case-sensitive.
+	}
+
+	/**
+	 * Test constant values are stable strings.
+	 */
+	public function test_constant_values_are_strings(): void {
+		$this->assertSame( 'ability_not_found', FailureReason::ABILITY_NOT_FOUND );
+		$this->assertSame( 'duplicate_uri', FailureReason::DUPLICATE_URI );
+		$this->assertSame( 'builder_exception', FailureReason::BUILDER_EXCEPTION );
+		$this->assertSame( 'no_permission_strategy', FailureReason::NO_PERMISSION_STRATEGY );
+		$this->assertSame( 'ability_conversion_failed', FailureReason::ABILITY_CONVERSION_FAILED );
+		$this->assertSame( 'permission_denied', FailureReason::PERMISSION_DENIED );
+		$this->assertSame( 'permission_check_failed', FailureReason::PERMISSION_CHECK_FAILED );
+		$this->assertSame( 'not_found', FailureReason::NOT_FOUND );
+		$this->assertSame( 'execution_failed', FailureReason::EXECUTION_FAILED );
+		$this->assertSame( 'execution_exception', FailureReason::EXECUTION_EXCEPTION );
+		$this->assertSame( 'missing_parameter', FailureReason::MISSING_PARAMETER );
+		$this->assertSame( 'invalid_parameter', FailureReason::INVALID_PARAMETER );
+	}
+
+	/**
+	 * Test all() returns unique values.
+	 */
+	public function test_all_values_are_unique(): void {
+		$all    = FailureReason::all();
+		$unique = array_unique( $all );
+
+		$this->assertCount( count( $all ), $unique, 'All failure reason values should be unique' );
+	}
+
+	/**
+	 * Test all() returns consistent count.
+	 */
+	public function test_all_returns_expected_count(): void {
+		// Currently 12 failure reasons defined.
+		$this->assertCount( 12, FailureReason::all() );
+	}
+}

--- a/tests/Unit/Infrastructure/Observability/McpObservabilityHelperTraitTest.php
+++ b/tests/Unit/Infrastructure/Observability/McpObservabilityHelperTraitTest.php
@@ -49,6 +49,14 @@ final class McpObservabilityHelperTraitTest extends TestCase {
 			public static function test_categorize_error( \Throwable $exception ): string {
 				return self::categorize_error( $exception );
 			}
+
+			public static function test_is_sensitive_key( string $key ): bool {
+				return self::is_sensitive_key( $key );
+			}
+
+			public static function test_redact_sensitive_values( string $value ): string {
+				return self::redact_sensitive_values( $value );
+			}
 		};
 	}
 
@@ -66,34 +74,51 @@ final class McpObservabilityHelperTraitTest extends TestCase {
 		$this->assertGreaterThan( 0, $tags['timestamp'] );
 	}
 
-	public function test_sanitize_tags_removes_sensitive_data(): void {
-		$tags_with_sensitive_data = array(
-			'username'      => 'testuser',
-			'user_password' => 'my password is secret',  // Contains 'password' as whole word
-			'bearer_token'  => 'token value here',        // Contains 'token' as whole word
-			'api_key'       => 'key is sensitive',        // Contains 'key' as whole word
-			'user_secret'   => 'secret data',             // Contains 'secret' as whole word
-			'normal_value'  => 'normal_data',             // Should not be redacted
+	public function test_sanitize_tags_redacts_sensitive_keys(): void {
+		// Keys that look sensitive should have their values fully redacted
+		$tags_with_sensitive_keys = array(
+			'username'    => 'testuser',           // Safe key
+			'api_key'     => 'abc123',             // Sensitive key - value should be [REDACTED]
+			'apiKey'      => 'xyz789',             // camelCase sensitive key
+			'API_KEY'     => 'DEF456',             // SCREAMING_CASE sensitive key
+			'authToken'   => 'my-token',           // Sensitive key
+			'normal_data' => 'safe_value',         // Safe key
 		);
 
-		$sanitized = $this->trait_user::test_sanitize_tags( $tags_with_sensitive_data );
+		$sanitized = $this->trait_user::test_sanitize_tags( $tags_with_sensitive_keys );
 
 		$this->assertIsArray( $sanitized );
 		$this->assertEquals( 'testuser', $sanitized['username'] );
-		$this->assertStringContainsString( '[REDACTED]', $sanitized['user_password'] );
-		$this->assertStringContainsString( '[REDACTED]', $sanitized['bearer_token'] );
-		$this->assertStringContainsString( '[REDACTED]', $sanitized['api_key'] );
-		$this->assertStringContainsString( '[REDACTED]', $sanitized['user_secret'] );
-		$this->assertEquals( 'normal_data', $sanitized['normal_value'] );
+		$this->assertEquals( '[REDACTED]', $sanitized['api_key'] );
+		$this->assertEquals( '[REDACTED]', $sanitized['apiKey'] );
+		$this->assertEquals( '[REDACTED]', $sanitized['API_KEY'] );
+		$this->assertEquals( '[REDACTED]', $sanitized['authToken'] );
+		$this->assertEquals( 'safe_value', $sanitized['normal_data'] );
 	}
 
-	public function test_sanitize_tags_limits_length(): void {
-		$tags_with_long_values = array(
-			'long_key_' . str_repeat( 'x', 100 ) => 'value',
-			'normal_key'                         => str_repeat( 'y', 200 ),
+	public function test_sanitize_tags_redacts_sensitive_values(): void {
+		// Values containing sensitive patterns should have those patterns redacted
+		$tags_with_sensitive_values = array(
+			'log_message' => 'User password was reset',           // Contains 'password'
+			'debug_info'  => 'Using bearer token for auth',       // Contains 'bearer' and 'token'
+			'safe_text'   => 'This is normal text',               // No sensitive patterns
 		);
 
-		$sanitized = $this->trait_user::test_sanitize_tags( $tags_with_long_values );
+		$sanitized = $this->trait_user::test_sanitize_tags( $tags_with_sensitive_values );
+
+		$this->assertIsArray( $sanitized );
+		$this->assertStringContainsString( '[REDACTED]', $sanitized['log_message'] );
+		$this->assertStringNotContainsString( 'password', $sanitized['log_message'] );
+		$this->assertStringContainsString( '[REDACTED]', $sanitized['debug_info'] );
+		$this->assertEquals( 'This is normal text', $sanitized['safe_text'] );
+	}
+
+	public function test_sanitize_tags_limits_key_length(): void {
+		$tags_with_long_key = array(
+			'long_key_' . str_repeat( 'x', 100 ) => 'value',
+		);
+
+		$sanitized = $this->trait_user::test_sanitize_tags( $tags_with_long_key );
 
 		$this->assertIsArray( $sanitized );
 
@@ -103,9 +128,19 @@ final class McpObservabilityHelperTraitTest extends TestCase {
 			$this->assertLessThanOrEqual( 64, strlen( $key ) );
 		}
 
-		// Values are not truncated, they maintain their full length
-		$this->assertEquals( 'value', $sanitized[ 'long_key_' . str_repeat( 'x', 55 ) ] ); // First 64 chars of key
-		$this->assertEquals( 200, strlen( $sanitized['normal_key'] ) ); // Value is not truncated
+		$this->assertEquals( 'value', $sanitized[ 'long_key_' . str_repeat( 'x', 55 ) ] );
+	}
+
+	public function test_sanitize_tags_truncates_long_values(): void {
+		$long_value = str_repeat( 'y', 2000 );
+		$tags       = array( 'data' => $long_value );
+
+		$sanitized = $this->trait_user::test_sanitize_tags( $tags );
+
+		$this->assertIsArray( $sanitized );
+		// Value should be truncated to 1024 chars + truncation marker
+		$this->assertStringContainsString( '...[truncated]', $sanitized['data'] );
+		$this->assertLessThan( 2000, strlen( $sanitized['data'] ) );
 	}
 
 	public function test_format_metric_name_adds_mcp_prefix(): void {


### PR DESCRIPTION
## Summary

Updates the Infrastructure layer (error handling and observability) to use php-mcp-schema DTOs for JSON-RPC error responses.

## Changes

### Error Handling
- `McpErrorHandlerInterface` — Updated contract
- `McpErrorFactory` — Now produces `JSONRPCErrorResponse` DTOs
- `ErrorLogMcpErrorHandler` — Updated implementation
- `NullMcpErrorHandler` — Updated implementation

### Observability
- `McpObservabilityHandlerInterface` — Updated contract
- `FailureReason` — New enum for structured failure tracking
- `McpObservabilityHelperTrait` — Updated helper methods
- Handler implementations updated

### Tests
- Updated unit tests for error factory
- Added `FailureReasonTest`
- Updated observability trait tests

## Why

- Replaces manual error array construction with type-safe DTOs
- Ensures JSON-RPC 2.0 compliance through schema validation
- Improves error consistency across the codebase

## Stacked PR

⚠️ **This is PR 2 of 6** in the MCP Schema integration series.

| # | Branch | Description |
|---|--------|-------------|
| 1 | `01-composer-deps` | Composer dependency |
| **2** | **`02-infrastructure`** | **← You are here** |
| 3 | `03-domain-utils` | Domain contracts + utilities |
| 4 | `04-domain-components` | Tools, Resources, Prompts |
| 5 | `05-core` | Core + abilities + plugin |
| 6 | `06-handlers-transport` | Handlers + Transport + CLI |

**Merge order**: 1 → 2 → 3 → 4 → 5 → 6

## Testing

- [ ] Unit tests pass for error handling
- [ ] Unit tests pass for observability