### PR TITLE
[3/6] Add domain contracts and utility classes for MCP components

### DIFF
--- a/includes/Domain/Contracts/McpComponentInterface.php
+++ b/includes/Domain/Contracts/McpComponentInterface.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Contract for MCP component classes (tools, resources, prompts).
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Domain\Contracts;
+
+use WP\McpSchema\Common\AbstractDataTransferObject;
+
+/**
+ * Interface McpComponentInterface.
+ *
+ * Classes implementing this interface encapsulate:
+ * - a clean protocol DTO (Tool/Resource/Prompt) that is safe to expose to MCP clients, and
+ * - MCP Adapter internal metadata and execution wiring (ability-backed OR direct-callable).
+ *
+ * This keeps protocol DTOs free of internal adapter fields, while still
+ * providing a uniform execution and permission-check surface for handlers.
+ *
+ * @internal
+ *
+ * @since n.e.x.t
+ */
+interface McpComponentInterface {
+
+	/**
+	 * Get the clean protocol DTO for MCP responses.
+	 *
+	 * @return \WP\McpSchema\Common\AbstractDataTransferObject Protocol-only DTO.
+	 * @since n.e.x.t
+	 *
+	 */
+	public function get_component(): AbstractDataTransferObject;
+
+	/**
+	 * Execute the component using the configured strategy.
+	 *
+	 * Implementations MUST execute via either:
+	 * - an attached WordPress ability, or
+	 * - a direct callable handler (for non-ability registrations).
+	 *
+	 * @param mixed $arguments Component arguments (typically an associative array).
+	 *
+	 * @return mixed Execution result.
+	 * @since n.e.x.t
+	 *
+	 */
+	public function execute( $arguments );
+
+	/**
+	 * Check whether execution is permitted for the current request.
+	 *
+	 * Implementations MUST check permissions via either:
+	 * - the attached WordPress ability, or
+	 * - a direct permission callback (for non-ability registrations).
+	 *
+	 * @param mixed $arguments Component arguments (typically an associative array).
+	 *
+	 * @return bool|\WP_Error True when permitted, false or WP_Error otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	public function check_permission( $arguments );
+
+	/**
+	 * Get MCP Adapter internal metadata for this component.
+	 *
+	 * This metadata MUST NOT be stored on protocol DTOs and MUST NOT be exposed to MCP clients.
+	 *
+	 * @return array<string, mixed> Internal metadata.
+	 * @since n.e.x.t
+	 *
+	 */
+	public function get_adapter_meta(): array;
+
+	/**
+	 * Get observability context tags for logging/metrics.
+	 *
+	 * This replaces legacy approaches that derived observability tags from DTO `_meta`.
+	 *
+	 * @return array<string, mixed> Observability tags (component_type, source, etc.).
+	 * @since n.e.x.t
+	 *
+	 */
+	public function get_observability_context(): array;
+}

--- a/includes/Domain/Prompts/Contracts/McpPromptBuilderInterface.php
+++ b/includes/Domain/Prompts/Contracts/McpPromptBuilderInterface.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Prompts\Contracts;
 
-use WP\MCP\Domain\Prompts\McpPrompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
 
 /**
  * Interface for building MCP prompts.
@@ -20,11 +20,11 @@ use WP\MCP\Domain\Prompts\McpPrompt;
 interface McpPromptBuilderInterface {
 
 	/**
-	 * Build and return the MCP prompt instance.
+	 * Build and return the Prompt DTO instance.
 	 *
-	 * @return \WP\MCP\Domain\Prompts\McpPrompt The built prompt.
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt The built prompt DTO.
 	 */
-	public function build(): McpPrompt;
+	public function build(): Prompt;
 
 	/**
 	 * Get the unique name for this prompt.

--- a/includes/Domain/Utils/AbilityArgumentNormalizer.php
+++ b/includes/Domain/Utils/AbilityArgumentNormalizer.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Normalizes ability arguments for MCP protocol compatibility.
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Domain\Utils;
+
+/**
+ * Normalizes ability arguments between MCP and WordPress Abilities API.
+ *
+ * MCP clients send {} (empty object) for tools without arguments.
+ * PHP decodes this as [] (empty array).
+ * Abilities without input_schema expect null, not empty array.
+ *
+ * @since n.e.x.t
+ */
+class AbilityArgumentNormalizer {
+
+	/**
+	 * Normalize parameters for an ability based on its input schema.
+	 *
+	 * If the ability has no input schema, empty arrays are converted to null.
+	 * This ensures compatibility with abilities that don't accept parameters.
+	 *
+	 * @param \WP_Ability $ability The ability to normalize parameters for.
+	 * @param mixed $parameters The parameters to normalize.
+	 *
+	 * @return mixed Normalized parameters (null if ability has no schema and params are empty).
+	 * @since n.e.x.t
+	 *
+	 */
+	public static function normalize( \WP_Ability $ability, $parameters ) {
+		$input_schema = $ability->get_input_schema();
+
+		if ( empty( $input_schema ) && is_array( $parameters ) && empty( $parameters ) ) {
+			return null;
+		}
+
+		return $parameters;
+	}
+}

--- a/includes/Domain/Utils/ContentBlockHelper.php
+++ b/includes/Domain/Utils/ContentBlockHelper.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * ContentBlockHelper - Factory for creating MCP content block DTOs.
+ *
+ * This helper provides convenience methods for constructing typed content block DTOs
+ * from the php-mcp-schema library. It simplifies the creation of TextContent,
+ * ImageContent, AudioContent, and EmbeddedResource instances.
+ *
+ * @package WP\MCP\Domain\Utils
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Domain\Utils;
+
+use WP\McpSchema\Common\Content\DTO\AudioContent;
+use WP\McpSchema\Common\Content\DTO\ImageContent;
+use WP\McpSchema\Common\Content\DTO\TextContent;
+use WP\McpSchema\Common\Protocol\DTO\Annotations;
+use WP\McpSchema\Common\Protocol\DTO\BlobResourceContents;
+use WP\McpSchema\Common\Protocol\DTO\EmbeddedResource;
+use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
+use WP\McpSchema\Common\Protocol\Union\ContentBlockInterface;
+
+/**
+ * Helper class for creating MCP content block DTOs.
+ *
+ * Provides static factory methods to create typed content blocks that implement
+ * ContentBlockInterface. These DTOs are used in tool call results, prompt messages,
+ * and resource contents throughout the MCP protocol.
+ *
+ * @since n.e.x.t
+ */
+final class ContentBlockHelper {
+
+	/**
+	 * Creates an ImageContent DTO.
+	 *
+	 * @param string $data Base64-encoded image data.
+	 * @param string $mime_type The MIME type of the image (e.g., 'image/png').
+	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
+	 * @param array|null $_meta Optional metadata.
+	 *
+	 * @return \WP\McpSchema\Common\Content\DTO\ImageContent The created ImageContent DTO.
+	 */
+	public static function image( string $data, string $mime_type, ?Annotations $annotations = null, ?array $_meta = null ): ImageContent {
+		return ImageContent::fromArray(
+			array(
+				'type'        => ImageContent::TYPE,
+				'data'        => $data,
+				'mimeType'    => $mime_type,
+				'annotations' => $annotations,
+				'_meta'       => $_meta,
+			)
+		);
+	}
+
+	/**
+	 * Creates an AudioContent DTO.
+	 *
+	 * @param string $data Base64-encoded audio data.
+	 * @param string $mime_type The MIME type of the audio (e.g., 'audio/mp3').
+	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
+	 * @param array|null $_meta Optional metadata.
+	 *
+	 * @return \WP\McpSchema\Common\Content\DTO\AudioContent The created AudioContent DTO.
+	 */
+	public static function audio( string $data, string $mime_type, ?Annotations $annotations = null, ?array $_meta = null ): AudioContent {
+		return AudioContent::fromArray(
+			array(
+				'type'        => AudioContent::TYPE,
+				'data'        => $data,
+				'mimeType'    => $mime_type,
+				'annotations' => $annotations,
+				'_meta'       => $_meta,
+			)
+		);
+	}
+
+	/**
+	 * Creates an EmbeddedResource DTO with TextResourceContents.
+	 *
+	 * Use this for embedding text-based resources (files, documents, etc.) in content.
+	 *
+	 * @param string $uri The URI of the resource.
+	 * @param string $text The text content of the resource.
+	 * @param string|null $mime_type Optional MIME type of the resource.
+	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
+	 * @param array|null $_meta Optional metadata.
+	 *
+	 * @return \WP\McpSchema\Common\Protocol\DTO\EmbeddedResource The created EmbeddedResource DTO.
+	 */
+	public static function embedded_text_resource(
+		string $uri,
+		string $text,
+		?string $mime_type = null,
+		?Annotations $annotations = null,
+		?array $_meta = null
+	): EmbeddedResource {
+		$resource = TextResourceContents::fromArray(
+			array(
+				'uri'      => $uri,
+				'text'     => $text,
+				'mimeType' => $mime_type,
+			)
+		);
+
+		return EmbeddedResource::fromArray(
+			array(
+				'type'        => EmbeddedResource::TYPE,
+				'resource'    => $resource,
+				'annotations' => $annotations,
+				'_meta'       => $_meta,
+			)
+		);
+	}
+
+	/**
+	 * Creates an EmbeddedResource DTO with BlobResourceContents.
+	 *
+	 * Use this for embedding binary resources (images, PDFs, etc.) in content.
+	 *
+	 * @param string $uri The URI of the resource.
+	 * @param string $blob Base64-encoded binary data.
+	 * @param string|null $mime_type Optional MIME type of the resource.
+	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
+	 * @param array|null $_meta Optional metadata.
+	 *
+	 * @return \WP\McpSchema\Common\Protocol\DTO\EmbeddedResource The created EmbeddedResource DTO.
+	 */
+	public static function embedded_blob_resource(
+		string $uri,
+		string $blob,
+		?string $mime_type = null,
+		?Annotations $annotations = null,
+		?array $_meta = null
+	): EmbeddedResource {
+		$resource = BlobResourceContents::fromArray(
+			array(
+				'uri'      => $uri,
+				'blob'     => $blob,
+				'mimeType' => $mime_type,
+			)
+		);
+
+		return EmbeddedResource::fromArray(
+			array(
+				'type'        => EmbeddedResource::TYPE,
+				'resource'    => $resource,
+				'annotations' => $annotations,
+				'_meta'       => $_meta,
+			)
+		);
+	}
+
+	/**
+	 * Creates a TextContent DTO for error messages.
+	 *
+	 * Convenience method for creating text content specifically for error responses.
+	 * This is semantically equivalent to text() but makes the intent clearer in code.
+	 *
+	 * @param string $message The error message.
+	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
+	 * @param array|null $_meta Optional metadata.
+	 *
+	 * @return \WP\McpSchema\Common\Content\DTO\TextContent The created TextContent DTO.
+	 */
+	public static function error_text( string $message, ?Annotations $annotations = null, ?array $_meta = null ): TextContent {
+		return self::text( $message, $annotations, $_meta );
+	}
+
+	/**
+	 * Creates a TextContent DTO.
+	 *
+	 * @param string $text The text content.
+	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
+	 * @param array|null $_meta Optional metadata.
+	 *
+	 * @return \WP\McpSchema\Common\Content\DTO\TextContent The created TextContent DTO.
+	 */
+	public static function text( string $text, ?Annotations $annotations = null, ?array $_meta = null ): TextContent {
+		return TextContent::fromArray(
+			array(
+				'type'        => TextContent::TYPE,
+				'text'        => $text,
+				'annotations' => $annotations,
+				'_meta'       => $_meta,
+			)
+		);
+	}
+
+	/**
+	 * Creates a TextContent DTO with JSON-encoded data.
+	 *
+	 * Convenience method for creating text content from structured data.
+	 * The data is encoded as JSON and wrapped in a TextContent DTO.
+	 *
+	 * @param mixed $data The data to JSON-encode.
+	 * @param int $flags JSON encoding flags (default: 0).
+	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
+	 * @param array|null $_meta Optional metadata.
+	 *
+	 * @return \WP\McpSchema\Common\Content\DTO\TextContent The created TextContent DTO.
+	 */
+	public static function json_text( $data, int $flags = 0, ?Annotations $annotations = null, ?array $_meta = null ): TextContent {
+		$json = wp_json_encode( $data, $flags );
+		if ( false === $json ) {
+			$json = '{}';
+		}
+
+		return self::text( $json, $annotations, $_meta );
+	}
+
+	/**
+	 * Converts an array of ContentBlockInterface DTOs to their array representations.
+	 *
+	 * Use this at the serialization boundary when preparing content blocks for JSON output.
+	 *
+	 * @param \WP\McpSchema\Common\Protocol\Union\ContentBlockInterface[] $blocks Array of content block DTOs.
+	 *
+	 * @return array[] Array of content block arrays.
+	 */
+	public static function to_array_list( array $blocks ): array {
+		return array_map(
+			static function ( ContentBlockInterface $block ): array {
+				return $block->toArray();
+			},
+			$blocks
+		);
+	}
+}

--- a/includes/Domain/Utils/McpAnnotationMapper.php
+++ b/includes/Domain/Utils/McpAnnotationMapper.php
@@ -26,28 +26,36 @@ class McpAnnotationMapper {
 	 *
 	 * Structure:
 	 * - type: The data type (boolean, string, array, number)
-	 * - features: Array of MCP features where this annotation is used (tool, resource, prompt)
+	 * - features: Array of MCP features where this annotation is used (tool, resource)
 	 * - ability_property: The WordPress Ability API property name (may differ from MCP field name), or null if mapping 1:1
+	 *
+	 * Note: Per MCP 2025-11-25 spec:
+	 * - Tools use ToolAnnotations (title, *Hint fields only)
+	 * - Resources use shared Annotations (audience, priority, lastModified)
+	 * - Prompts do NOT support annotations at template level (only on message content blocks)
 	 *
 	 * @var array<string, array{type: string, features: array<string>, ability_property: string|null}>
 	 */
 	private static array $mcp_annotations = array(
-		// Shared annotations (all features) - in annotations object.
+		// Shared annotations - Resources only (NOT Tools or Prompt templates per MCP spec).
+		// ToolAnnotations is a separate type that does not include these fields.
+		// Prompt templates do not support annotations; only content blocks inside messages do.
 		'audience'        => array(
 			'type'             => 'array',
-			'features'         => array( 'tool', 'resource', 'prompt' ),
+			'features'         => array( 'resource' ),
 			'ability_property' => null,
 		),
 		'lastModified'    => array(
 			'type'             => 'string',
-			'features'         => array( 'tool', 'resource', 'prompt' ),
+			'features'         => array( 'resource' ),
 			'ability_property' => null,
 		),
 		'priority'        => array(
 			'type'             => 'number',
-			'features'         => array( 'tool', 'resource', 'prompt' ),
+			'features'         => array( 'resource' ),
 			'ability_property' => null,
 		),
+		// Tool-specific annotations (ToolAnnotations type per MCP 2025-11-25 spec).
 		'readOnlyHint'    => array(
 			'type'             => 'boolean',
 			'features'         => array( 'tool' ),
@@ -82,8 +90,8 @@ class McpAnnotationMapper {
 	 * Only includes annotations applicable to the specified feature type.
 	 * Null values are excluded from the result.
 	 *
-	 * @param array  $ability_annotations WordPress ability annotations.
-	 * @param string $feature_type        The MCP feature type ('tool', 'resource', or 'prompt').
+	 * @param array $ability_annotations WordPress ability annotations.
+	 * @param string $feature_type The MCP feature type ('tool', 'resource', or 'prompt').
 	 *
 	 * @return array Mapped annotations for the specified feature type.
 	 */
@@ -119,8 +127,8 @@ class McpAnnotationMapper {
 	/**
 	 * Resolve the annotation value, preferring WordPress-format overrides when available.
 	 *
-	 * @param array       $annotations     Raw annotations from the ability.
-	 * @param string      $mcp_field       The MCP field name.
+	 * @param array $annotations Raw annotations from the ability.
+	 * @param string $mcp_field The MCP field name.
 	 * @param string|null $ability_property Optional WordPress-format field name, or null if mapping 1:1.
 	 *
 	 * @return mixed The annotation value, or null if not found.
@@ -142,20 +150,21 @@ class McpAnnotationMapper {
 	 * Normalize annotation values to the types expected by MCP.
 	 *
 	 * @param string $field_type Expected MCP type (boolean, string, array, number).
-	 * @param mixed  $value      Raw annotation value.
+	 * @param mixed $value Raw annotation value.
 	 *
 	 * @return mixed|null Normalized value or null if invalid.
 	 */
 	private static function normalize_annotation_value( string $field_type, $value ) {
 		switch ( $field_type ) {
 			case 'boolean':
-				return (bool) $value;
+				return self::normalize_boolean( $value );
 
 			case 'string':
 				if ( ! is_scalar( $value ) ) {
 					return null;
 				}
 				$trimmed = trim( (string) $value );
+
 				return '' === $trimmed ? null : $trimmed;
 
 			case 'array':
@@ -167,5 +176,57 @@ class McpAnnotationMapper {
 			default:
 				return $value;
 		}
+	}
+
+	/**
+	 * Normalize a value to a strict boolean.
+	 *
+	 * Accepts only well-defined boolean representations to avoid ambiguous conversions.
+	 * PHP's default (bool) cast incorrectly converts 'false' string to true.
+	 *
+	 * Accepted values:
+	 * - true, false (PHP booleans)
+	 * - 1, 0 (integers)
+	 * - '1', '0', 'true', 'false' (case-insensitive strings)
+	 *
+	 * @param mixed $value The value to normalize.
+	 *
+	 * @return bool|null The normalized boolean, or null if value cannot be safely converted.
+	 */
+	private static function normalize_boolean( $value ): ?bool {
+		// Already a boolean - return as-is.
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+
+		// Integer 1 or 0.
+		if ( is_int( $value ) ) {
+			if ( 1 === $value ) {
+				return true;
+			}
+			if ( 0 === $value ) {
+				return false;
+			}
+
+			// Other integers are invalid (e.g., 2, -1).
+			return null;
+		}
+
+		// String representations (case-insensitive).
+		if ( is_string( $value ) ) {
+			$lower = strtolower( trim( $value ) );
+			if ( 'true' === $lower || '1' === $lower ) {
+				return true;
+			}
+			if ( 'false' === $lower || '0' === $lower ) {
+				return false;
+			}
+
+			// Other strings are invalid (e.g., 'yes', 'no', empty string).
+			return null;
+		}
+
+		// All other types (arrays, objects, floats, null) are invalid.
+		return null;
 	}
 }

--- a/includes/Domain/Utils/McpNameSanitizer.php
+++ b/includes/Domain/Utils/McpNameSanitizer.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * MCP Name Sanitizer utility for normalizing component names.
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Domain\Utils;
+
+/**
+ * Utility class for sanitizing names to MCP-valid format.
+ *
+ * Implements best-effort sanitization per MCP 2025-11-25 spec:
+ * - Length: 1-128 characters
+ * - Charset: A-Za-z0-9_.-
+ *
+ * Used for both tools and prompts (same naming rules).
+ * NOT used for resources (which use URIs as identifiers).
+ *
+ * @since n.e.x.t
+ */
+class McpNameSanitizer {
+
+	/**
+	 * Maximum length for MCP tool/prompt names per spec.
+	 *
+	 * @var int
+	 */
+	public const MAX_LENGTH = 128;
+
+	/**
+	 * Length of the hash suffix used for truncation uniqueness.
+	 *
+	 * @var int
+	 */
+	public const HASH_LENGTH = 12;
+
+	/**
+	 * Maximum characters to keep when truncating (MAX_LENGTH - 1 separator - HASH_LENGTH).
+	 *
+	 * @var int
+	 */
+	public const TRUNCATE_LENGTH = 115;
+
+	/**
+	 * Sanitize a name to be MCP-valid for tools and prompts.
+	 *
+	 * Normalization steps:
+	 * 1. Trim whitespace
+	 * 2. Replace `/` with `-` (forward slash not allowed in MCP)
+	 * 3. If valid, return as-is
+	 * 4. Otherwise: transliterate accents, replace invalid chars, collapse hyphens, trim edges
+	 * 5. If too long: truncate + add hash suffix for uniqueness
+	 * 6. If still invalid/empty: return WP_Error
+	 *
+	 * @param string $name Original name.
+	 *
+	 * @return string|\WP_Error Sanitized name or WP_Error if unsalvageable.
+	 * @since n.e.x.t
+	 *
+	 */
+	public static function sanitize_name( string $name ) {
+		$original = $name;
+
+		// Step 1: Trim whitespace.
+		$name = trim( $name );
+
+		// Step 2: Replace / with - (forward slash not allowed in MCP).
+		$name = str_replace( '/', '-', $name );
+
+		// Step 3: Early validation - if already valid, return as-is.
+		if ( McpValidator::validate_name( $name ) ) {
+			return $name;
+		}
+
+		// Step 4a: Transliterate accented characters to ASCII equivalents.
+		// Uses WordPress core function: é→e, ü→u, ñ→n, etc.
+		$name = remove_accents( $name );
+
+		// Step 4b: Replace any remaining non-allowed chars with hyphen.
+		$name = (string) preg_replace( '/[^a-zA-Z0-9_.-]/', '-', $name );
+
+		// Step 4c: Collapse consecutive hyphens.
+		$name = (string) preg_replace( '/-+/', '-', $name );
+
+		// Step 4d: Trim leading/trailing hyphens and underscores.
+		$name = trim( $name, '-_' );
+
+		// Step 5: Handle length > 128.
+		if ( strlen( $name ) > self::MAX_LENGTH ) {
+			$hash = substr( md5( $original ), 0, self::HASH_LENGTH );
+			$name = substr( $name, 0, self::TRUNCATE_LENGTH ) . '-' . $hash;
+		}
+
+		// Step 6: Final check - only empty is possible failure after sanitization.
+		// Characters are guaranteed valid (replaced), length is handled (truncated).
+		if ( empty( $name ) ) {
+			return new \WP_Error(
+				'mcp_name_invalid',
+				sprintf(
+				/* translators: %s: original ability name */
+					__( 'Unable to derive valid MCP name from: %s', 'mcp-adapter' ),
+					$original
+				)
+			);
+		}
+
+		return $name;
+	}
+}

--- a/includes/Domain/Utils/McpValidator.php
+++ b/includes/Domain/Utils/McpValidator.php
@@ -490,7 +490,6 @@ class McpValidator {
 		return $priority_float >= 0.0 && $priority_float <= 1.0;
 	}
 
-
 	/**
 	 * Validate a resource URI format.
 	 *

--- a/includes/Domain/Utils/McpValidator.php
+++ b/includes/Domain/Utils/McpValidator.php
@@ -20,7 +20,6 @@ use DateTime;
  */
 class McpValidator {
 
-
 	/**
 	 * Allowed MIME types for MCP icons per specification.
 	 *

--- a/includes/Domain/Utils/McpValidator.php
+++ b/includes/Domain/Utils/McpValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * MCP Validator utility class for validating MCP component data.
  *
@@ -9,6 +10,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Utils;
 
+use DateTime;
+
 /**
  * Utility class for validating MCP component data according to MCP specification.
  *
@@ -17,57 +20,43 @@ namespace WP\MCP\Domain\Utils;
  */
 class McpValidator {
 
+
 	/**
-	 * Validate ISO 8601 timestamp format.
+	 * Allowed MIME types for MCP icons per specification.
 	 *
-	 * Checks if a string is a valid ISO 8601 timestamp by attempting to parse
-	 * it using multiple ISO 8601 format variations.
+	 * MUST support: image/png, image/jpeg, image/jpg
+	 * SHOULD support: image/svg+xml, image/webp
 	 *
-	 * @param string $timestamp The timestamp to validate.
+	 * @since n.e.x.t
 	 *
-	 * @return bool True if valid ISO 8601 timestamp, false otherwise.
+	 * @var array<string>
 	 */
-	public static function validate_iso8601_timestamp( string $timestamp ): bool {
-		// Try to parse as DateTime with ISO 8601 format.
-		$datetime = \DateTime::createFromFormat( \DateTime::ATOM, $timestamp );
-		if ( $datetime && $datetime->format( \DateTime::ATOM ) === $timestamp ) {
-			return true;
-		}
-
-		// Try alternative ISO 8601 formats.
-		$formats = array(
-			'Y-m-d\TH:i:s\Z',           // UTC format
-			'Y-m-d\TH:i:sP',            // With timezone offset
-			'Y-m-d\TH:i:s.u\Z',         // With microseconds UTC
-			'Y-m-d\TH:i:s.uP',          // With microseconds and timezone
-		);
-
-		foreach ( $formats as $format ) {
-			$datetime = \DateTime::createFromFormat( $format, $timestamp );
-			if ( $datetime && $datetime->format( $format ) === $timestamp ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
+	private static array $allowed_icon_mime_types = array(
+		'image/png',
+		'image/jpeg',
+		'image/jpg',
+		'image/svg+xml',
+		'image/webp',
+	);
 
 	/**
 	 * Validate an MCP component name.
 	 *
-	 * Validates that a name follows MCP naming conventions:
+	 * Validates that a name follows MCP naming conventions per MCP 2025-11-25 spec:
 	 * - Must not be empty
 	 * - Must not exceed the maximum length
-	 * - Must only contain letters, numbers, hyphens (-), and underscores (_)
+	 * - Must only contain letters, numbers, hyphens (-), underscores (_), and dots (.)
 	 *
 	 * @param string $name The name to validate.
-	 * @param int    $max_length Maximum allowed length. Default is 255.
+	 * @param int $max_length Maximum allowed length. Default is 128 per MCP spec.
 	 *
 	 * @return bool True if valid, false otherwise.
+	 * @since n.e.x.t
+	 *
 	 */
-	public static function validate_name( string $name, int $max_length = 255 ): bool {
-		// Names should not be empty.
-		if ( empty( $name ) ) {
+	public static function validate_name( string $name, int $max_length = 128 ): bool {
+		// Names should not be empty (but allow "0" since it matches the regex).
+		if ( '' === $name ) {
 			return false;
 		}
 
@@ -76,44 +65,8 @@ class McpValidator {
 			return false;
 		}
 
-		// Only allow letters, numbers, hyphens, and underscores.
-		return (bool) preg_match( '/^[a-zA-Z0-9_-]+$/', $name );
-	}
-
-	/**
-	 * Validate a tool or prompt name (max 255 characters).
-	 *
-	 * @param string $name The name to validate.
-	 *
-	 * @return bool True if valid, false otherwise.
-	 */
-	public static function validate_tool_or_prompt_name( string $name ): bool {
-		return self::validate_name( $name, 255 );
-	}
-
-	/**
-	 * Validate an argument name (max 64 characters).
-	 *
-	 * @param string $name The name to validate.
-	 *
-	 * @return bool True if valid, false otherwise.
-	 */
-	public static function validate_argument_name( string $name ): bool {
-		return self::validate_name( $name, 64 );
-	}
-
-	/**
-	 * Validate general MIME type format.
-	 *
-	 * Validates that a MIME type follows the standard format: type/subtype
-	 * where both type and subtype contain valid characters.
-	 *
-	 * @param string $mime_type The MIME type to validate.
-	 *
-	 * @return bool True if valid MIME type format, false otherwise.
-	 */
-	public static function validate_mime_type( string $mime_type ): bool {
-		return (bool) preg_match( '/^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_]*$/', $mime_type );
+		// Only allow letters, numbers, hyphens, underscores, and dots per MCP spec.
+		return (bool) preg_match( '/^[a-zA-Z0-9_.-]+$/', $name );
 	}
 
 	/**
@@ -167,137 +120,130 @@ class McpValidator {
 	}
 
 	/**
-	 * Validate a resource URI format.
+	 * Validate an array of icons.
 	 *
-	 * Per MCP spec: "The URI can use any protocol; it is up to the server how to interpret it."
-	 * This validates basic URI structure per RFC 3986.
+	 * Returns valid icons and logs warnings for invalid ones.
+	 * Invalid icons are filtered out (graceful degradation).
 	 *
-	 * @param string $uri The URI to validate.
+	 * @param array $icons Array of icon data.
+	 * @param bool $log_warnings Whether to log warnings for invalid icons. Default true.
 	 *
-	 * @return bool True if valid, false otherwise.
+	 * @return array{valid: array, errors: array} Array with 'valid' icons and 'errors' details.
+	 * @since n.e.x.t
+	 *
 	 */
-	public static function validate_resource_uri( string $uri ): bool {
-		// URI should not be empty.
-		if ( empty( $uri ) ) {
-			return false;
-		}
+	public static function validate_icons_array( array $icons, bool $log_warnings = true ): array {
+		$valid_icons = array();
+		$all_errors  = array();
 
-		// Check reasonable length constraints.
-		if ( strlen( $uri ) > 2048 ) {
-			return false;
-		}
+		foreach ( $icons as $index => $icon ) {
+			if ( ! is_array( $icon ) ) {
+				$all_errors[] = array(
+					'index'  => $index,
+					'errors' => array( __( 'Icon must be an array', 'mcp-adapter' ) ),
+				);
+				continue;
+			}
 
-		// Basic URI validation: must have scheme followed by colon (RFC 3986).
-		// This accepts any protocol as per MCP specification.
-		return (bool) preg_match( '/^[a-zA-Z][a-zA-Z0-9+.-]*:.+/', $uri );
-	}
+			$errors = self::get_icon_validation_errors( $icon );
 
-	/**
-	 * Validate a role value according to MCP specification.
-	 *
-	 * Valid roles are "user" or "assistant".
-	 *
-	 * @param string $role The role to validate.
-	 *
-	 * @return bool True if valid, false otherwise.
-	 */
-	public static function validate_role( string $role ): bool {
-		return in_array( $role, array( 'user', 'assistant' ), true );
-	}
+			if ( empty( $errors ) ) {
+				$valid_icons[] = $icon;
+			} else {
+				$all_errors[] = array(
+					'index'  => $index,
+					'errors' => $errors,
+				);
 
-	/**
-	 * Validate an array of roles according to MCP specification.
-	 *
-	 * All roles must be strings and must be either "user" or "assistant".
-	 *
-	 * @param array $roles The roles array to validate.
-	 *
-	 * @return bool True if all roles are valid, false otherwise.
-	 */
-	public static function validate_roles_array( array $roles ): bool {
-		if ( empty( $roles ) ) {
-			return false;
-		}
-
-		foreach ( $roles as $role ) {
-			if ( ! is_string( $role ) || ! self::validate_role( $role ) ) {
-				return false;
+				if ( $log_warnings ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log(
+						sprintf(
+							'MCP Adapter: Invalid icon at index %d skipped: %s',
+							$index,
+							implode( '; ', $errors )
+						)
+					);
+				}
 			}
 		}
 
-		return true;
+		return array(
+			'valid'  => $valid_icons,
+			'errors' => $all_errors,
+		);
 	}
 
 	/**
-	 * Validate a priority value according to MCP specification.
+	 * Get validation errors for an MCP icon object.
 	 *
-	 * Priority must be a number between 0.0 and 1.0 (inclusive).
+	 * Validates icon fields per MCP 2025-11-25 specification:
+	 * - src (required): Valid URL or data: URI
+	 * - mimeType (optional): One of allowed image MIME types
+	 * - sizes (optional): Array of size strings in WxH format or "any"
+	 * - theme (optional): "light" or "dark"
 	 *
-	 * @param mixed $priority The priority value to validate.
-	 *
-	 * @return bool True if valid, false otherwise.
-	 */
-	public static function validate_priority( $priority ): bool {
-		if ( ! is_numeric( $priority ) ) {
-			return false;
-		}
-
-		$priority_float = (float) $priority;
-		return $priority_float >= 0.0 && $priority_float <= 1.0;
-	}
-
-	/**
-	 * Get validation errors for tool-specific MCP annotations.
-	 *
-	 * Validates tool annotation fields per MCP 2025-06-18 specification:
-	 * - readOnlyHint, destructiveHint, idempotentHint, openWorldHint must be booleans
-	 * - title must be a non-empty string
-	 *
-	 * Only validates known tool annotation fields. Unknown fields are ignored.
-	 *
-	 * @param array $annotations The annotations to validate.
+	 * @param array $icon The icon data to validate.
 	 *
 	 * @return array Array of validation errors, empty if valid.
+	 * @since n.e.x.t
+	 *
 	 */
-	public static function get_tool_annotation_validation_errors( array $annotations ): array {
+	public static function get_icon_validation_errors( array $icon ): array {
 		$errors = array();
 
-		foreach ( $annotations as $field => $value ) {
-			switch ( $field ) {
-				case 'readOnlyHint':
-				case 'destructiveHint':
-				case 'idempotentHint':
-				case 'openWorldHint':
-					if ( ! is_bool( $value ) ) {
-						$errors[] = sprintf(
-							/* translators: %s: annotation field name */
-							__( 'Tool annotation field %s must be a boolean', 'mcp-adapter' ),
-							$field
-						);
-					}
-					break;
+		// src is required.
+		if ( ! isset( $icon['src'] ) ) {
+			$errors[] = __( 'Icon must have a src field', 'mcp-adapter' );
+		} elseif ( ! is_string( $icon['src'] ) ) {
+			$errors[] = __( 'Icon src must be a string', 'mcp-adapter' );
+		} elseif ( ! self::validate_icon_src( $icon['src'] ) ) {
+			$errors[] = __( 'Icon src must be a valid URL (http/https) or data: URI', 'mcp-adapter' );
+		}
 
-				case 'title':
-					if ( ! is_string( $value ) ) {
-						$errors[] = sprintf(
-							/* translators: %s: annotation field name */
-							__( 'Tool annotation field %s must be a string', 'mcp-adapter' ),
-							$field
-						);
-						break;
-					}
-					if ( empty( trim( $value ) ) ) {
-						$errors[] = sprintf(
-							/* translators: %s: annotation field name */
-							__( 'Tool annotation field %s must be a non-empty string', 'mcp-adapter' ),
-							$field
-						);
-					}
-					break;
+		// mimeType is optional but must be valid if present.
+		if ( isset( $icon['mimeType'] ) ) {
+			if ( ! is_string( $icon['mimeType'] ) ) {
+				$errors[] = __( 'Icon mimeType must be a string', 'mcp-adapter' );
+			} elseif ( ! self::validate_icon_mime_type( $icon['mimeType'] ) ) {
+				$errors[] = sprintf(
+				/* translators: %s: comma-separated list of allowed MIME types */
+					__( 'Icon mimeType must be one of: %s', 'mcp-adapter' ),
+					implode( ', ', self::$allowed_icon_mime_types )
+				);
+			}
+		}
 
-				default:
-					// Unknown fields are ignored to allow forward compatibility.
-					break;
+		// sizes is optional but must be valid if present.
+		if ( isset( $icon['sizes'] ) ) {
+			if ( ! is_array( $icon['sizes'] ) ) {
+				$errors[] = __( 'Icon sizes must be an array', 'mcp-adapter' );
+			} else {
+				foreach ( $icon['sizes'] as $index => $size ) {
+					if ( ! is_string( $size ) ) {
+						$errors[] = sprintf(
+						/* translators: %d: array index */
+							__( 'Icon size at index %d must be a string', 'mcp-adapter' ),
+							$index
+						);
+					} elseif ( ! self::validate_icon_size( $size ) ) {
+						$errors[] = sprintf(
+						/* translators: 1: size value, 2: array index */
+							__( 'Icon size "%1$s" at index %2$d must be in WxH format (e.g., "48x48") or "any"', 'mcp-adapter' ),
+							$size,
+							$index
+						);
+					}
+				}
+			}
+		}
+
+		// theme is optional but must be valid if present.
+		if ( isset( $icon['theme'] ) ) {
+			if ( ! is_string( $icon['theme'] ) ) {
+				$errors[] = __( 'Icon theme must be a string', 'mcp-adapter' );
+			} elseif ( ! self::validate_icon_theme( $icon['theme'] ) ) {
+				$errors[] = __( 'Icon theme must be "light" or "dark"', 'mcp-adapter' );
 			}
 		}
 
@@ -305,15 +251,110 @@ class McpValidator {
 	}
 
 	/**
+	 * Validate an icon source (src) value.
+	 *
+	 * Icon src must be a valid URL (http/https) or a data: URI with base64-encoded image data.
+	 *
+	 * @param string $src The icon source to validate.
+	 *
+	 * @return bool True if valid, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	public static function validate_icon_src( string $src ): bool {
+		$src = trim( $src );
+
+		if ( empty( $src ) ) {
+			return false;
+		}
+
+		// Check for data: URI.
+		if ( str_starts_with( $src, 'data:' ) ) {
+			// data:[<mediatype>][;base64],<data>
+			// Simplified validation: must have data: prefix and contain comma.
+			return str_contains( $src, ',' );
+		}
+
+		// Check for http/https URL.
+		if ( str_starts_with( $src, 'http://' ) || str_starts_with( $src, 'https://' ) ) {
+			return filter_var( $src, FILTER_VALIDATE_URL ) !== false;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Validate an icon MIME type.
+	 *
+	 * Per MCP spec, clients MUST support image/png, image/jpeg (and image/jpg).
+	 * Clients SHOULD support image/svg+xml, image/webp.
+	 *
+	 * @param string $mime_type The MIME type to validate.
+	 *
+	 * @return bool True if valid icon MIME type, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	public static function validate_icon_mime_type( string $mime_type ): bool {
+		return in_array( strtolower( trim( $mime_type ) ), self::$allowed_icon_mime_types, true );
+	}
+
+	/**
+	 * Validate an icon size string.
+	 *
+	 * Icon sizes must be in WxH format (e.g., "48x48", "96x96") or "any" for scalable formats.
+	 * Both width and height must be positive integers (no zero dimensions, no leading zeros).
+	 *
+	 * @param string $size The size string to validate.
+	 *
+	 * @return bool True if valid, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	public static function validate_icon_size( string $size ): bool {
+		$size = trim( $size );
+
+		if ( empty( $size ) ) {
+			return false;
+		}
+
+		// "any" is valid for scalable formats like SVG.
+		if ( 'any' === strtolower( $size ) ) {
+			return true;
+		}
+
+		// Must match WxH format with positive integers (no zero dimensions, no leading zeros).
+		// [1-9]\d* matches: 1, 2, ..., 9, 10, 11, ..., 99, 100, etc.
+		return (bool) preg_match( '/^[1-9]\d*x[1-9]\d*$/', $size );
+	}
+
+	/**
+	 * Validate an icon theme value.
+	 *
+	 * Valid themes are "light" or "dark".
+	 *
+	 * @param string $theme The theme to validate.
+	 *
+	 * @return bool True if valid, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	public static function validate_icon_theme( string $theme ): bool {
+		return in_array( strtolower( trim( $theme ) ), array( 'light', 'dark' ), true );
+	}
+
+	/**
 	 * Get validation errors for shared MCP annotations.
 	 *
-	 * Validates shared annotation fields per MCP 2025-06-18 specification:
-	 * - audience must be a non-empty array of valid Role values ("user", "assistant")
+	 * Validates shared annotation fields per MCP 2025-11-25 specification:
+	 * - audience must be an array of valid Role values ("user", "assistant")
 	 * - lastModified must be a valid ISO 8601 formatted string
 	 * - priority must be a number between 0.0 and 1.0
 	 *
 	 * Only validates known shared annotation fields. Unknown fields are ignored.
-	 * Used by resources, prompts, and tools.
+	 * Used by resources and content types (text, image, audio).
+	 *
+	 * Note: Tools use ToolAnnotations which is a separate type validated by McpToolValidator.
 	 *
 	 * @param array $annotations The annotations to validate.
 	 *
@@ -327,10 +368,6 @@ class McpValidator {
 				case 'audience':
 					if ( ! is_array( $value ) ) {
 						$errors[] = __( 'Annotation field audience must be an array', 'mcp-adapter' );
-						break;
-					}
-					if ( empty( $value ) ) {
-						$errors[] = __( 'Annotation field audience must be a non-empty array', 'mcp-adapter' );
 						break;
 					}
 					if ( ! self::validate_roles_array( $value ) ) {
@@ -365,5 +402,134 @@ class McpValidator {
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * Validate an array of roles according to MCP specification.
+	 *
+	 * All roles must be strings and must be either "user" or "assistant".
+	 *
+	 * @param array $roles The roles array to validate.
+	 *
+	 * @return bool True if all roles are valid, false otherwise.
+	 */
+	public static function validate_roles_array( array $roles ): bool {
+		foreach ( $roles as $role ) {
+			if ( ! is_string( $role ) || ! self::validate_role( $role ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate a role value according to MCP specification.
+	 *
+	 * Valid roles are "user" or "assistant".
+	 *
+	 * @param string $role The role to validate.
+	 *
+	 * @return bool True if valid, false otherwise.
+	 */
+	public static function validate_role( string $role ): bool {
+		return in_array( $role, array( 'user', 'assistant' ), true );
+	}
+
+	/**
+	 * Validate ISO 8601 timestamp format.
+	 *
+	 * Checks if a string is a valid ISO 8601 timestamp by attempting to parse
+	 * it using multiple ISO 8601 format variations.
+	 *
+	 * @param string $timestamp The timestamp to validate.
+	 *
+	 * @return bool True if valid ISO 8601 timestamp, false otherwise.
+	 */
+	public static function validate_iso8601_timestamp( string $timestamp ): bool {
+		// Try to parse as DateTime with ISO 8601 format.
+		$datetime = DateTime::createFromFormat( DateTime::ATOM, $timestamp );
+		if ( $datetime && $datetime->format( DateTime::ATOM ) === $timestamp ) {
+			return true;
+		}
+
+		// Try alternative ISO 8601 formats.
+		$formats = array(
+			'Y-m-d\TH:i:s\Z',           // UTC format
+			'Y-m-d\TH:i:sP',            // With timezone offset
+			'Y-m-d\TH:i:s.u\Z',         // With microseconds UTC
+			'Y-m-d\TH:i:s.uP',          // With microseconds and timezone
+		);
+
+		foreach ( $formats as $format ) {
+			$datetime = DateTime::createFromFormat( $format, $timestamp );
+			if ( $datetime && $datetime->format( $format ) === $timestamp ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Validate a priority value according to MCP specification.
+	 *
+	 * Priority must be a number between 0.0 and 1.0 (inclusive).
+	 *
+	 * @param mixed $priority The priority value to validate.
+	 *
+	 * @return bool True if valid, false otherwise.
+	 */
+	public static function validate_priority( $priority ): bool {
+		if ( ! is_numeric( $priority ) ) {
+			return false;
+		}
+
+		$priority_float = (float) $priority;
+
+		return $priority_float >= 0.0 && $priority_float <= 1.0;
+	}
+
+
+	/**
+	 * Validate a resource URI format.
+	 *
+	 * Per MCP spec: "The URI can use any protocol; it is up to the server how to interpret it."
+	 * This validates basic URI structure per RFC 3986.
+	 *
+	 * @param string $uri The URI to validate.
+	 *
+	 * @return bool True if valid, false otherwise.
+	 */
+	public static function validate_resource_uri( string $uri ): bool {
+		// URI should not be empty.
+		if ( empty( $uri ) ) {
+			return false;
+		}
+
+		// Check reasonable length constraints.
+		if ( strlen( $uri ) > 2048 ) {
+			return false;
+		}
+
+		// Basic URI validation: must have scheme followed by colon (RFC 3986).
+		// This accepts any protocol as per MCP specification.
+		return (bool) preg_match( '/^[a-zA-Z][a-zA-Z0-9+.-]*:.+/', $uri );
+	}
+
+	/**
+	 * Validate general MIME type format.
+	 *
+	 * Validates that a MIME type follows the standard format: type/subtype
+	 * where both type and subtype contain valid characters.
+	 *
+	 * @param string $mime_type The MIME type to validate.
+	 *
+	 * @return bool True if valid MIME type format, false otherwise.
+	 */
+	public static function validate_mime_type( string $mime_type ): bool {
+		// RFC 2045 compliant: allows +, ., and other valid MIME type characters.
+		// Examples: image/svg+xml, application/vnd.api+json, text/plain.
+		return (bool) preg_match( '/^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*$/', $mime_type );
 	}
 }

--- a/includes/Domain/Utils/SchemaTransformer.php
+++ b/includes/Domain/Utils/SchemaTransformer.php
@@ -25,26 +25,27 @@ class SchemaTransformer {
 	 * If the schema is a flattened type (string, number, boolean, array), it is
 	 * wrapped in an object structure with a single property (defaults to "input").
 	 *
-	 * @param array<string,mixed>|null $schema       The JSON schema to transform.
-	 * @param string                   $wrapper_key  Property name to use when wrapping non-object schemas.
+	 * @param array<string,mixed>|null $schema The JSON schema to transform.
+	 * @param string $wrapper_key Property name to use when wrapping non-object schemas.
 	 *
 	 * @return array<string,mixed> Array containing 'schema', 'was_transformed' (bool), and 'wrapper_property' when transformed.
 	 */
 	public static function transform_to_object_schema( ?array $schema, string $wrapper_key = 'input' ): array {
-		// Handle null or empty schema - return minimal object schema
+		// Handle null or empty schema - return minimal valid MCP object schema.
 		if ( empty( $schema ) ) {
 			return array(
 				'schema'           => array(
-					'type'                 => 'object',
-					'additionalProperties' => false,
+					'type' => 'object',
 				),
-				'was_transformed'  => false, // Empty schema wasn't really transformed
+				'was_transformed'  => false,
 				'wrapper_property' => null,
 			);
 		}
 
-		// If no type is specified, just return it as-is. It will fail MCP validation later because MCP requires an explicit type: "object"
+		// If no type is specified, add 'object' type since MCP requires it.
 		if ( ! isset( $schema['type'] ) ) {
+			$schema['type'] = 'object';
+
 			return array(
 				'schema'           => $schema,
 				'was_transformed'  => false,
@@ -76,7 +77,7 @@ class SchemaTransformer {
 	 * contains the original flattened schema.
 	 *
 	 * @param array<string,mixed> $schema The flattened schema to wrap.
-	 * @param string              $wrapper_key Property name to wrap the value under.
+	 * @param string $wrapper_key Property name to wrap the value under.
 	 *
 	 * @return array<string,mixed> The wrapped object schema.
 	 */

--- a/tests/Fixtures/DummyAbility.php
+++ b/tests/Fixtures/DummyAbility.php
@@ -182,7 +182,100 @@ final class DummyAbility {
 			)
 		);
 
-		// Resource ability with URI in meta
+		// Tool ability: returns an EmbeddedResource-style payload (text).
+		wp_register_ability(
+			'test/embedded-text-resource',
+			array(
+				'label'               => 'Embedded Text Resource Tool',
+				'description'         => 'Returns an embedded text resource payload',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return array(
+						'type'     => 'resource',
+						'uri'      => 'WordPress://local/tool-embedded-text',
+						'text'     => 'hello from embedded resource',
+						'mimeType' => 'text/plain',
+					);
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true, // Expose via MCP for testing
+					),
+				),
+			)
+		);
+
+		// Tool ability: returns an EmbeddedResource-style payload (blob).
+		wp_register_ability(
+			'test/embedded-blob-resource',
+			array(
+				'label'               => 'Embedded Blob Resource Tool',
+				'description'         => 'Returns an embedded blob resource payload',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return array(
+						'type'     => 'resource',
+						'uri'      => 'WordPress://local/tool-embedded-blob',
+						'blob'     => base64_encode( 'blob-bytes' ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+						'mimeType' => 'application/octet-stream',
+					);
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true, // Expose via MCP for testing
+					),
+				),
+			)
+		);
+
+		// Tool ability: returns nested internal _meta to verify it is never exposed to clients.
+		wp_register_ability(
+			'test/meta-leak',
+			array(
+				'label'               => 'Meta Leak Tool',
+				'description'         => 'Returns a payload containing internal adapter metadata for redaction tests',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return array(
+						'ok'     => true,
+						'_meta'  => array(
+							'mcp_adapter' => array(
+								'should_not' => 'leak',
+							),
+							'keep'        => 'top',
+						),
+						'nested' => array(
+							'value' => 123,
+							'_meta' => array(
+								'mcp_adapter' => array(
+									'should_not' => 'leak',
+								),
+								'keep'        => 'nested',
+							),
+						),
+					);
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true, // Expose via MCP for testing
+					),
+				),
+			)
+		);
+
+		// Resource ability with URI in meta (using standardized mcp.* structure)
 		wp_register_ability(
 			'test/resource',
 			array(
@@ -196,11 +289,10 @@ final class DummyAbility {
 					return true;
 				},
 				'meta'                => array(
-					'uri'         => 'WordPress://local/resource-1',
-					'annotations' => array( 'group' => 'tests' ),
-					'mcp'         => array(
+					'mcp' => array(
 						'public' => true, // Expose via MCP for testing
 						'type'   => 'resource', // Explicitly mark as resource
+						'uri'    => 'WordPress://local/resource-1',
 					),
 				),
 			)
@@ -581,6 +673,1017 @@ final class DummyAbility {
 				),
 			)
 		);
+
+		// Prompt with flattened string schema (should wrap as single 'input' argument).
+		wp_register_ability(
+			'test/prompt-flattened-string',
+			array(
+				'label'               => 'Prompt Flattened String',
+				'description'         => 'A prompt with flattened string schema',
+				'category'            => 'test',
+				'input_schema'        => array(
+					'type'        => 'string',
+					'description' => 'The code to review',
+				),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+					),
+				),
+			)
+		);
+
+		// Prompt with flattened array schema (should wrap as single 'input' argument).
+		wp_register_ability(
+			'test/prompt-flattened-array',
+			array(
+				'label'               => 'Prompt Flattened Array',
+				'description'         => 'A prompt with flattened array schema',
+				'category'            => 'test',
+				'input_schema'        => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'description' => 'List of items to process',
+				),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+					),
+				),
+			)
+		);
+
+		// Prompt with property titles (should map title to PromptArgument.title).
+		wp_register_ability(
+			'test/prompt-with-titles',
+			array(
+				'label'               => 'Prompt With Titles',
+				'description'         => 'A prompt with JSON Schema property titles',
+				'category'            => 'test',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'code'     => array(
+							'type'        => 'string',
+							'title'       => 'Source Code',
+							'description' => 'The code to review',
+						),
+						'language' => array(
+							'type'        => 'string',
+							'title'       => 'Programming Language',
+							'description' => 'The programming language',
+						),
+					),
+					'required'   => array( 'code' ),
+				),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+					),
+				),
+			)
+		);
+
+		// Prompt with mixed required/optional arguments.
+		wp_register_ability(
+			'test/prompt-mixed-required',
+			array(
+				'label'               => 'Prompt Mixed Required',
+				'description'         => 'A prompt with mixed required and optional arguments',
+				'category'            => 'test',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'topic'  => array(
+							'type'        => 'string',
+							'description' => 'The topic (required)',
+						),
+						'tone'   => array(
+							'type'        => 'string',
+							'description' => 'The tone (optional)',
+						),
+						'length' => array(
+							'type'        => 'integer',
+							'description' => 'The length (optional)',
+						),
+					),
+					'required'   => array( 'topic' ),
+				),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+					),
+				),
+			)
+		);
+
+		// Prompt with empty object schema (no properties).
+		wp_register_ability(
+			'test/prompt-empty-object',
+			array(
+				'label'               => 'Prompt Empty Object',
+				'description'         => 'A prompt with empty object schema',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+					),
+				),
+			)
+		);
+
+		// Prompt with no input_schema.
+		wp_register_ability(
+			'test/prompt-no-schema',
+			array(
+				'label'               => 'Prompt No Schema',
+				'description'         => 'A prompt with no input schema',
+				'category'            => 'test',
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+					),
+				),
+			)
+		);
+
+		// Tool with valid icons (MCP 2025-11-25)
+		wp_register_ability(
+			'test/with-icons',
+			array(
+				'label'               => 'Tool With Icons',
+				'description'         => 'A tool with MCP icons',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'success';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'icons'  => array(
+							array(
+								'src'      => 'https://example.com/icon.png',
+								'mimeType' => 'image/png',
+								'sizes'    => array( '32x32' ), // sizes is an array per MCP spec.
+								'theme'    => 'light',
+							),
+							array(
+								'src'      => 'https://example.com/icon-dark.svg',
+								'mimeType' => 'image/svg+xml',
+								'theme'    => 'dark',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Tool with some invalid icons (should filter out invalid, keep valid)
+		wp_register_ability(
+			'test/with-mixed-icons',
+			array(
+				'label'               => 'Tool With Mixed Icons',
+				'description'         => 'A tool with some valid and some invalid icons',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'success';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'icons'  => array(
+							array(
+								'src'      => 'https://example.com/valid-icon.png',
+								'mimeType' => 'image/png',
+							),
+							array(
+								// Missing src - invalid
+								'mimeType' => 'image/png',
+							),
+							array(
+								'src'      => 'https://example.com/another-valid.svg',
+								'mimeType' => 'image/svg+xml',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Tool with custom _meta passthrough
+		wp_register_ability(
+			'test/with-custom-meta',
+			array(
+				'label'               => 'Tool With Custom Meta',
+				'description'         => 'A tool with custom _meta passed through',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'success';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'_meta'  => array(
+							'custom_vendor'  => array(
+								'feature_flag' => true,
+								'version'      => '1.0',
+							),
+							'another_vendor' => 'some-value',
+						),
+					),
+				),
+			)
+		);
+
+		// Tool with both icons and custom _meta
+		wp_register_ability(
+			'test/with-icons-and-meta',
+			array(
+				'label'               => 'Tool With Icons And Meta',
+				'description'         => 'A tool with both icons and custom _meta',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'success';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'icons'  => array(
+							array(
+								'src'      => 'https://example.com/combined-icon.png',
+								'mimeType' => 'image/png',
+								'sizes'    => array( '48x48' ), // sizes is an array per MCP spec.
+							),
+						),
+						'_meta'  => array(
+							'vendor_info' => array(
+								'custom_data' => 'test-value',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Resource using standardized mcp.* meta structure (new pattern)
+		wp_register_ability(
+			'test/resource-new-meta',
+			array(
+				'label'               => 'Resource New Meta',
+				'description'         => 'A resource using standardized mcp.* meta structure',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'      => true,
+						'type'        => 'resource',
+						'uri'         => 'WordPress://local/resource-new-meta',
+						'mimeType'    => 'text/plain',
+						'size'        => 1024,
+						'annotations' => array(
+							'audience'     => array( 'user' ),
+							'priority'     => 0.7,
+							'lastModified' => '2025-01-15T10:30:00Z',
+						),
+						'icons'       => array(
+							array(
+								'src'      => 'https://example.com/resource-icon.png',
+								'mimeType' => 'image/png',
+								'sizes'    => array( '32x32' ),
+							),
+						),
+						'_meta'       => array(
+							'custom_field' => 'custom_value',
+						),
+					),
+				),
+			)
+		);
+
+		// Resource with invalid URI (no scheme) - should return WP_Error
+		wp_register_ability(
+			'test/resource-invalid-uri',
+			array(
+				'label'               => 'Resource Invalid URI',
+				'description'         => 'A resource with invalid URI for testing validation',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'no-scheme-invalid-uri',
+					),
+				),
+			)
+		);
+
+		// Resource with invalid mimeType - should silently skip mimeType
+		wp_register_ability(
+			'test/resource-invalid-mimetype',
+			array(
+				'label'               => 'Resource Invalid MimeType',
+				'description'         => 'A resource with invalid mimeType for testing validation',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'   => true,
+						'type'     => 'resource',
+						'uri'      => 'WordPress://local/resource-invalid-mimetype',
+						'mimeType' => 'not//valid',  // Invalid mime type.
+					),
+				),
+			)
+		);
+
+		// Resource with size field
+		wp_register_ability(
+			'test/resource-with-size',
+			array(
+				'label'               => 'Resource With Size',
+				'description'         => 'A resource with size field',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'WordPress://local/resource-with-size',
+						'size'   => 2048,
+					),
+				),
+			)
+		);
+
+		// Resource with INVALID annotations in new meta structure (for validation testing)
+		// All annotations should be dropped with _doing_it_wrong notice
+		wp_register_ability(
+			'test/resource-invalid-annotations-new-meta',
+			array(
+				'label'               => 'Resource Invalid Annotations New Meta',
+				'description'         => 'A resource with invalid annotations using new meta structure',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'      => true,
+						'type'        => 'resource',
+						'uri'         => 'WordPress://local/resource-invalid-annotations-new',
+						'annotations' => array(
+							'audience'     => array( 'admin', 'superuser' ), // Invalid roles (should be 'user' or 'assistant')
+							'lastModified' => 'yesterday',                   // Invalid ISO 8601 timestamp
+							'priority'     => 2.5,                           // Out of range (should be 0.0-1.0)
+						),
+					),
+				),
+			)
+		);
+
+		// Resource with MIXED valid/invalid annotations - should drop ALL because one is invalid
+		wp_register_ability(
+			'test/resource-mixed-annotations',
+			array(
+				'label'               => 'Resource Mixed Annotations',
+				'description'         => 'A resource with one valid and one invalid annotation',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'      => true,
+						'type'        => 'resource',
+						'uri'         => 'WordPress://local/resource-mixed-annotations',
+						'annotations' => array(
+							'priority'     => 0.5,                           // Valid
+							'lastModified' => 'not-valid-timestamp',         // Invalid - should cause ALL to be dropped
+						),
+					),
+				),
+			)
+		);
+
+		// Resource with icons (using new meta structure)
+		wp_register_ability(
+			'test/resource-with-icons',
+			array(
+				'label'               => 'Resource With Icons',
+				'description'         => 'A resource with icons using new meta structure',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'WordPress://local/resource-with-icons',
+						'icons'  => array(
+							array(
+								'src'      => 'https://example.com/resource-icon.svg',
+								'mimeType' => 'image/svg+xml',
+								'sizes'    => array( 'any' ),
+								'theme'    => 'light',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Resource with missing URI in meta (should fail conversion).
+		wp_register_ability(
+			'test/resource-missing-uri',
+			array(
+				'label'               => 'Resource Missing URI',
+				'description'         => 'A resource with no URI defined',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						// No uri key - should fail
+					),
+				),
+			)
+		);
+
+		// Resource with valid mimeType (for acceptance testing).
+		wp_register_ability(
+			'test/resource-valid-mimetype',
+			array(
+				'label'               => 'Resource Valid MimeType',
+				'description'         => 'A resource with valid mimeType',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'   => true,
+						'type'     => 'resource',
+						'uri'      => 'WordPress://local/resource-valid-mimetype',
+						'mimeType' => 'application/json',
+					),
+				),
+			)
+		);
+
+		// Resource that returns blob content (for BlobResourceContents testing).
+		wp_register_ability(
+			'test/resource-blob-content',
+			array(
+				'label'               => 'Resource Blob Content',
+				'description'         => 'A resource returning blob data',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return array(
+						array(
+							'uri'      => 'WordPress://local/resource-blob',
+							'blob'     => base64_encode( 'binary-data-here' ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+							'mimeType' => 'application/octet-stream',
+						),
+					);
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'WordPress://local/resource-blob-content',
+					),
+				),
+			)
+		);
+
+		// Resource that returns multiple content items.
+		wp_register_ability(
+			'test/resource-multiple-contents',
+			array(
+				'label'               => 'Resource Multiple Contents',
+				'description'         => 'A resource returning multiple content items',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return array(
+						array(
+							'uri'      => 'WordPress://local/resource-multi/part1',
+							'text'     => 'First content part',
+							'mimeType' => 'text/plain',
+						),
+						array(
+							'uri'      => 'WordPress://local/resource-multi/part2',
+							'text'     => 'Second content part',
+							'mimeType' => 'text/plain',
+						),
+					);
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'WordPress://local/resource-multiple-contents',
+					),
+				),
+			)
+		);
+
+		// Resource returning text with custom mimeType.
+		wp_register_ability(
+			'test/resource-text-with-mimetype',
+			array(
+				'label'               => 'Resource Text With MimeType',
+				'description'         => 'A resource returning text with custom mimeType',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return array(
+						array(
+							'uri'      => 'WordPress://local/resource-json',
+							'text'     => '{"key": "value"}',
+							'mimeType' => 'application/json',
+						),
+					);
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'WordPress://local/resource-text-with-mimetype',
+					),
+				),
+			)
+		);
+
+		// Resource returning plain string (non-array, for wrapping test).
+		wp_register_ability(
+			'test/resource-plain-string',
+			array(
+				'label'               => 'Resource Plain String',
+				'description'         => 'A resource returning a plain string',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'plain string content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'WordPress://local/resource-plain-string',
+					),
+				),
+			)
+		);
+
+		// =========================================================================
+		// Prompt Icons and _meta Test Abilities (MCP 2025-11-25)
+		// =========================================================================
+
+		// Prompt with valid icons.
+		wp_register_ability(
+			'test/prompt-with-icons',
+			array(
+				'label'               => 'Prompt With Icons',
+				'description'         => 'A prompt with MCP icons',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+						'icons'  => array(
+							array(
+								'src'      => 'https://example.com/prompt-icon.png',
+								'mimeType' => 'image/png',
+								'sizes'    => array( '32x32' ),
+								'theme'    => 'light',
+							),
+							array(
+								'src'      => 'https://example.com/prompt-icon-dark.svg',
+								'mimeType' => 'image/svg+xml',
+								'theme'    => 'dark',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Prompt with some invalid icons (should filter out invalid, keep valid).
+		wp_register_ability(
+			'test/prompt-with-mixed-icons',
+			array(
+				'label'               => 'Prompt With Mixed Icons',
+				'description'         => 'A prompt with some valid and some invalid icons',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+						'icons'  => array(
+							array(
+								'src'      => 'https://example.com/valid-prompt-icon.png',
+								'mimeType' => 'image/png',
+							),
+							array(
+								// Missing src - invalid.
+								'mimeType' => 'image/png',
+							),
+							array(
+								'src'      => 'https://example.com/another-valid-prompt.svg',
+								'mimeType' => 'image/svg+xml',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Prompt with custom _meta passthrough.
+		wp_register_ability(
+			'test/prompt-with-custom-meta',
+			array(
+				'label'               => 'Prompt With Custom Meta',
+				'description'         => 'A prompt with custom _meta passed through',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+						'_meta'  => array(
+							'custom_vendor'  => array(
+								'feature_flag' => true,
+								'version'      => '1.0',
+							),
+							'another_vendor' => 'some-value',
+						),
+					),
+				),
+			)
+		);
+
+		// Prompt with both icons and custom _meta.
+		wp_register_ability(
+			'test/prompt-with-icons-and-meta',
+			array(
+				'label'               => 'Prompt With Icons And Meta',
+				'description'         => 'A prompt with both icons and custom _meta',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'prompt',
+						'icons'  => array(
+							array(
+								'src'      => 'https://example.com/combined-prompt-icon.png',
+								'mimeType' => 'image/png',
+								'sizes'    => array( '48x48' ),
+							),
+						),
+						'_meta'  => array(
+							'vendor_info' => array(
+								'custom_data' => 'test-value',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// =========================================================================
+		// Explicit mcp.arguments Test Abilities
+		// =========================================================================
+
+		// Prompt with explicit mcp.arguments (no input_schema).
+		wp_register_ability(
+			'test/prompt-explicit-args',
+			array(
+				'label'               => 'Prompt Explicit Args',
+				'description'         => 'A prompt with explicit mcp.arguments and no input_schema',
+				'category'            => 'test',
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'    => true,
+						'type'      => 'prompt',
+						'arguments' => array(
+							array(
+								'name'        => 'code',
+								'title'       => 'Source Code',
+								'description' => 'The code to review',
+								'required'    => true,
+							),
+							array(
+								'name'        => 'language',
+								'description' => 'Programming language (optional)',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Prompt with explicit mcp.arguments that OVERRIDE input_schema.
+		wp_register_ability(
+			'test/prompt-explicit-args-override',
+			array(
+				'label'               => 'Prompt Explicit Args Override',
+				'description'         => 'A prompt where mcp.arguments override input_schema',
+				'category'            => 'test',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'schema_field' => array(
+							'type'        => 'string',
+							'description' => 'This should NOT appear in arguments',
+						),
+					),
+					'required'   => array( 'schema_field' ),
+				),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'    => true,
+						'type'      => 'prompt',
+						'arguments' => array(
+							array(
+								'name'        => 'explicit_field',
+								'title'       => 'Explicit Field',
+								'description' => 'This should appear instead of schema_field',
+								'required'    => true,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Prompt with empty mcp.arguments array (should fall back to input_schema).
+		wp_register_ability(
+			'test/prompt-empty-explicit-args',
+			array(
+				'label'               => 'Prompt Empty Explicit Args',
+				'description'         => 'A prompt with empty mcp.arguments, should use input_schema',
+				'category'            => 'test',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'fallback_field' => array(
+							'type'        => 'string',
+							'description' => 'This should appear because mcp.arguments is empty',
+						),
+					),
+					'required'   => array( 'fallback_field' ),
+				),
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'    => true,
+						'type'      => 'prompt',
+						'arguments' => array(), // Empty array - should fall back to input_schema.
+					),
+				),
+			)
+		);
+
+		// Prompt with invalid mcp.arguments (missing name) - should return WP_Error.
+		wp_register_ability(
+			'test/prompt-invalid-explicit-args-no-name',
+			array(
+				'label'               => 'Prompt Invalid Args No Name',
+				'description'         => 'A prompt with invalid mcp.arguments (missing name)',
+				'category'            => 'test',
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'    => true,
+						'type'      => 'prompt',
+						'arguments' => array(
+							array(
+								// Missing 'name' field - should fail validation.
+								'description' => 'This argument has no name',
+								'required'    => true,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Prompt with invalid mcp.arguments (non-array argument) - should return WP_Error.
+		wp_register_ability(
+			'test/prompt-invalid-explicit-args-not-array',
+			array(
+				'label'               => 'Prompt Invalid Args Not Array',
+				'description'         => 'A prompt with invalid mcp.arguments (argument is not an array)',
+				'category'            => 'test',
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'    => true,
+						'type'      => 'prompt',
+						'arguments' => array(
+							'not-an-array', // Invalid - should be an array.
+						),
+					),
+				),
+			)
+		);
+
+		// Prompt with explicit args containing all optional fields.
+		wp_register_ability(
+			'test/prompt-explicit-args-all-fields',
+			array(
+				'label'               => 'Prompt Explicit Args All Fields',
+				'description'         => 'A prompt with explicit arguments including all optional fields',
+				'category'            => 'test',
+				'execute_callback'    => static function ( array $input ) {
+					return array( 'messages' => array() );
+				},
+				'permission_callback' => static function ( array $input ) {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public'    => true,
+						'type'      => 'prompt',
+						'arguments' => array(
+							array(
+								'name'        => 'full_arg',
+								'title'       => 'Full Argument',
+								'description' => 'An argument with all fields populated',
+								'required'    => true,
+							),
+							array(
+								'name' => 'minimal_arg',
+								// Only name - all optional fields omitted.
+							),
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -617,7 +1720,43 @@ final class DummyAbility {
 			'test/prompt-with-annotations',
 			'test/prompt-partial-annotations',
 			'test/prompt-invalid-annotations',
+			'test/prompt-flattened-string',
+			'test/prompt-flattened-array',
+			'test/prompt-with-titles',
+			'test/prompt-mixed-required',
+			'test/prompt-empty-object',
+			'test/prompt-no-schema',
 			'test/resource-whitespace-uri',
+			'test/embedded-text-resource',
+			'test/embedded-blob-resource',
+			'test/meta-leak',
+			'test/with-icons',
+			'test/with-mixed-icons',
+			'test/with-custom-meta',
+			'test/with-icons-and-meta',
+			'test/resource-new-meta',
+			'test/resource-invalid-uri',
+			'test/resource-invalid-mimetype',
+			'test/resource-with-size',
+			'test/resource-invalid-annotations-new-meta',
+			'test/resource-mixed-annotations',
+			'test/resource-with-icons',
+			'test/resource-missing-uri',
+			'test/resource-valid-mimetype',
+			'test/resource-blob-content',
+			'test/resource-multiple-contents',
+			'test/resource-text-with-mimetype',
+			'test/resource-plain-string',
+			'test/prompt-explicit-args',
+			'test/prompt-explicit-args-override',
+			'test/prompt-empty-explicit-args',
+			'test/prompt-invalid-explicit-args-no-name',
+			'test/prompt-invalid-explicit-args-not-array',
+			'test/prompt-explicit-args-all-fields',
+			'test/prompt-with-icons',
+			'test/prompt-with-mixed-icons',
+			'test/prompt-with-custom-meta',
+			'test/prompt-with-icons-and-meta',
 		);
 
 		foreach ( $names as $name ) {

--- a/tests/Unit/Domain/Utils/AbilityArgumentNormalizerTest.php
+++ b/tests/Unit/Domain/Utils/AbilityArgumentNormalizerTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Tests for AbilityArgumentNormalizer class.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Domain\Utils;
+
+use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
+use WP\MCP\Tests\TestCase;
+
+/**
+ * Test AbilityArgumentNormalizer functionality.
+ *
+ * The normalizer converts empty arrays to null for abilities without input schemas.
+ * This handles MCP protocol compatibility where clients send {} for parameterless tools.
+ */
+final class AbilityArgumentNormalizerTest extends TestCase {
+
+	/**
+	 * Test that empty array is normalized to null when ability has empty input schema.
+	 */
+	public function test_empty_array_normalized_to_null_when_empty_input_schema(): void {
+		$ability = $this->create_ability_mock( array() );
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, array() );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that empty array is preserved when ability has an input schema.
+	 */
+	public function test_empty_array_preserved_when_ability_has_input_schema(): void {
+		$ability = $this->create_ability_mock(
+			array(
+				'type'       => 'object',
+				'properties' => array(
+					'name' => array( 'type' => 'string' ),
+				),
+			)
+		);
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, array() );
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that non-empty parameters are passed through unchanged regardless of schema.
+	 */
+	public function test_non_empty_parameters_passed_through_with_schema(): void {
+		$ability    = $this->create_ability_mock(
+			array(
+				'type'       => 'object',
+				'properties' => array(
+					'name' => array( 'type' => 'string' ),
+				),
+			)
+		);
+		$parameters = array( 'name' => 'test' );
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, $parameters );
+
+		$this->assertEquals( $parameters, $result );
+	}
+
+	/**
+	 * Test that non-empty parameters are passed through when ability has no schema.
+	 */
+	public function test_non_empty_parameters_passed_through_without_schema(): void {
+		$ability    = $this->create_ability_mock( array() );
+		$parameters = array( 'unexpected' => 'value' );
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, $parameters );
+
+		$this->assertEquals( $parameters, $result );
+	}
+
+	/**
+	 * Test that null parameters remain null.
+	 */
+	public function test_null_parameters_remain_null(): void {
+		$ability = $this->create_ability_mock( array() );
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, null );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that null parameters remain null even with input schema.
+	 */
+	public function test_null_parameters_remain_null_with_schema(): void {
+		$ability = $this->create_ability_mock(
+			array(
+				'type'       => 'object',
+				'properties' => array(
+					'name' => array( 'type' => 'string' ),
+				),
+			)
+		);
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, null );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that non-array parameters are passed through unchanged.
+	 */
+	public function test_non_array_parameters_passed_through(): void {
+		$ability = $this->create_ability_mock( array() );
+
+		// String parameter
+		$result = AbilityArgumentNormalizer::normalize( $ability, 'string-value' );
+		$this->assertEquals( 'string-value', $result );
+
+		// Integer parameter
+		$result = AbilityArgumentNormalizer::normalize( $ability, 42 );
+		$this->assertEquals( 42, $result );
+
+		// Boolean parameter
+		$result = AbilityArgumentNormalizer::normalize( $ability, true );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test with real registered ability that has no input schema.
+	 */
+	public function test_with_real_ability_without_input_schema(): void {
+		$ability = wp_get_ability( 'test/always-allowed' );
+		$this->assertNotNull( $ability, 'Test ability should be registered' );
+
+		// Verify the ability has no input schema
+		$this->assertEmpty( $ability->get_input_schema() );
+
+		// Empty array should be normalized to null
+		$result = AbilityArgumentNormalizer::normalize( $ability, array() );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test with real registered ability that has an input schema.
+	 */
+	public function test_with_real_ability_with_input_schema(): void {
+		$ability = wp_get_ability( 'test/permission-exception' );
+		$this->assertNotNull( $ability, 'Test permission-exception ability should be registered' );
+
+		// Verify the ability has an input schema
+		$this->assertNotEmpty( $ability->get_input_schema() );
+
+		// Empty array should be preserved
+		$result = AbilityArgumentNormalizer::normalize( $ability, array() );
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Create a mock WP_Ability with the specified input schema.
+	 *
+	 * @param array $input_schema The input schema to return from get_input_schema().
+	 * @return \WP_Ability Mock ability object.
+	 */
+	private function create_ability_mock( array $input_schema ): \WP_Ability {
+		$ability = $this->getMockBuilder( \WP_Ability::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_input_schema' ) )
+			->getMock();
+
+		$ability->method( 'get_input_schema' )
+			->willReturn( $input_schema );
+
+		return $ability;
+	}
+}

--- a/tests/Unit/Domain/Utils/ContentBlockHelperTest.php
+++ b/tests/Unit/Domain/Utils/ContentBlockHelperTest.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Tests for ContentBlockHelper factory class.
+ *
+ * @package WP\MCP\Tests\Unit\Domain\Utils
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Domain\Utils;
+
+use WP\MCP\Domain\Utils\ContentBlockHelper;
+use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Common\Content\DTO\AudioContent;
+use WP\McpSchema\Common\Content\DTO\ImageContent;
+use WP\McpSchema\Common\Content\DTO\TextContent;
+use WP\McpSchema\Common\Protocol\DTO\Annotations;
+use WP\McpSchema\Common\Protocol\DTO\BlobResourceContents;
+use WP\McpSchema\Common\Protocol\DTO\EmbeddedResource;
+use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
+use WP\McpSchema\Common\Protocol\Union\ContentBlockInterface;
+
+/**
+ * Test class for ContentBlockHelper.
+ */
+final class ContentBlockHelperTest extends TestCase {
+
+	/**
+	 * Test that text() creates a TextContent DTO.
+	 */
+	public function test_text_creates_text_content_dto(): void {
+		$content = ContentBlockHelper::text( 'Hello, World!' );
+
+		$this->assertInstanceOf( TextContent::class, $content );
+		$this->assertInstanceOf( ContentBlockInterface::class, $content );
+		$this->assertSame( 'text', $content->getType() );
+		$this->assertSame( 'Hello, World!', $content->getText() );
+		$this->assertNull( $content->getAnnotations() );
+		$this->assertNull( $content->get_meta() );
+	}
+
+	/**
+	 * Test that text() creates a TextContent with empty string.
+	 */
+	public function test_text_accepts_empty_string(): void {
+		$content = ContentBlockHelper::text( '' );
+
+		$this->assertInstanceOf( TextContent::class, $content );
+		$this->assertSame( '', $content->getText() );
+	}
+
+	/**
+	 * Test that text() creates a TextContent with annotations.
+	 */
+	public function test_text_with_annotations(): void {
+		$annotations = new Annotations( array( 'user' ), 0.8 );
+		$content     = ContentBlockHelper::text( 'Test message', $annotations );
+
+		$this->assertInstanceOf( TextContent::class, $content );
+		$this->assertSame( 'Test message', $content->getText() );
+		$this->assertSame( $annotations, $content->getAnnotations() );
+	}
+
+	/**
+	 * Test that text() creates a TextContent with _meta.
+	 */
+	public function test_text_with_meta(): void {
+		$meta    = array( 'key' => 'value' );
+		$content = ContentBlockHelper::text( 'Test message', null, $meta );
+
+		$this->assertInstanceOf( TextContent::class, $content );
+		$this->assertSame( $meta, $content->get_meta() );
+	}
+
+	/**
+	 * Test that text() toArray produces valid structure.
+	 */
+	public function test_text_to_array_produces_valid_structure(): void {
+		$content = ContentBlockHelper::text( 'Hello' );
+		$array   = $content->toArray();
+
+		$this->assertArrayHasKey( 'type', $array );
+		$this->assertArrayHasKey( 'text', $array );
+		$this->assertSame( 'text', $array['type'] );
+		$this->assertSame( 'Hello', $array['text'] );
+	}
+
+	/**
+	 * Test that image() creates an ImageContent DTO.
+	 */
+	public function test_image_creates_image_content_dto(): void {
+		$content = ContentBlockHelper::image( 'base64data', 'image/png' );
+
+		$this->assertInstanceOf( ImageContent::class, $content );
+		$this->assertInstanceOf( ContentBlockInterface::class, $content );
+		$this->assertSame( 'image', $content->getType() );
+		$this->assertSame( 'base64data', $content->getData() );
+		$this->assertSame( 'image/png', $content->getMimeType() );
+		$this->assertNull( $content->getAnnotations() );
+		$this->assertNull( $content->get_meta() );
+	}
+
+	/**
+	 * Test that image() creates an ImageContent with annotations.
+	 */
+	public function test_image_with_annotations(): void {
+		$annotations = new Annotations( array( 'user' ), 1.0 );
+		$content     = ContentBlockHelper::image( 'data', 'image/jpeg', $annotations );
+
+		$this->assertInstanceOf( ImageContent::class, $content );
+		$this->assertSame( $annotations, $content->getAnnotations() );
+	}
+
+	/**
+	 * Test that image() toArray produces valid structure.
+	 */
+	public function test_image_to_array_produces_valid_structure(): void {
+		$content = ContentBlockHelper::image( 'base64data', 'image/png' );
+		$array   = $content->toArray();
+
+		$this->assertArrayHasKey( 'type', $array );
+		$this->assertArrayHasKey( 'data', $array );
+		$this->assertArrayHasKey( 'mimeType', $array );
+		$this->assertSame( 'image', $array['type'] );
+		$this->assertSame( 'base64data', $array['data'] );
+		$this->assertSame( 'image/png', $array['mimeType'] );
+	}
+
+	/**
+	 * Test that audio() creates an AudioContent DTO.
+	 */
+	public function test_audio_creates_audio_content_dto(): void {
+		$content = ContentBlockHelper::audio( 'base64audiodata', 'audio/mp3' );
+
+		$this->assertInstanceOf( AudioContent::class, $content );
+		$this->assertInstanceOf( ContentBlockInterface::class, $content );
+		$this->assertSame( 'audio', $content->getType() );
+		$this->assertSame( 'base64audiodata', $content->getData() );
+		$this->assertSame( 'audio/mp3', $content->getMimeType() );
+		$this->assertNull( $content->getAnnotations() );
+		$this->assertNull( $content->get_meta() );
+	}
+
+	/**
+	 * Test that audio() creates an AudioContent with annotations.
+	 */
+	public function test_audio_with_annotations(): void {
+		$annotations = new Annotations( array( 'assistant' ), 0.5 );
+		$content     = ContentBlockHelper::audio( 'data', 'audio/wav', $annotations );
+
+		$this->assertInstanceOf( AudioContent::class, $content );
+		$this->assertSame( $annotations, $content->getAnnotations() );
+	}
+
+	/**
+	 * Test that audio() toArray produces valid structure.
+	 */
+	public function test_audio_to_array_produces_valid_structure(): void {
+		$content = ContentBlockHelper::audio( 'audiodata', 'audio/ogg' );
+		$array   = $content->toArray();
+
+		$this->assertArrayHasKey( 'type', $array );
+		$this->assertArrayHasKey( 'data', $array );
+		$this->assertArrayHasKey( 'mimeType', $array );
+		$this->assertSame( 'audio', $array['type'] );
+		$this->assertSame( 'audiodata', $array['data'] );
+		$this->assertSame( 'audio/ogg', $array['mimeType'] );
+	}
+
+	/**
+	 * Test that embeddedTextResource() creates an EmbeddedResource with TextResourceContents.
+	 */
+	public function test_embedded_text_resource_creates_embedded_resource_dto(): void {
+		$content = ContentBlockHelper::embedded_text_resource( 'file:///test.txt', 'Hello content' );
+
+		$this->assertInstanceOf( EmbeddedResource::class, $content );
+		$this->assertInstanceOf( ContentBlockInterface::class, $content );
+		$this->assertSame( 'resource', $content->getType() );
+
+		$resource = $content->getResource();
+		$this->assertInstanceOf( TextResourceContents::class, $resource );
+		$this->assertSame( 'file:///test.txt', $resource->getUri() );
+		$this->assertSame( 'Hello content', $resource->getText() );
+	}
+
+	/**
+	 * Test that embeddedTextResource() accepts optional mimeType.
+	 */
+	public function test_embedded_text_resource_with_mime_type(): void {
+		$content  = ContentBlockHelper::embedded_text_resource( 'file:///test.json', '{}', 'application/json' );
+		$resource = $content->getResource();
+
+		$this->assertSame( 'application/json', $resource->getMimeType() );
+	}
+
+	/**
+	 * Test that embeddedTextResource() with annotations.
+	 */
+	public function test_embedded_text_resource_with_annotations(): void {
+		$annotations = new Annotations( array( 'user' ) );
+		$content     = ContentBlockHelper::embedded_text_resource( 'file:///test.txt', 'content', null, $annotations );
+
+		$this->assertSame( $annotations, $content->getAnnotations() );
+	}
+
+	/**
+	 * Test that embeddedBlobResource() creates an EmbeddedResource with BlobResourceContents.
+	 */
+	public function test_embedded_blob_resource_creates_embedded_resource_dto(): void {
+		$content = ContentBlockHelper::embedded_blob_resource( 'file:///image.png', 'base64blob', 'image/png' );
+
+		$this->assertInstanceOf( EmbeddedResource::class, $content );
+		$this->assertInstanceOf( ContentBlockInterface::class, $content );
+		$this->assertSame( 'resource', $content->getType() );
+
+		$resource = $content->getResource();
+		$this->assertInstanceOf( BlobResourceContents::class, $resource );
+		$this->assertSame( 'file:///image.png', $resource->getUri() );
+		$this->assertSame( 'base64blob', $resource->getBlob() );
+		$this->assertSame( 'image/png', $resource->getMimeType() );
+	}
+
+	/**
+	 * Test that embeddedBlobResource() with annotations.
+	 */
+	public function test_embedded_blob_resource_with_annotations(): void {
+		$annotations = new Annotations( array( 'assistant' ), 0.9 );
+		$content     = ContentBlockHelper::embedded_blob_resource( 'file:///doc.pdf', 'data', 'application/pdf', $annotations );
+
+		$this->assertSame( $annotations, $content->getAnnotations() );
+	}
+
+	/**
+	 * Test that errorText() creates a TextContent for error messages.
+	 */
+	public function test_error_text_creates_text_content_dto(): void {
+		$content = ContentBlockHelper::error_text( 'Something went wrong' );
+
+		$this->assertInstanceOf( TextContent::class, $content );
+		$this->assertSame( 'text', $content->getType() );
+		$this->assertSame( 'Something went wrong', $content->getText() );
+	}
+
+	/**
+	 * Test that jsonText() creates a TextContent with JSON-encoded data.
+	 */
+	public function test_json_text_creates_text_content_with_json(): void {
+		$data    = array(
+			'key'    => 'value',
+			'nested' => array( 'a' => 1 ),
+		);
+		$content = ContentBlockHelper::json_text( $data );
+
+		$this->assertInstanceOf( TextContent::class, $content );
+		$this->assertSame( 'text', $content->getType() );
+		$this->assertSame( '{"key":"value","nested":{"a":1}}', $content->getText() );
+	}
+
+	/**
+	 * Test that jsonText() handles encoding options.
+	 */
+	public function test_json_text_with_pretty_print(): void {
+		$data    = array( 'key' => 'value' );
+		$content = ContentBlockHelper::json_text( $data, JSON_PRETTY_PRINT );
+
+		$this->assertInstanceOf( TextContent::class, $content );
+		$expected = "{\n    \"key\": \"value\"\n}";
+		$this->assertSame( $expected, $content->getText() );
+	}
+
+	/**
+	 * Test that toArrayList() converts array of DTOs to array format.
+	 */
+	public function test_to_array_list_converts_dtos_to_arrays(): void {
+		$blocks = array(
+			ContentBlockHelper::text( 'First' ),
+			ContentBlockHelper::text( 'Second' ),
+		);
+
+		$arrays = ContentBlockHelper::to_array_list( $blocks );
+
+		$this->assertCount( 2, $arrays );
+		$this->assertSame(
+			array(
+				'type' => 'text',
+				'text' => 'First',
+			),
+			$arrays[0]
+		);
+		$this->assertSame(
+			array(
+				'type' => 'text',
+				'text' => 'Second',
+			),
+			$arrays[1]
+		);
+	}
+
+	/**
+	 * Test that toArrayList() handles empty array.
+	 */
+	public function test_to_array_list_handles_empty_array(): void {
+		$arrays = ContentBlockHelper::to_array_list( array() );
+
+		$this->assertIsArray( $arrays );
+		$this->assertEmpty( $arrays );
+	}
+
+	/**
+	 * Test that toArrayList() handles mixed content types.
+	 */
+	public function test_to_array_list_handles_mixed_content_types(): void {
+		$blocks = array(
+			ContentBlockHelper::text( 'Message' ),
+			ContentBlockHelper::image( 'imgdata', 'image/png' ),
+		);
+
+		$arrays = ContentBlockHelper::to_array_list( $blocks );
+
+		$this->assertCount( 2, $arrays );
+		$this->assertSame( 'text', $arrays[0]['type'] );
+		$this->assertSame( 'image', $arrays[1]['type'] );
+	}
+}

--- a/tests/Unit/Domain/Utils/McpAnnotationMapperTest.php
+++ b/tests/Unit/Domain/Utils/McpAnnotationMapperTest.php
@@ -54,7 +54,12 @@ final class McpAnnotationMapperTest extends TestCase {
 		$this->assertCount( 3, $result );
 	}
 
-	public function test_map_includes_valid_fields_for_prompt(): void {
+	/**
+	 * Per MCP 2025-11-25 spec, Prompt templates do NOT support annotations.
+	 * Only content blocks inside prompt messages support annotations.
+	 * The mapper returns empty for 'prompt' feature type.
+	 */
+	public function test_map_returns_empty_for_prompt_feature_type(): void {
 		$annotations = array(
 			'audience'     => array( 'user' ),
 			'lastModified' => '2024-01-15T10:30:00Z',
@@ -63,10 +68,7 @@ final class McpAnnotationMapperTest extends TestCase {
 
 		$result = McpAnnotationMapper::map( $annotations, 'prompt' );
 
-		$this->assertArrayHasKey( 'audience', $result );
-		$this->assertArrayHasKey( 'lastModified', $result );
-		$this->assertArrayHasKey( 'priority', $result );
-		$this->assertCount( 3, $result );
+		$this->assertEmpty( $result, 'Prompt templates do not support annotations per MCP spec' );
 	}
 
 	public function test_map_includes_tool_specific_fields(): void {
@@ -168,22 +170,22 @@ final class McpAnnotationMapperTest extends TestCase {
 		$this->assertCount( 1, $result );
 	}
 
-	public function test_map_excludes_tool_fields_for_prompt(): void {
+	/**
+	 * Per MCP 2025-11-25 spec, Prompt templates do NOT support any annotations.
+	 * Neither tool-specific nor shared annotations are mapped.
+	 */
+	public function test_map_excludes_all_fields_for_prompt(): void {
 		$annotations = array(
 			'readonly'    => true,
 			'title'       => 'Some Title',
 			'priority'    => 0.5,
+			'audience'    => array( 'user' ),
 		);
 
 		$result = McpAnnotationMapper::map( $annotations, 'prompt' );
 
-		// Tool-specific fields should NOT be included for prompts
-		$this->assertArrayNotHasKey( 'readOnlyHint', $result );
-		$this->assertArrayNotHasKey( 'title', $result );
-
-		// But shared fields should be included
-		$this->assertArrayHasKey( 'priority', $result );
-		$this->assertCount( 1, $result );
+		// No annotations should be included for prompts
+		$this->assertEmpty( $result, 'Prompt templates do not support any annotations per MCP spec' );
 	}
 
 	public function test_map_filters_out_null_values(): void {
@@ -202,39 +204,172 @@ final class McpAnnotationMapperTest extends TestCase {
 	}
 
 	public function test_map_performs_light_type_validation(): void {
+		// Test with resource feature type since shared annotations apply to resources, not tools.
 		$annotations = array(
 			'audience'     => array( 'user', 'invalid-role' ), // Invalid role passed through
 			'lastModified' => '  whitespace  ',                // Strings get trimmed
 			'priority'     => -0.5,                            // Numbers cast to float, not clamped
-			'title'        => '  untrimmed  ',                 // Strings get trimmed
 		);
 
-		$result = McpAnnotationMapper::map( $annotations, 'tool' );
+		$result = McpAnnotationMapper::map( $annotations, 'resource' );
 
 		// Light validation: basic type checks and trimming only
 		$this->assertSame( array( 'user', 'invalid-role' ), $result['audience'] ); // Array passed through
 		$this->assertSame( 'whitespace', $result['lastModified'] );                 // String trimmed
 		$this->assertSame( -0.5, $result['priority'] );                             // Number not clamped
-		$this->assertSame( 'untrimmed', $result['title'] );                         // String trimmed
 	}
 
-	public function test_map_with_null_ability_property_uses_mcp_field_name(): void {
+	public function test_map_performs_light_type_validation_for_tools(): void {
 		$annotations = array(
-			// Fields with null ability_property should map 1:1
-			'audience'     => array( 'user' ),
-			'lastModified' => '2024-01-15T10:30:00Z',
-			'priority'     => 0.5,
+			'title' => '  untrimmed  ', // Strings get trimmed
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'tool' );
+
+		$this->assertSame( 'untrimmed', $result['title'] ); // String trimmed
+	}
+
+	public function test_map_with_null_ability_property_uses_mcp_field_name_for_tools(): void {
+		$annotations = array(
+			// Fields with null ability_property should map 1:1.
+			// For tools, only openWorldHint and title have null ability_property.
 			'openWorldHint' => true,
-			'title'        => 'Test',
+			'title'         => 'Test',
 		);
 
 		$result = McpAnnotationMapper::map( $annotations, 'tool' );
 
 		// These should map 1:1 (ability_property is null)
+		$this->assertArrayHasKey( 'openWorldHint', $result );
+		$this->assertArrayHasKey( 'title', $result );
+	}
+
+	public function test_map_with_null_ability_property_uses_mcp_field_name_for_resources(): void {
+		$annotations = array(
+			// Fields with null ability_property should map 1:1.
+			// Shared annotations (audience, lastModified, priority) apply to resources.
+			'audience'     => array( 'user' ),
+			'lastModified' => '2024-01-15T10:30:00Z',
+			'priority'     => 0.5,
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'resource' );
+
+		// These should map 1:1 (ability_property is null)
 		$this->assertArrayHasKey( 'audience', $result );
 		$this->assertArrayHasKey( 'lastModified', $result );
 		$this->assertArrayHasKey( 'priority', $result );
-		$this->assertArrayHasKey( 'openWorldHint', $result );
+	}
+
+	public function test_map_excludes_shared_annotations_from_tools(): void {
+		// Per MCP 2025-11-25 spec, ToolAnnotations does NOT include shared Annotations fields.
+		$annotations = array(
+			'audience'      => array( 'user' ),        // Shared annotation - NOT for tools
+			'lastModified'  => '2024-01-15T10:30:00Z', // Shared annotation - NOT for tools
+			'priority'      => 0.5,                     // Shared annotation - NOT for tools
+			'readOnlyHint'  => true,                    // Tool annotation - should be included
+			'title'         => 'Test Title',           // Tool annotation - should be included
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'tool' );
+
+		// Shared annotations should NOT be mapped for tools
+		$this->assertArrayNotHasKey( 'audience', $result, 'Shared annotation audience should not be mapped for tools' );
+		$this->assertArrayNotHasKey( 'lastModified', $result, 'Shared annotation lastModified should not be mapped for tools' );
+		$this->assertArrayNotHasKey( 'priority', $result, 'Shared annotation priority should not be mapped for tools' );
+
+		// Tool-specific annotations SHOULD be mapped
+		$this->assertArrayHasKey( 'readOnlyHint', $result );
 		$this->assertArrayHasKey( 'title', $result );
+	}
+
+	// Boolean Normalization Tests
+
+	public function test_map_normalizes_boolean_true_values(): void {
+		$test_cases = array(
+			true,     // PHP boolean
+			1,        // Integer
+			'1',      // String
+			'true',   // String
+			'TRUE',   // Uppercase string
+			'True',   // Mixed case string
+		);
+
+		foreach ( $test_cases as $value ) {
+			$annotations = array( 'readonly' => $value );
+			$result      = McpAnnotationMapper::map( $annotations, 'tool' );
+
+			$this->assertArrayHasKey( 'readOnlyHint', $result, "Value '{$value}' should result in readOnlyHint key" );
+			$this->assertTrue( $result['readOnlyHint'], "Value '{$value}' should normalize to true" );
+		}
+	}
+
+	public function test_map_normalizes_boolean_false_values(): void {
+		$test_cases = array(
+			false,    // PHP boolean
+			0,        // Integer
+			'0',      // String
+			'false',  // String
+			'FALSE',  // Uppercase string
+			'False',  // Mixed case string
+		);
+
+		foreach ( $test_cases as $index => $value ) {
+			$annotations = array( 'readonly' => $value );
+			$result      = McpAnnotationMapper::map( $annotations, 'tool' );
+
+			$this->assertArrayHasKey( 'readOnlyHint', $result, "Value at index {$index} should result in readOnlyHint key" );
+			$this->assertFalse( $result['readOnlyHint'], "Value at index {$index} should normalize to false" );
+		}
+	}
+
+	public function test_map_drops_invalid_boolean_values(): void {
+		$invalid_values = array(
+			'yes',            // Not a recognized boolean string
+			'no',             // Not a recognized boolean string
+			'on',             // Not a recognized boolean string
+			'off',            // Not a recognized boolean string
+			'',               // Empty string
+			'invalid',        // Random string
+			2,                // Integer other than 0/1
+			-1,               // Negative integer
+			1.0,              // Float (not accepted)
+			0.0,              // Float (not accepted)
+			array(),          // Array
+			array( 'true' ),  // Array containing string
+			null,             // Null (handled separately but should not produce key)
+		);
+
+		foreach ( $invalid_values as $index => $value ) {
+			$annotations = array( 'readonly' => $value );
+			$result      = McpAnnotationMapper::map( $annotations, 'tool' );
+
+			$this->assertArrayNotHasKey(
+				'readOnlyHint',
+				$result,
+				"Invalid value at index {$index} should be dropped (no readOnlyHint key)"
+			);
+		}
+	}
+
+	public function test_map_string_false_does_not_become_true(): void {
+		// This test specifically verifies the bug fix: 'false' string should NOT become true.
+		// PHP's (bool)'false' returns true because 'false' is a non-empty string.
+		$annotations = array(
+			'readonly'    => 'false',
+			'destructive' => 'FALSE',
+			'idempotent'  => 'False',
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'tool' );
+
+		$this->assertArrayHasKey( 'readOnlyHint', $result );
+		$this->assertFalse( $result['readOnlyHint'], "'false' string should normalize to false, not true" );
+
+		$this->assertArrayHasKey( 'destructiveHint', $result );
+		$this->assertFalse( $result['destructiveHint'], "'FALSE' string should normalize to false, not true" );
+
+		$this->assertArrayHasKey( 'idempotentHint', $result );
+		$this->assertFalse( $result['idempotentHint'], "'False' string should normalize to false, not true" );
 	}
 }

--- a/tests/Unit/Domain/Utils/McpNameSanitizerTest.php
+++ b/tests/Unit/Domain/Utils/McpNameSanitizerTest.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Tests for McpNameSanitizer class.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Domain\Utils;
+
+use WP\MCP\Domain\Utils\McpNameSanitizer;
+use WP\MCP\Tests\TestCase;
+use WP_Error;
+
+/**
+ * Test McpNameSanitizer functionality.
+ *
+ * Tests the best-effort sanitization logic for MCP tool/prompt names
+ * per MCP 2025-11-25 specification.
+ */
+final class McpNameSanitizerTest extends TestCase {
+
+	// Basic Sanitization Tests
+
+	public function test_sanitize_valid_name_unchanged(): void {
+		// Already valid names should pass through unchanged.
+		$this->assertSame( 'my-tool', McpNameSanitizer::sanitize_name( 'my-tool' ) );
+		$this->assertSame( 'foo_bar', McpNameSanitizer::sanitize_name( 'foo_bar' ) );
+		$this->assertSame( 'tool123', McpNameSanitizer::sanitize_name( 'tool123' ) );
+		$this->assertSame( 'foo.bar', McpNameSanitizer::sanitize_name( 'foo.bar' ) );
+	}
+
+	public function test_sanitize_replaces_slash(): void {
+		// Forward slash should be replaced with hyphen.
+		$this->assertSame( 'posts-create', McpNameSanitizer::sanitize_name( 'posts/create' ) );
+		$this->assertSame( 'namespace-tool-action', McpNameSanitizer::sanitize_name( 'namespace/tool/action' ) );
+	}
+
+	public function test_sanitize_replaces_spaces(): void {
+		// Spaces should be replaced with hyphens.
+		$this->assertSame( 'my-tool', McpNameSanitizer::sanitize_name( 'my tool' ) );
+		$this->assertSame( 'create-new-post', McpNameSanitizer::sanitize_name( 'create new post' ) );
+	}
+
+	public function test_sanitize_collapses_runs_when_sanitizing(): void {
+		// Consecutive hyphens are only collapsed when sanitization is needed.
+		// If the name is already valid per MCP spec, it passes through unchanged.
+		// This happens when invalid chars are replaced with hyphens.
+		$this->assertSame( 'my-tool', McpNameSanitizer::sanitize_name( 'my@@tool' ) );
+		$this->assertSame( 'foo-bar', McpNameSanitizer::sanitize_name( 'foo@@@bar' ) );
+	}
+
+	public function test_sanitize_valid_names_with_multiple_hyphens_unchanged(): void {
+		// Names with multiple hyphens are valid per MCP spec and pass through.
+		$this->assertSame( 'my--tool', McpNameSanitizer::sanitize_name( 'my--tool' ) );
+		$this->assertSame( '-my-tool-', McpNameSanitizer::sanitize_name( '-my-tool-' ) );
+	}
+
+	public function test_sanitize_trims_edges_when_sanitizing(): void {
+		// Leading/trailing hyphens are only trimmed when sanitization is needed.
+		// This happens after invalid chars are replaced with hyphens.
+		$this->assertSame( 'my-tool', McpNameSanitizer::sanitize_name( '@@my-tool@@' ) );
+		$this->assertSame( 'my-tool', McpNameSanitizer::sanitize_name( '  my-tool  ' ) );
+	}
+
+	public function test_sanitize_trims_whitespace(): void {
+		// Leading/trailing whitespace should be trimmed first.
+		$this->assertSame( 'my-tool', McpNameSanitizer::sanitize_name( '  my-tool  ' ) );
+		$this->assertSame( 'my-tool', McpNameSanitizer::sanitize_name( "\tmy-tool\n" ) );
+	}
+
+	// Length Handling Tests
+
+	public function test_sanitize_truncates_long_names(): void {
+		// Names > 128 chars should be truncated with hash suffix.
+		$long_name = str_repeat( 'a', 200 );
+		$result    = McpNameSanitizer::sanitize_name( $long_name );
+
+		$this->assertIsString( $result );
+		$this->assertSame( 128, strlen( $result ), 'Result should be exactly 128 characters' );
+		$this->assertStringStartsWith( str_repeat( 'a', 115 ), $result );
+		// Last 13 chars should be hyphen + 12-char hash.
+		$this->assertMatchesRegularExpression( '/-[a-f0-9]{12}$/', $result );
+	}
+
+	public function test_sanitize_preserves_truncation_uniqueness(): void {
+		// Different long names should produce different hashes.
+		$name1 = str_repeat( 'a', 200 );
+		$name2 = str_repeat( 'a', 199 ) . 'b';
+
+		$result1 = McpNameSanitizer::sanitize_name( $name1 );
+		$result2 = McpNameSanitizer::sanitize_name( $name2 );
+
+		$this->assertIsString( $result1 );
+		$this->assertIsString( $result2 );
+		$this->assertNotSame( $result1, $result2, 'Different inputs should produce different truncated names' );
+
+		// Both should be 128 chars.
+		$this->assertSame( 128, strlen( $result1 ) );
+		$this->assertSame( 128, strlen( $result2 ) );
+	}
+
+	public function test_sanitize_max_length_boundary(): void {
+		// Exactly 128 chars should not be truncated.
+		$name_128 = str_repeat( 'a', 128 );
+		$this->assertSame( $name_128, McpNameSanitizer::sanitize_name( $name_128 ) );
+
+		// 129 chars should be truncated.
+		$name_129 = str_repeat( 'a', 129 );
+		$result   = McpNameSanitizer::sanitize_name( $name_129 );
+		$this->assertIsString( $result );
+		$this->assertSame( 128, strlen( $result ) );
+	}
+
+	// Error Cases
+
+	public function test_sanitize_returns_error_for_empty(): void {
+		// Empty string should return WP_Error.
+		$result = McpNameSanitizer::sanitize_name( '' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_name_invalid', $result->get_error_code() );
+	}
+
+	public function test_sanitize_returns_error_for_whitespace_only(): void {
+		// Whitespace-only should return WP_Error.
+		$result = McpNameSanitizer::sanitize_name( '   ' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_name_invalid', $result->get_error_code() );
+	}
+
+	public function test_sanitize_returns_error_for_only_invalid_chars(): void {
+		// String with only invalid characters should return WP_Error.
+		$result = McpNameSanitizer::sanitize_name( '!!!' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_name_invalid', $result->get_error_code() );
+	}
+
+	public function test_sanitize_only_hyphens_is_valid(): void {
+		// '---' is valid per MCP spec (only contains valid chars), so it passes through.
+		$result = McpNameSanitizer::sanitize_name( '---' );
+		$this->assertIsString( $result );
+		$this->assertSame( '---', $result );
+	}
+
+	public function test_sanitize_returns_error_for_only_invalid_trimmed_to_empty(): void {
+		// String with only invalid chars that become hyphens and get trimmed to empty.
+		$result = McpNameSanitizer::sanitize_name( '@@@' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_name_invalid', $result->get_error_code() );
+	}
+
+	// Unicode/Accent Handling Tests
+
+	public function test_sanitize_transliterates_accents(): void {
+		// Accented characters should be transliterated to ASCII.
+		$this->assertSame( 'creer-post', McpNameSanitizer::sanitize_name( 'créer-post' ) );
+		$this->assertSame( 'resume', McpNameSanitizer::sanitize_name( 'résumé' ) );
+	}
+
+	public function test_sanitize_transliterates_mixed_unicode(): void {
+		// Mixed unicode should be transliterated.
+		$this->assertSame( 'uber-cafe-naive', McpNameSanitizer::sanitize_name( 'über-café-naïve' ) );
+	}
+
+	public function test_sanitize_transliterates_german_umlaut(): void {
+		// German umlauts should transliterate.
+		$this->assertSame( 'Munchen', McpNameSanitizer::sanitize_name( 'München' ) );
+		// Note: WordPress remove_accents() converts ß to 's', not 'ss'.
+		$this->assertSame( 'strase', McpNameSanitizer::sanitize_name( 'straße' ) );
+	}
+
+	public function test_sanitize_transliterates_spanish(): void {
+		// Spanish characters should transliterate.
+		$this->assertSame( 'nino', McpNameSanitizer::sanitize_name( 'niño' ) );
+		$this->assertSame( 'espanol', McpNameSanitizer::sanitize_name( 'español' ) );
+	}
+
+	// Edge Cases
+
+	public function test_sanitize_preserves_leading_numbers(): void {
+		// Names starting with numbers should be preserved.
+		$this->assertSame( '123tool', McpNameSanitizer::sanitize_name( '123tool' ) );
+		$this->assertSame( '123tool', McpNameSanitizer::sanitize_name( '!!!123tool' ) );
+	}
+
+	public function test_sanitize_handles_mixed_invalid_chars(): void {
+		// Mixed invalid characters should be sanitized.
+		$this->assertSame( 'my-tool-name', McpNameSanitizer::sanitize_name( 'my@tool#name' ) );
+		$this->assertSame( 'foo-bar-baz', McpNameSanitizer::sanitize_name( 'foo$bar%baz' ) );
+	}
+
+	public function test_sanitize_preserves_dots_and_underscores(): void {
+		// Dots and underscores are valid and should be preserved.
+		$this->assertSame( 'foo.bar_baz', McpNameSanitizer::sanitize_name( 'foo.bar_baz' ) );
+		$this->assertSame( 'api.v2.endpoint', McpNameSanitizer::sanitize_name( 'api.v2.endpoint' ) );
+	}
+
+	public function test_sanitize_complex_real_world_name(): void {
+		// Real-world complex name with multiple issues.
+		$this->assertSame(
+			'my-plugin-create-post',
+			McpNameSanitizer::sanitize_name( '  my-plugin/create post  ' )
+		);
+	}
+
+	// Constants Tests
+
+	public function test_constants_are_correct(): void {
+		// Verify constants match MCP spec and truncation logic.
+		$this->assertSame( 128, McpNameSanitizer::MAX_LENGTH );
+		$this->assertSame( 12, McpNameSanitizer::HASH_LENGTH );
+		$this->assertSame( 115, McpNameSanitizer::TRUNCATE_LENGTH );
+		// Verify truncate + separator + hash = max length.
+		$this->assertSame(
+			McpNameSanitizer::MAX_LENGTH,
+			McpNameSanitizer::TRUNCATE_LENGTH + 1 + McpNameSanitizer::HASH_LENGTH
+		);
+	}
+}

--- a/tests/Unit/Domain/Utils/McpValidatorTest.php
+++ b/tests/Unit/Domain/Utils/McpValidatorTest.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Tests for McpValidator class.
  *
  * @package WP\MCP\Tests
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Domain\Utils;
 
@@ -16,6 +17,7 @@ use WP\MCP\Tests\TestCase;
  * Test McpValidator functionality.
  */
 final class McpValidatorTest extends TestCase {
+
 
 	// ISO 8601 Timestamp Validation Tests
 
@@ -91,12 +93,14 @@ final class McpValidatorTest extends TestCase {
 	}
 
 	public function test_validate_name_rejects_too_long(): void {
-		$long_name = str_repeat( 'a', 256 );
+		// Default max length is 128 per MCP spec.
+		$long_name = str_repeat( 'a', 129 );
 		$this->assertFalse( McpValidator::validate_name( $long_name ) );
 	}
 
 	public function test_validate_name_accepts_max_length(): void {
-		$max_length_name = str_repeat( 'a', 255 );
+		// Default max length is 128 per MCP spec.
+		$max_length_name = str_repeat( 'a', 128 );
 		$this->assertTrue( McpValidator::validate_name( $max_length_name ) );
 	}
 
@@ -104,15 +108,29 @@ final class McpValidatorTest extends TestCase {
 		$invalid_names = array(
 			'name with spaces',
 			'name@invalid',
-			'name.invalid',
 			'name#invalid',
 			'name$invalid',
 			'name%invalid',
+			'name/invalid',
 		);
 
 		foreach ( $invalid_names as $name ) {
 			$this->assertFalse( McpValidator::validate_name( $name ), "Name '{$name}' should be invalid" );
 		}
+	}
+
+	public function test_validate_name_accepts_dot(): void {
+		// Dots are allowed per MCP 2025-11-25 spec: [A-Za-z0-9_.-]
+		$this->assertTrue( McpValidator::validate_name( 'name.with.dots' ) );
+		$this->assertTrue( McpValidator::validate_name( 'foo.bar' ) );
+		$this->assertTrue( McpValidator::validate_name( 'api.v2.endpoint' ) );
+	}
+
+	public function test_validate_name_accepts_numeric_zero(): void {
+		// Numeric "0" should be valid (matches regex but not empty()).
+		$this->assertTrue( McpValidator::validate_name( '0' ) );
+		$this->assertTrue( McpValidator::validate_name( '123' ) );
+		$this->assertTrue( McpValidator::validate_name( '000' ) );
 	}
 
 	public function test_validate_name_with_custom_max_length(): void {
@@ -123,9 +141,9 @@ final class McpValidatorTest extends TestCase {
 		$this->assertFalse( McpValidator::validate_name( $name_65_chars, 64 ) );
 	}
 
-	// Tool/Prompt Name Validation Tests
+	// Tool/Prompt Name Validation Tests (using validate_name with default 128-char limit)
 
-	public function test_validate_tool_or_prompt_name_with_valid_names(): void {
+	public function test_validate_name_default_128_with_valid_names(): void {
 		$valid_names = array(
 			'tool-name',
 			'prompt_name',
@@ -133,57 +151,42 @@ final class McpValidatorTest extends TestCase {
 		);
 
 		foreach ( $valid_names as $name ) {
-			$this->assertTrue( McpValidator::validate_tool_or_prompt_name( $name ), "Name '{$name}' should be valid" );
+			$this->assertTrue( McpValidator::validate_name( $name ), "Name '{$name}' should be valid" );
 		}
 	}
 
-	public function test_validate_tool_or_prompt_name_rejects_invalid(): void {
+	public function test_validate_name_default_128_rejects_invalid(): void {
 		$invalid_names = array(
 			'',
 			'tool with spaces',
 			'tool@invalid',
-			str_repeat( 'a', 256 ),
+			'tool/invalid',
 		);
 
 		foreach ( $invalid_names as $name ) {
-			$this->assertFalse( McpValidator::validate_tool_or_prompt_name( $name ), "Name '{$name}' should be invalid" );
+			$this->assertFalse( McpValidator::validate_name( $name ), "Name '{$name}' should be invalid" );
 		}
 	}
 
-	// Argument Name Validation Tests
+	public function test_validate_name_default_max_length_128(): void {
+		// MCP 2025-11-25 spec: tool/prompt names max 128 characters (default).
+		$name_128_chars = str_repeat( 'a', 128 );
+		$name_129_chars = str_repeat( 'a', 129 );
 
-	public function test_validate_argument_name_with_valid_names(): void {
-		$valid_names = array(
-			'arg-name',
-			'arg_name',
-			'arg123',
-		);
-
-		foreach ( $valid_names as $name ) {
-			$this->assertTrue( McpValidator::validate_argument_name( $name ), "Name '{$name}' should be valid" );
-		}
+		$this->assertTrue( McpValidator::validate_name( $name_128_chars ), '128 chars should be valid' );
+		$this->assertFalse( McpValidator::validate_name( $name_129_chars ), '129 chars should be invalid' );
 	}
 
-	public function test_validate_argument_name_rejects_too_long(): void {
-		$long_name = str_repeat( 'a', 65 );
-		$this->assertFalse( McpValidator::validate_argument_name( $long_name ) );
+	public function test_validate_name_allows_dot(): void {
+		// MCP 2025-11-25 spec allows dots in tool/prompt names.
+		$this->assertTrue( McpValidator::validate_name( 'foo.bar' ) );
+		$this->assertTrue( McpValidator::validate_name( 'namespace.tool.action' ) );
 	}
 
-	public function test_validate_argument_name_accepts_max_length(): void {
-		$max_length_name = str_repeat( 'a', 64 );
-		$this->assertTrue( McpValidator::validate_argument_name( $max_length_name ) );
-	}
-
-	public function test_validate_argument_name_rejects_invalid(): void {
-		$invalid_names = array(
-			'',
-			'arg with spaces',
-			'arg@invalid',
-		);
-
-		foreach ( $invalid_names as $name ) {
-			$this->assertFalse( McpValidator::validate_argument_name( $name ), "Name '{$name}' should be invalid" );
-		}
+	public function test_validate_name_rejects_slash(): void {
+		// Forward slash is NOT allowed in MCP tool/prompt names.
+		$this->assertFalse( McpValidator::validate_name( 'foo/bar' ) );
+		$this->assertFalse( McpValidator::validate_name( 'namespace/tool' ) );
 	}
 
 	// MIME Type Validation Tests
@@ -219,18 +222,42 @@ final class McpValidatorTest extends TestCase {
 		}
 	}
 
-	public function test_validate_mime_type_with_special_characters(): void {
-		$valid_special_types = array(
+	public function test_validate_mime_type_with_structured_syntax_suffix(): void {
+		// RFC 6839: Structured syntax suffixes like +json, +xml are valid.
+		$valid_suffix_types = array(
 			'application/vnd.api+json',
-			'text/html; charset=utf-8',
+			'image/svg+xml',
+			'application/atom+xml',
+			'application/hal+json',
 		);
 
-		// Note: The regex may not support all special characters, test what's actually supported
-		foreach ( $valid_special_types as $type ) {
-			// This might fail depending on regex implementation
-			$result = McpValidator::validate_mime_type( $type );
-			// Just verify the method doesn't throw an error
-			$this->assertIsBool( $result );
+		foreach ( $valid_suffix_types as $type ) {
+			$this->assertTrue( McpValidator::validate_mime_type( $type ), "MIME type '{$type}' should be valid" );
+		}
+	}
+
+	public function test_validate_mime_type_with_vendor_types(): void {
+		// RFC 2045: Vendor-specific types with dots and other characters.
+		$valid_vendor_types = array(
+			'application/vnd.ms-excel',
+			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+			'text/vnd.example.custom',
+		);
+
+		foreach ( $valid_vendor_types as $type ) {
+			$this->assertTrue( McpValidator::validate_mime_type( $type ), "MIME type '{$type}' should be valid" );
+		}
+	}
+
+	public function test_validate_mime_type_rejects_parameters(): void {
+		// MIME type parameters (after ;) are not supported by the validator.
+		$types_with_parameters = array(
+			'text/html; charset=utf-8',
+			'text/plain; format=flowed',
+		);
+
+		foreach ( $types_with_parameters as $type ) {
+			$this->assertFalse( McpValidator::validate_mime_type( $type ), "MIME type with parameter '{$type}' should be rejected" );
 		}
 	}
 
@@ -411,7 +438,7 @@ final class McpValidatorTest extends TestCase {
 
 	public function test_validate_resource_uri_accepts_max_length(): void {
 		// Build a URI that's exactly 2048 characters
-		$path         = str_repeat( 'a', 2048 - strlen( 'http://a.com/' ) );
+		$path           = str_repeat( 'a', 2048 - strlen( 'http://a.com/' ) );
 		$max_length_uri = 'http://a.com/' . $path;
 		$this->assertTrue( McpValidator::validate_resource_uri( $max_length_uri ) );
 	}
@@ -453,8 +480,8 @@ final class McpValidatorTest extends TestCase {
 		}
 	}
 
-	public function test_validate_roles_array_rejects_empty_array(): void {
-		$this->assertFalse( McpValidator::validate_roles_array( array() ) );
+	public function test_validate_roles_array_accepts_empty_array(): void {
+		$this->assertTrue( McpValidator::validate_roles_array( array() ) );
 	}
 
 	public function test_validate_roles_array_rejects_invalid_roles(): void {
@@ -574,9 +601,9 @@ final class McpValidatorTest extends TestCase {
 		$errors = McpValidator::get_annotation_validation_errors( array( 'audience' => 'user' ) );
 		$this->assertNotEmpty( $errors );
 
-		// Invalid: empty array
+		// Valid: empty array (no audience preference).
 		$errors = McpValidator::get_annotation_validation_errors( array( 'audience' => array() ) );
-		$this->assertNotEmpty( $errors );
+		$this->assertEmpty( $errors );
 
 		// Invalid: invalid role
 		$errors = McpValidator::get_annotation_validation_errors( array( 'audience' => array( 'admin' ) ) );
@@ -609,5 +636,335 @@ final class McpValidatorTest extends TestCase {
 		// Invalid: out of range (too high)
 		$errors = McpValidator::get_annotation_validation_errors( array( 'priority' => 1.5 ) );
 		$this->assertNotEmpty( $errors );
+	}
+
+	// Icon Source Validation Tests
+
+	public function test_validate_icon_src_with_valid_https_url(): void {
+		$this->assertTrue( McpValidator::validate_icon_src( 'https://example.com/icon.png' ) );
+		$this->assertTrue( McpValidator::validate_icon_src( 'https://cdn.example.com/icons/my-icon-48x48.png' ) );
+	}
+
+	public function test_validate_icon_src_with_valid_http_url(): void {
+		$this->assertTrue( McpValidator::validate_icon_src( 'http://example.com/icon.png' ) );
+	}
+
+	public function test_validate_icon_src_with_valid_data_uri(): void {
+		// Minimal valid data URI.
+		$this->assertTrue( McpValidator::validate_icon_src( 'data:image/png;base64,iVBORw0KGgo=' ) );
+		// Data URI without base64 encoding.
+		$this->assertTrue( McpValidator::validate_icon_src( 'data:text/plain,Hello' ) );
+	}
+
+	public function test_validate_icon_src_rejects_empty_string(): void {
+		$this->assertFalse( McpValidator::validate_icon_src( '' ) );
+	}
+
+	public function test_validate_icon_src_rejects_whitespace_only(): void {
+		$this->assertFalse( McpValidator::validate_icon_src( '   ' ) );
+	}
+
+	public function test_validate_icon_src_rejects_relative_paths(): void {
+		$this->assertFalse( McpValidator::validate_icon_src( '/icons/icon.png' ) );
+		$this->assertFalse( McpValidator::validate_icon_src( 'icons/icon.png' ) );
+		$this->assertFalse( McpValidator::validate_icon_src( '../icon.png' ) );
+	}
+
+	public function test_validate_icon_src_rejects_invalid_urls(): void {
+		$this->assertFalse( McpValidator::validate_icon_src( 'ftp://example.com/icon.png' ) );
+		$this->assertFalse( McpValidator::validate_icon_src( 'file:///path/to/icon.png' ) );
+		$this->assertFalse( McpValidator::validate_icon_src( 'just-a-string' ) );
+	}
+
+	public function test_validate_icon_src_rejects_invalid_data_uri(): void {
+		// Data URI without comma separator.
+		$this->assertFalse( McpValidator::validate_icon_src( 'data:image/png' ) );
+	}
+
+	// Icon MIME Type Validation Tests
+
+	public function test_validate_icon_mime_type_with_required_types(): void {
+		// MUST support per MCP spec.
+		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/png' ) );
+		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/jpeg' ) );
+		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/jpg' ) );
+	}
+
+	public function test_validate_icon_mime_type_with_recommended_types(): void {
+		// SHOULD support per MCP spec.
+		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/svg+xml' ) );
+		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/webp' ) );
+	}
+
+	public function test_validate_icon_mime_type_case_insensitive(): void {
+		$this->assertTrue( McpValidator::validate_icon_mime_type( 'IMAGE/PNG' ) );
+		$this->assertTrue( McpValidator::validate_icon_mime_type( 'Image/Jpeg' ) );
+		$this->assertTrue( McpValidator::validate_icon_mime_type( 'IMAGE/SVG+XML' ) );
+	}
+
+	public function test_validate_icon_mime_type_rejects_unsupported_types(): void {
+		$this->assertFalse( McpValidator::validate_icon_mime_type( 'image/gif' ) );
+		$this->assertFalse( McpValidator::validate_icon_mime_type( 'image/bmp' ) );
+		$this->assertFalse( McpValidator::validate_icon_mime_type( 'image/tiff' ) );
+		$this->assertFalse( McpValidator::validate_icon_mime_type( 'text/plain' ) );
+		$this->assertFalse( McpValidator::validate_icon_mime_type( 'application/json' ) );
+	}
+
+	// Icon Size Validation Tests
+
+	public function test_validate_icon_size_with_valid_sizes(): void {
+		$this->assertTrue( McpValidator::validate_icon_size( '48x48' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( '96x96' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( '192x192' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( '16x16' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( '512x512' ) );
+	}
+
+	public function test_validate_icon_size_with_any(): void {
+		$this->assertTrue( McpValidator::validate_icon_size( 'any' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( 'ANY' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( 'Any' ) );
+	}
+
+	public function test_validate_icon_size_with_whitespace_trimmed(): void {
+		$this->assertTrue( McpValidator::validate_icon_size( ' 48x48 ' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( ' any ' ) );
+	}
+
+	public function test_validate_icon_size_rejects_empty_string(): void {
+		$this->assertFalse( McpValidator::validate_icon_size( '' ) );
+	}
+
+	public function test_validate_icon_size_rejects_invalid_formats(): void {
+		$this->assertFalse( McpValidator::validate_icon_size( '48' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '48x' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( 'x48' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '48x48x48' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( 'large' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '48px' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '48 x 48' ) );
+	}
+
+	public function test_validate_icon_size_rejects_zero_dimensions(): void {
+		// Zero dimensions are invalid - an icon can't have zero width or height.
+		// phpcs:disable PHPCompatibility.Numbers.RemovedHexadecimalNumericStrings.Found -- These are size strings, not hex numbers.
+		$this->assertFalse( McpValidator::validate_icon_size( '0x0' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '0x48' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '48x0' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '00x00' ) );
+		// phpcs:enable PHPCompatibility.Numbers.RemovedHexadecimalNumericStrings.Found
+	}
+
+	public function test_validate_icon_size_rejects_leading_zeros(): void {
+		// Leading zeros indicate malformed input.
+		$this->assertFalse( McpValidator::validate_icon_size( '048x048' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '048x48' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '48x048' ) );
+		$this->assertFalse( McpValidator::validate_icon_size( '0048x0048' ) );
+	}
+
+	public function test_validate_icon_size_accepts_very_large_dimensions(): void {
+		// Very large dimensions should be valid (though impractical).
+		$this->assertTrue( McpValidator::validate_icon_size( '99999x99999' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( '1000000x1000000' ) );
+	}
+
+	public function test_validate_icon_size_accepts_non_square(): void {
+		// Non-square icons are valid.
+		$this->assertTrue( McpValidator::validate_icon_size( '48x96' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( '100x50' ) );
+		$this->assertTrue( McpValidator::validate_icon_size( '1920x1080' ) );
+	}
+
+	// Icon Theme Validation Tests
+
+	public function test_validate_icon_theme_with_valid_themes(): void {
+		$this->assertTrue( McpValidator::validate_icon_theme( 'light' ) );
+		$this->assertTrue( McpValidator::validate_icon_theme( 'dark' ) );
+	}
+
+	public function test_validate_icon_theme_case_insensitive(): void {
+		$this->assertTrue( McpValidator::validate_icon_theme( 'LIGHT' ) );
+		$this->assertTrue( McpValidator::validate_icon_theme( 'DARK' ) );
+		$this->assertTrue( McpValidator::validate_icon_theme( 'Light' ) );
+		$this->assertTrue( McpValidator::validate_icon_theme( 'Dark' ) );
+	}
+
+	public function test_validate_icon_theme_with_whitespace_trimmed(): void {
+		$this->assertTrue( McpValidator::validate_icon_theme( ' light ' ) );
+		$this->assertTrue( McpValidator::validate_icon_theme( ' dark ' ) );
+	}
+
+	public function test_validate_icon_theme_rejects_invalid_themes(): void {
+		$this->assertFalse( McpValidator::validate_icon_theme( '' ) );
+		$this->assertFalse( McpValidator::validate_icon_theme( 'auto' ) );
+		$this->assertFalse( McpValidator::validate_icon_theme( 'system' ) );
+		$this->assertFalse( McpValidator::validate_icon_theme( 'high-contrast' ) );
+	}
+
+	// Icon Validation Errors Tests
+
+	public function test_get_icon_validation_errors_with_valid_full_icon(): void {
+		$icon = array(
+			'src'      => 'https://example.com/icon.png',
+			'mimeType' => 'image/png',
+			'sizes'    => array( '48x48', '96x96' ),
+			'theme'    => 'light',
+		);
+
+		$errors = McpValidator::get_icon_validation_errors( $icon );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_get_icon_validation_errors_with_minimal_icon(): void {
+		// Only src is required.
+		$icon = array( 'src' => 'https://example.com/icon.png' );
+
+		$errors = McpValidator::get_icon_validation_errors( $icon );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_get_icon_validation_errors_missing_src(): void {
+		$icon   = array( 'mimeType' => 'image/png' );
+		$errors = McpValidator::get_icon_validation_errors( $icon );
+
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'src', $errors[0] );
+	}
+
+	public function test_get_icon_validation_errors_invalid_src(): void {
+		$icon   = array( 'src' => 'not-a-valid-url' );
+		$errors = McpValidator::get_icon_validation_errors( $icon );
+
+		$this->assertNotEmpty( $errors );
+	}
+
+	public function test_get_icon_validation_errors_src_not_string(): void {
+		$icon   = array( 'src' => 123 );
+		$errors = McpValidator::get_icon_validation_errors( $icon );
+
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'string', $errors[0] );
+	}
+
+	public function test_get_icon_validation_errors_invalid_mime_type(): void {
+		$icon = array(
+			'src'      => 'https://example.com/icon.gif',
+			'mimeType' => 'image/gif', // Not in allowed list.
+		);
+
+		$errors = McpValidator::get_icon_validation_errors( $icon );
+		$this->assertNotEmpty( $errors );
+	}
+
+	public function test_get_icon_validation_errors_invalid_sizes_not_array(): void {
+		$icon = array(
+			'src'   => 'https://example.com/icon.png',
+			'sizes' => '48x48', // Should be array.
+		);
+
+		$errors = McpValidator::get_icon_validation_errors( $icon );
+		$this->assertNotEmpty( $errors );
+	}
+
+	public function test_get_icon_validation_errors_invalid_size_format(): void {
+		$icon = array(
+			'src'   => 'https://example.com/icon.png',
+			'sizes' => array( '48x48', 'invalid' ),
+		);
+
+		$errors = McpValidator::get_icon_validation_errors( $icon );
+		$this->assertNotEmpty( $errors );
+	}
+
+	public function test_get_icon_validation_errors_invalid_theme(): void {
+		$icon = array(
+			'src'   => 'https://example.com/icon.png',
+			'theme' => 'invalid-theme',
+		);
+
+		$errors = McpValidator::get_icon_validation_errors( $icon );
+		$this->assertNotEmpty( $errors );
+	}
+
+	// Icons Array Validation Tests
+
+	public function test_validate_icons_array_with_valid_icons(): void {
+		$icons = array(
+			array( 'src' => 'https://example.com/icon1.png' ),
+			array(
+				'src'      => 'https://example.com/icon2.png',
+				'mimeType' => 'image/png',
+			),
+		);
+
+		$result = McpValidator::validate_icons_array( $icons, false );
+
+		$this->assertCount( 2, $result['valid'] );
+		$this->assertEmpty( $result['errors'] );
+	}
+
+	public function test_validate_icons_array_filters_invalid_icons(): void {
+		$icons = array(
+			array( 'src' => 'https://example.com/valid.png' ),
+			array( 'src' => 'invalid-url' ),
+			array( 'src' => 'https://example.com/another-valid.png' ),
+		);
+
+		$result = McpValidator::validate_icons_array( $icons, false );
+
+		$this->assertCount( 2, $result['valid'] );
+		$this->assertCount( 1, $result['errors'] );
+		$this->assertEquals( 1, $result['errors'][0]['index'] );
+	}
+
+	public function test_validate_icons_array_rejects_non_array_items(): void {
+		$icons = array(
+			array( 'src' => 'https://example.com/icon.png' ),
+			'not-an-array',
+		);
+
+		$result = McpValidator::validate_icons_array( $icons, false );
+
+		$this->assertCount( 1, $result['valid'] );
+		$this->assertCount( 1, $result['errors'] );
+	}
+
+	public function test_validate_icons_array_empty_array(): void {
+		$result = McpValidator::validate_icons_array( array(), false );
+
+		$this->assertEmpty( $result['valid'] );
+		$this->assertEmpty( $result['errors'] );
+	}
+
+	public function test_validate_icons_array_all_invalid(): void {
+		$icons = array(
+			array( 'src' => 'invalid1' ),
+			array( 'mimeType' => 'image/png' ), // Missing src.
+		);
+
+		$result = McpValidator::validate_icons_array( $icons, false );
+
+		$this->assertEmpty( $result['valid'] );
+		$this->assertCount( 2, $result['errors'] );
+	}
+
+	public function test_validate_icons_array_preserves_valid_icon_data(): void {
+		$icons = array(
+			array(
+				'src'      => 'https://example.com/icon.png',
+				'mimeType' => 'image/png',
+				'sizes'    => array( '48x48' ),
+				'theme'    => 'light',
+			),
+		);
+
+		$result = McpValidator::validate_icons_array( $icons, false );
+
+		$this->assertCount( 1, $result['valid'] );
+		$this->assertEquals( 'https://example.com/icon.png', $result['valid'][0]['src'] );
+		$this->assertEquals( 'image/png', $result['valid'][0]['mimeType'] );
+		$this->assertEquals( array( '48x48' ), $result['valid'][0]['sizes'] );
+		$this->assertEquals( 'light', $result['valid'][0]['theme'] );
 	}
 }

--- a/tests/Unit/Domain/Utils/McpValidatorTest.php
+++ b/tests/Unit/Domain/Utils/McpValidatorTest.php
@@ -6,7 +6,7 @@
  * @package WP\MCP\Tests
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WP\MCP\Tests\Unit\Domain\Utils;
 

--- a/tests/Unit/Domain/Utils/McpValidatorTest.php
+++ b/tests/Unit/Domain/Utils/McpValidatorTest.php
@@ -18,7 +18,6 @@ use WP\MCP\Tests\TestCase;
  */
 final class McpValidatorTest extends TestCase {
 
-
 	// ISO 8601 Timestamp Validation Tests
 
 	public function test_validate_iso8601_timestamp_with_atom_format(): void {

--- a/tests/Unit/Domain/Utils/SchemaTransformerTest.php
+++ b/tests/Unit/Domain/Utils/SchemaTransformerTest.php
@@ -146,31 +146,29 @@ final class SchemaTransformerTest extends TestCase {
 		$this->assertEquals( $object_schema, $result['schema'] );
 	}
 
-	public function test_null_schema_returns_empty_object(): void {
+	public function test_null_schema_returns_minimal_object(): void {
 		$result = SchemaTransformer::transform_to_object_schema( null );
 
 		$this->assertIsArray( $result );
 		$this->assertFalse( $result['was_transformed'] );
+		$this->assertNull( $result['wrapper_property'] );
 
 		$schema = $result['schema'];
-		$this->assertEquals( 'object', $schema['type'] );
-		$this->assertArrayHasKey( 'additionalProperties', $schema );
-		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertEquals( array( 'type' => 'object' ), $schema );
 	}
 
-	public function test_empty_array_schema_returns_empty_object(): void {
+	public function test_empty_array_schema_returns_minimal_object(): void {
 		$result = SchemaTransformer::transform_to_object_schema( array() );
 
 		$this->assertIsArray( $result );
 		$this->assertFalse( $result['was_transformed'] );
+		$this->assertNull( $result['wrapper_property'] );
 
 		$schema = $result['schema'];
-		$this->assertEquals( 'object', $schema['type'] );
-		$this->assertArrayHasKey( 'additionalProperties', $schema );
-		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertEquals( array( 'type' => 'object' ), $schema );
 	}
 
-	public function test_schema_without_type_passes_through(): void {
+	public function test_schema_without_type_gets_object_type_added(): void {
 		$schema_without_type = array(
 			'properties' => array(
 				'param1' => array( 'type' => 'string' ),
@@ -180,7 +178,12 @@ final class SchemaTransformerTest extends TestCase {
 		$result = SchemaTransformer::transform_to_object_schema( $schema_without_type );
 
 		$this->assertFalse( $result['was_transformed'] );
-		$this->assertEquals( $schema_without_type, $result['schema'] );
+		$this->assertNull( $result['wrapper_property'] );
+
+		// Type should be added to the schema.
+		$this->assertEquals( 'object', $result['schema']['type'] );
+		$this->assertArrayHasKey( 'properties', $result['schema'] );
+		$this->assertEquals( $schema_without_type['properties'], $result['schema']['properties'] );
 	}
 
 	public function test_string_schema_with_enum_preserves_constraints(): void {


### PR DESCRIPTION
## Summary

Introduces domain layer foundation: contracts for MCP components and utility classes for schema transformation, name sanitization, and validation.

## Changes

### Contracts
- `McpComponentInterface` — Base interface for all MCP components
- `McpPromptBuilderInterface` — Updated prompt builder contract

### Utilities
- `AbilityArgumentNormalizer` — Normalizes ability arguments to MCP format
- `ContentBlockHelper` — Helper for creating MCP content blocks
- `McpAnnotationMapper` — Maps ability metadata to MCP annotations
- `McpNameSanitizer` — Ensures MCP-compliant naming
- `McpValidator` — Updated validation utilities
- `SchemaTransformer` — Transforms ability schemas to MCP JSON Schema

### Tests
- Full test coverage for all utility classes
- Updated `DummyAbility` fixture for testing

## Why

These utilities provide the building blocks for converting WordPress Abilities to MCP components:
- Consistent name formatting across tools, resources, and prompts
- Schema transformation from ability format to MCP JSON Schema
- Content block generation for responses

## Stacked PR

⚠️ **This is PR 3 of 6** in the MCP Schema integration series.

| # | Branch | Description |
|---|--------|-------------|
| 1 | `01-composer-deps` | Composer dependency |
| 2 | `02-infrastructure` | Error handling + observability |
| **3** | **`03-domain-utils`** | **← You are here** |
| 4 | `04-domain-components` | Tools, Resources, Prompts |
| 5 | `05-core` | Core + abilities + plugin |
| 6 | `06-handlers-transport` | Handlers + Transport + CLI |

**Merge order**: 1 → 2 → 3 → 4 → 5 → 6

## Testing

- [ ] All utility class tests pass
- [ ] Schema transformation produces valid MCP schemas