### PR TITLE
[4/6] Refactor domain models to use MCP schema DTOs

### DIFF
--- a/includes/Domain/Contracts/McpComponentInterface.php
+++ b/includes/Domain/Contracts/McpComponentInterface.php
@@ -30,11 +30,14 @@ interface McpComponentInterface {
 	/**
 	 * Get the clean protocol DTO for MCP responses.
 	 *
+	 * This DTO is used only for protocol serialization and MUST NOT include
+	 * internal adapter metadata or execution wiring.
+	 *
 	 * @return \WP\McpSchema\Common\AbstractDataTransferObject Protocol-only DTO.
 	 * @since n.e.x.t
 	 *
 	 */
-	public function get_component(): AbstractDataTransferObject;
+	public function get_protocol_dto(): AbstractDataTransferObject;
 
 	/**
 	 * Execute the component using the configured strategy.

--- a/includes/Domain/Prompts/McpPrompt.php
+++ b/includes/Domain/Prompts/McpPrompt.php
@@ -63,7 +63,7 @@ final class McpPrompt implements McpComponentInterface {
 	/**
 	 * Clean Prompt DTO (protocol-only).
 	 *
-	 * @var PromptDto
+	 * @var \WP\McpSchema\Server\Prompts\DTO\Prompt
 	 */
 	private PromptDto $prompt;
 
@@ -116,7 +116,7 @@ final class McpPrompt implements McpComponentInterface {
 	/**
 	 * Private constructor - use factory methods.
 	 *
-	 * @param PromptDto $prompt The Prompt DTO.
+	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The Prompt DTO.
 	 */
 	private function __construct( PromptDto $prompt ) {
 		$this->prompt = $prompt;
@@ -303,7 +303,7 @@ final class McpPrompt implements McpComponentInterface {
 	/**
 	 * Get the clean protocol DTO for MCP responses.
 	 *
-	 * @return PromptDto
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt
 	 */
 	public function get_protocol_dto(): PromptDto {
 		return $this->prompt;

--- a/includes/Domain/Prompts/McpPrompt.php
+++ b/includes/Domain/Prompts/McpPrompt.php
@@ -15,7 +15,7 @@ use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
 use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\Observability\FailureReason;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 
 /**
@@ -47,6 +47,10 @@ use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
  * $prompt = McpPrompt::fromBuilder($builder);
  * ```
  *
+ * McpPrompt wraps a protocol-only PromptDto for MCP serialization. Internal
+ * adapter metadata and execution wiring live on this class and are never
+ * exposed to MCP clients. Use get_protocol_dto() for protocol responses.
+ *
  * @since n.e.x.t
  */
 final class McpPrompt implements McpComponentInterface {
@@ -59,9 +63,9 @@ final class McpPrompt implements McpComponentInterface {
 	/**
 	 * Clean Prompt DTO (protocol-only).
 	 *
-	 * @var \WP\McpSchema\Server\Prompts\DTO\Prompt
+	 * @var PromptDto
 	 */
-	private Prompt $prompt;
+	private PromptDto $prompt;
 
 	/**
 	 * Ability used for execution/permission checks (ability-backed prompts).
@@ -112,9 +116,9 @@ final class McpPrompt implements McpComponentInterface {
 	/**
 	 * Private constructor - use factory methods.
 	 *
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The Prompt DTO.
+	 * @param PromptDto $prompt The Prompt DTO.
 	 */
-	private function __construct( Prompt $prompt ) {
+	private function __construct( PromptDto $prompt ) {
 		$this->prompt = $prompt;
 	}
 
@@ -164,7 +168,7 @@ final class McpPrompt implements McpComponentInterface {
 			$prompt_data['icons'] = $valid_icons;
 		}
 
-		// Create the Prompt DTO - wrap in try-catch since PromptArgument::fromArray() and Prompt::fromArray() can throw.
+		// Create the Prompt DTO - wrap in try-catch since PromptArgument::fromArray() and PromptDto::fromArray() can throw.
 		try {
 			// Process arguments inside try-catch since PromptArgument::fromArray() can throw.
 			if ( isset( $config['arguments'] ) && is_array( $config['arguments'] ) && ! empty( $config['arguments'] ) ) {
@@ -183,7 +187,7 @@ final class McpPrompt implements McpComponentInterface {
 				);
 			}
 
-			$prompt = Prompt::fromArray( $prompt_data );
+			$prompt = PromptDto::fromArray( $prompt_data );
 		} catch ( \Throwable $e ) {
 			return new \WP_Error(
 				'mcp_prompt_dto_creation_failed',
@@ -299,9 +303,9 @@ final class McpPrompt implements McpComponentInterface {
 	/**
 	 * Get the clean protocol DTO for MCP responses.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt
+	 * @return PromptDto
 	 */
-	public function get_component(): Prompt {
+	public function get_protocol_dto(): PromptDto {
 		return $this->prompt;
 	}
 

--- a/includes/Domain/Prompts/McpPrompt.php
+++ b/includes/Domain/Prompts/McpPrompt.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * WordPress MCP Prompt class for representing MCP prompts according to the specification.
+ * MCP Prompt component.
  *
  * @package McpAdapter
  */
@@ -9,453 +10,465 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Prompts;
 
-use WP\MCP\Core\McpServer;
+use WP\MCP\Domain\Contracts\McpComponentInterface;
+use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
+use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
+use WP\MCP\Domain\Utils\McpValidator;
+use WP\MCP\Infrastructure\Observability\FailureReason;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 
 /**
- * Represents an MCP prompt according to the Model Context Protocol specification.
+ * Prompt component providing unified execution and permission checks.
  *
- * Prompts provide structured messages and instructions for interacting with language models.
- * Each prompt is uniquely identified by a name and can include arguments for customization.
+ * This class supports multiple ways to register prompts:
  *
- * @link https://modelcontextprotocol.io/specification/2025-06-18/server/prompts
+ * 1. Array configuration:
+ * ```php
+ * $prompt = McpPrompt::fromArray([
+ *     'name'        => 'code-review',
+ *     'title'       => 'Code Review',
+ *     'description' => 'Generate a comprehensive code review',
+ *     'arguments'   => [
+ *         ['name' => 'code', 'description' => 'The code to review', 'required' => true],
+ *     ],
+ *     'handler'     => fn($args) => ['messages' => [...]],
+ *     'permission'  => fn() => true,
+ * ]);
+ * ```
+ *
+ * 2. From WordPress Ability (ability-backed):
+ * ```php
+ * $prompt = McpPrompt::fromAbility($ability);
+ * ```
+ *
+ * 3. From prompt builder (builder-backed compatibility):
+ * ```php
+ * $prompt = McpPrompt::fromBuilder($builder);
+ * ```
+ *
+ * @since n.e.x.t
  */
-class McpPrompt {
+final class McpPrompt implements McpComponentInterface {
+
+
+	// =========================================================================
+	// Runtime Properties
+	// =========================================================================
 
 	/**
-	 * The ability name.
+	 * Clean Prompt DTO (protocol-only).
 	 *
-	 * @var string
+	 * @var \WP\McpSchema\Server\Prompts\DTO\Prompt
 	 */
-	private string $ability;
+	private Prompt $prompt;
 
 	/**
-	 * Unique identifier for the prompt.
+	 * Ability used for execution/permission checks (ability-backed prompts).
 	 *
-	 * @var string
+	 * @var \WP_Ability|null
 	 */
-	private string $name;
+	private ?\WP_Ability $ability = null;
 
 	/**
-	 * Optional human-readable name of the prompt for display purposes.
+	 * Builder instance (builder-backed prompts).
 	 *
-	 * @var string|null
+	 * @var \WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface|null
 	 */
-	private ?string $title;
+	private ?McpPromptBuilderInterface $builder = null;
 
 	/**
-	 * Optional human-readable description of the prompt.
+	 * Direct execution handler (callable-backed prompts).
 	 *
-	 * @var string|null
+	 * @var callable|null
 	 */
-	private ?string $description;
+	private $handler = null;
 
 	/**
-	 * Optional list of arguments for prompt customization.
+	 * Direct permission callback (callable-backed prompts).
 	 *
-	 * @var array
+	 * @var callable|null
 	 */
-	private array $arguments;
+	private $permission_callback = null;
 
 	/**
-	 * Optional properties describing prompt metadata.
+	 * Internal adapter metadata (never exposed to clients).
 	 *
-	 * @var array
+	 * @var array<string, mixed>
 	 */
-	private array $annotations;
+	private array $adapter_meta = array();
 
 	/**
-	 * The MCP server instance this prompt belongs to.
+	 * Observability context tags for logging/metrics.
 	 *
-	 * @var \WP\MCP\Core\McpServer|null
+	 * @var array<string, mixed>
 	 */
-	private ?McpServer $mcp_server = null;
+	private array $observability_context = array();
+
+	// =========================================================================
+	// Constructor
+	// =========================================================================
 
 	/**
-	 * Constructor for McpPrompt.
+	 * Private constructor - use factory methods.
 	 *
-	 * @param string      $ability The ability name.
-	 * @param string      $name Unique identifier for the prompt.
-	 * @param string|null $title Optional human-readable name for display.
-	 * @param string|null $description Optional human-readable description.
-	 * @param array       $arguments Optional list of arguments for customization.
-	 * @param array       $annotations Optional properties describing prompt metadata.
+	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The Prompt DTO.
 	 */
-	public function __construct(
-		string $ability,
-		string $name,
-		?string $title = null,
-		?string $description = null,
-		array $arguments = array(),
-		array $annotations = array()
-	) {
-		$this->ability     = $ability;
-		$this->name        = $name;
-		$this->title       = $title;
-		$this->description = $description;
-		$this->arguments   = $arguments;
-		$this->annotations = $annotations;
+	private function __construct( Prompt $prompt ) {
+		$this->prompt = $prompt;
 	}
 
-	/**
-	 * Get the prompt name.
-	 *
-	 * @return string
-	 */
-	public function get_name(): string {
-		return $this->name;
-	}
+	// =========================================================================
+	// Factory Methods
+	// =========================================================================
 
 	/**
-	 * Get the prompt title.
+	 * Create a prompt definition from an array configuration.
 	 *
-	 * @return string|null
-	 */
-	public function get_title(): ?string {
-		return $this->title;
-	}
-
-	/**
-	 * Get the prompt description.
+	 * @param array $config The prompt configuration array.
 	 *
-	 * @return string|null
+	 * @return self|\WP_Error
 	 */
-	public function get_description(): ?string {
-		return $this->description;
-	}
-
-	/**
-	 * Get the prompt arguments.
-	 *
-	 * @return array
-	 */
-	public function get_arguments(): array {
-		return $this->arguments;
-	}
-
-	/**
-	 * Get the annotations.
-	 *
-	 * @return array
-	 */
-	public function get_annotations(): array {
-		return $this->annotations;
-	}
-
-	/**
-	 * Get the ability name.
-	 *
-	 * @return \WP_Ability|\WP_Error WP_Ability instance on success, WP_Error on failure.
-	 */
-	public function get_ability() {
-		$ability = wp_get_ability( $this->ability );
-		if ( ! $ability ) {
-			return new \WP_Error(
-				'ability_not_found',
-				sprintf(
-					/* translators: %s: ability name */
-					esc_html__( "WordPress ability '%s' does not exist.", 'mcp-adapter' ),
-					esc_html( $this->ability )
-				)
-			);
+	public static function fromArray( array $config ) {
+		if ( empty( $config['name'] ) ) {
+			return new \WP_Error( 'mcp_prompt_missing_name', 'Prompt configuration must include a "name" field.' );
 		}
-		return $ability;
-	}
 
-	/**
-	 * Set the prompt title.
-	 *
-	 * @param string|null $title The title to set.
-	 *
-	 * @return void
-	 */
-	public function set_title( ?string $title ): void {
-		$this->title = $title;
-	}
+		if ( ! isset( $config['handler'] ) || ! is_callable( $config['handler'] ) ) {
+			return new \WP_Error( 'mcp_prompt_missing_handler', 'Prompt configuration must include a callable "handler" field.' );
+		}
 
-	/**
-	 * Set the prompt description.
-	 *
-	 * @param string|null $description The description to set.
-	 *
-	 * @return void
-	 */
-	public function set_description( ?string $description ): void {
-		$this->description = $description;
-	}
-
-	/**
-	 * Set the prompt arguments.
-	 *
-	 * @param array $arguments The arguments to set.
-	 *
-	 * @return void
-	 */
-	public function set_arguments( array $arguments ): void {
-		$this->arguments = $arguments;
-	}
-
-	/**
-	 * Set the annotations.
-	 *
-	 * @param array $annotations The annotations to set.
-	 *
-	 * @return void
-	 */
-	public function set_annotations( array $annotations ): void {
-		$this->annotations = $annotations;
-	}
-
-	/**
-	 * Add an argument to the prompt.
-	 *
-	 * @param array $argument The argument to add.
-	 *
-	 * @return void
-	 */
-	public function add_argument( array $argument ): void {
-		$this->arguments[] = $argument;
-	}
-
-	/**
-	 * Remove an argument by name.
-	 *
-	 * @param string $name The argument name to remove.
-	 *
-	 * @return void
-	 */
-	public function remove_argument( string $name ): void {
-		$this->arguments = array_filter(
-			$this->arguments,
-			static function ( $argument ) use ( $name ) {
-				return ( $argument['name'] ?? '' ) !== $name;
-			}
-		);
-		// Re-index array.
-		$this->arguments = array_values( $this->arguments );
-	}
-
-	/**
-	 * Get an argument by name.
-	 *
-	 * @param string $name The argument name.
-	 *
-	 * @return array|null The argument if found, null otherwise.
-	 */
-	public function get_argument( string $name ): ?array {
-		foreach ( $this->arguments as $argument ) {
-			if ( ( $argument['name'] ?? '' ) === $name ) {
-				return $argument;
+		// Validate and prepare icons if set.
+		$valid_icons = null;
+		if ( isset( $config['icons'] ) && is_array( $config['icons'] ) && ! empty( $config['icons'] ) ) {
+			$icons_result = McpValidator::validate_icons_array( $config['icons'] );
+			if ( ! empty( $icons_result['valid'] ) ) {
+				$valid_icons = $icons_result['valid'];
 			}
 		}
 
-		return null;
-	}
-
-	/**
-	 * Check if an argument exists.
-	 *
-	 * @param string $name The argument name.
-	 *
-	 * @return bool True if argument exists, false otherwise.
-	 */
-	public function has_argument( string $name ): bool {
-		return $this->get_argument( $name ) !== null;
-	}
-
-	/**
-	 * Add an annotation.
-	 *
-	 * @param string $key The annotation key.
-	 * @param mixed  $value The annotation value.
-	 *
-	 * @return void
-	 */
-	public function add_annotation( string $key, $value ): void {
-		$this->annotations[ $key ] = $value;
-	}
-
-	/**
-	 * Remove an annotation.
-	 *
-	 * @param string $key The annotation key to remove.
-	 *
-	 * @return void
-	 */
-	public function remove_annotation( string $key ): void {
-		unset( $this->annotations[ $key ] );
-	}
-
-	/**
-	 * Convert the prompt to an array representation according to MCP specification.
-	 *
-	 * @return array
-	 */
-	public function to_array(): array {
 		$prompt_data = array(
-			'name' => $this->name,
+			'name'        => $config['name'],
+			'description' => $config['description'] ?? null,
 		);
 
-		// Add optional fields only if they have values.
-		if ( ! is_null( $this->title ) ) {
-			$prompt_data['title'] = $this->title;
+		if ( isset( $config['title'] ) ) {
+			$prompt_data['title'] = $config['title'];
 		}
 
-		if ( ! is_null( $this->description ) ) {
-			$prompt_data['description'] = $this->description;
+		if ( isset( $config['meta'] ) && is_array( $config['meta'] ) && ! empty( $config['meta'] ) ) {
+			$prompt_data['_meta'] = $config['meta'];
 		}
 
-		if ( ! empty( $this->arguments ) ) {
-			$prompt_data['arguments'] = $this->arguments;
+		if ( null !== $valid_icons ) {
+			$prompt_data['icons'] = $valid_icons;
 		}
 
-		if ( ! empty( $this->annotations ) ) {
-			$prompt_data['annotations'] = $this->annotations;
-		}
+		// Create the Prompt DTO - wrap in try-catch since PromptArgument::fromArray() and Prompt::fromArray() can throw.
+		try {
+			// Process arguments inside try-catch since PromptArgument::fromArray() can throw.
+			if ( isset( $config['arguments'] ) && is_array( $config['arguments'] ) && ! empty( $config['arguments'] ) ) {
+				$prompt_data['arguments'] = array_map(
+					static function ( array $arg ): PromptArgument {
+						return PromptArgument::fromArray(
+							array(
+								'name'        => $arg['name'],
+								'title'       => $arg['title'] ?? null,
+								'description' => $arg['description'] ?? null,
+								'required'    => $arg['required'] ?? null,
+							)
+						);
+					},
+					$config['arguments']
+				);
+			}
 
-		return $prompt_data;
-	}
-
-	/**
-	 * Convert the prompt to JSON representation.
-	 *
-	 * @return string
-	 */
-	public function to_json(): string {
-		$json = wp_json_encode( $this->to_array() );
-		return false !== $json ? $json : '{}';
-	}
-
-	/**
-	 * Create an McpPrompt instance from an array.
-	 *
-	 * @param array     $data Array containing prompt data.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server instance.
-	 *
-	 * @return self|\WP_Error Returns a new McpPrompt instance or WP_Error if validation fails.
-	 */
-	public static function from_array( array $data, McpServer $mcp_server ) {
-		$prompt = new self(
-			$data['ability'] ?? '',
-			$data['name'] ?? '',
-			$data['title'] ?? null,
-			$data['description'] ?? null,
-			$data['arguments'] ?? array(),
-			$data['annotations'] ?? array()
-		);
-
-		$prompt->set_mcp_server( $mcp_server );
-
-		return $prompt->validate( "McpPrompt::from_array::{$data['name']}" );
-	}
-
-	/**
-	 * Validate the prompt instance.
-	 *
-	 * @param string $context Optional context for error messages.
-	 *
-	 * @return self|\WP_Error Returns the validated prompt instance or WP_Error if validation fails.
-	 */
-	public function validate( string $context = '' ) {
-		if ( null === $this->mcp_server ) {
+			$prompt = Prompt::fromArray( $prompt_data );
+		} catch ( \Throwable $e ) {
 			return new \WP_Error(
-				'prompt_missing_mcp_server',
-				esc_html__( 'MCP server must be set before validating a prompt.', 'mcp-adapter' )
+				'mcp_prompt_dto_creation_failed',
+				sprintf(
+				/* translators: %s: error message */
+					__( 'Failed to create Prompt DTO: %s', 'mcp-adapter' ),
+					$e->getMessage()
+				),
+				array( 'exception' => $e )
 			);
 		}
 
-		if ( ! $this->mcp_server->is_mcp_validation_enabled() ) {
-			return $this;
+		// Optional deep validation if enabled.
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		if ( $mcp_validation_enabled ) {
+			$validation_result = McpPromptValidator::validate_prompt_dto( $prompt );
+			if ( is_wp_error( $validation_result ) ) {
+				return $validation_result;
+			}
 		}
 
-		$context_to_use    = $context ?: "McpPrompt::{$this->name}";
-		$validation_result = McpPromptValidator::validate_prompt_instance( $this, $context_to_use );
+		$instance          = new self( $prompt );
+		$instance->handler = $config['handler'];
 
-		if ( is_wp_error( $validation_result ) ) {
-			return $validation_result;
+		if ( isset( $config['permission'] ) && is_callable( $config['permission'] ) ) {
+			$instance->permission_callback = $config['permission'];
 		}
 
-		return $this;
-	}
-
-	/**
-	 * Create a standard argument definition.
-	 *
-	 * @param string      $name The argument name.
-	 * @param string|null $description Optional argument description.
-	 * @param bool        $required Whether the argument is required.
-	 *
-	 * @return array The argument definition.
-	 */
-	public static function create_argument( string $name, ?string $description = null, bool $required = false ): array {
-		$argument = array(
-			'name' => $name,
+		$instance->observability_context = array(
+			'component_type' => 'prompt',
+			'prompt_name'    => $config['name'],
+			'source'         => 'array',
 		);
 
-		if ( ! is_null( $description ) ) {
-			$argument['description'] = $description;
+		return $instance;
+	}
+
+	/**
+	 * Create an ability-backed MCP prompt.
+	 *
+	 * @param \WP_Ability $ability WordPress ability.
+	 *
+	 * @return self|\WP_Error
+	 */
+	public static function fromAbility( \WP_Ability $ability ) {
+		$prompt_data = RegisterAbilityAsMcpPrompt::build( $ability );
+		if ( $prompt_data instanceof \WP_Error ) {
+			return $prompt_data;
 		}
 
-		if ( $required ) {
-			$argument['required'] = true;
+		$instance               = new self( $prompt_data['prompt'] );
+		$instance->adapter_meta = $prompt_data['adapter_meta'];
+		$instance->ability      = $ability;
+
+		$instance->observability_context = array(
+			'component_type' => 'prompt',
+			'prompt_name'    => $prompt_data['prompt']->getName(),
+			'ability_name'   => $ability->get_name(),
+			'source'         => 'ability',
+		);
+
+		return $instance;
+	}
+
+	/**
+	 * Create a builder-backed MCP prompt.
+	 *
+	 * @param \WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface $builder Builder instance.
+	 *
+	 * @return self|\WP_Error
+	 */
+	public static function fromBuilder( McpPromptBuilderInterface $builder ) {
+		try {
+			$prompt = $builder->build();
+		} catch ( \Throwable $throwable ) {
+			return new \WP_Error(
+				'mcp_prompt_builder_failed',
+				$throwable->getMessage(),
+				array( 'error_type' => get_class( $throwable ) )
+			);
 		}
 
-		return $argument;
-	}
-
-	/**
-	 * Get the MCP server instance this tool belongs to.
-	 *
-	 * @return \WP\MCP\Core\McpServer
-	 */
-	public function get_mcp_server(): McpServer {
-		if ( null === $this->mcp_server ) {
-			throw new \RuntimeException( 'MCP server has not been set on this prompt instance.' );
+		// Optional deep validation if enabled.
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		if ( $mcp_validation_enabled ) {
+			$validation_result = McpPromptValidator::validate_prompt_dto( $prompt );
+			if ( is_wp_error( $validation_result ) ) {
+				return $validation_result;
+			}
 		}
 
-		return $this->mcp_server;
+		$instance          = new self( $prompt );
+		$instance->builder = $builder;
+
+		$instance->adapter_meta = array(
+			'source'        => 'builder',
+			'builder_class' => get_class( $builder ),
+		);
+
+		$instance->observability_context = array(
+			'component_type' => 'prompt',
+			'prompt_name'    => $prompt->getName(),
+			'source'         => 'builder',
+		);
+
+		return $instance;
+	}
+
+	// =========================================================================
+	// McpComponentInterface Implementation
+	// =========================================================================
+
+	/**
+	 * Get the clean protocol DTO for MCP responses.
+	 *
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt
+	 */
+	public function get_component(): Prompt {
+		return $this->prompt;
 	}
 
 	/**
-	 * Set the MCP server instance this tool belongs to.
+	 * Execute the prompt.
 	 *
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server instance.
+	 * @param mixed $arguments Prompt arguments.
 	 *
-	 * @return void
+	 * @return mixed
 	 */
-	public function set_mcp_server( McpServer $mcp_server ): void {
-		$this->mcp_server = $mcp_server;
+	public function execute( $arguments ) {
+		$args = $this->unwrap_input_if_needed( $arguments );
+		$args = is_array( $args ) ? $args : array();
+
+		if ( null !== $this->ability ) {
+			$args = AbilityArgumentNormalizer::normalize( $this->ability, $args );
+
+			try {
+				$result = $this->ability->execute( $args );
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_execution_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		} elseif ( null !== $this->builder ) {
+			try {
+				$result = $this->builder->handle( $args );
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_execution_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		} elseif ( null !== $this->handler ) {
+			try {
+				$result = call_user_func( $this->handler, $args );
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_execution_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		} else {
+			return new \WP_Error( 'mcp_prompt_no_handler', 'No prompt execution strategy configured.' );
+		}
+
+		if ( $result instanceof \WP_Error ) {
+			return $result;
+		}
+
+		if ( ! is_array( $result ) ) {
+			$result = array( 'result' => $result );
+		}
+
+		return $result;
 	}
 
 	/**
-	 * Check if this prompt is builder-based (has direct execution capability).
+	 * Unwrap prompt input arguments when the input schema was transformed (flattened → object wrapper).
 	 *
-	 * @return bool True if this prompt can execute directly, false if it needs abilities.
+	 * @param mixed $arguments Raw prompt arguments.
+	 *
+	 * @return mixed
 	 */
-	public function is_builder_based(): bool {
-		return false; // Default: requires abilities
+	private function unwrap_input_if_needed( $arguments ) {
+		$is_transformed = true === ( $this->adapter_meta['input_schema_transformed'] ?? false );
+
+		if ( ! $is_transformed ) {
+			return $arguments;
+		}
+
+		$wrapper = $this->adapter_meta['input_schema_wrapper'] ?? 'input';
+		$wrapper = is_string( $wrapper ) && '' !== trim( $wrapper ) ? $wrapper : 'input';
+
+		return is_array( $arguments ) ? ( $arguments[ $wrapper ] ?? null ) : null;
 	}
 
 	/**
-	 * Execute the prompt directly (for builder-based prompts).
+	 * Check whether the current request has permission to execute this prompt.
 	 *
-	 * @param array $arguments The arguments passed to the prompt.
+	 * @param mixed $arguments Prompt arguments.
 	 *
-	 * @return array The prompt response.
-	 * @throws \Exception If this prompt is not builder-based.
+	 * @return bool|\WP_Error
 	 */
-	public function execute_direct( array $arguments ): array {
-		throw new \Exception( 'This prompt does not support direct execution' );
+	public function check_permission( $arguments ) {
+		$args = $this->unwrap_input_if_needed( $arguments );
+		$args = is_array( $args ) ? $args : array();
+
+		if ( null !== $this->ability ) {
+			$args = AbilityArgumentNormalizer::normalize( $this->ability, $args );
+
+			try {
+				return $this->ability->check_permissions( $args );
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_permission_check_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		}
+
+		if ( null !== $this->builder ) {
+			try {
+				return $this->builder->has_permission( $args );
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_permission_check_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		}
+
+		if ( null !== $this->permission_callback ) {
+			try {
+				$result = call_user_func( $this->permission_callback, $args );
+
+				return $result instanceof \WP_Error ? $result : (bool) $result;
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_permission_check_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		}
+
+		return new \WP_Error(
+			'mcp_permission_denied',
+			'Access denied.',
+			array( 'failure_reason' => FailureReason::NO_PERMISSION_STRATEGY )
+		);
 	}
 
 	/**
-	 * Check permission directly (for builder-based prompts).
+	 * Get internal adapter metadata for this prompt.
 	 *
-	 * @param array $arguments The arguments passed to the prompt.
-	 *
-	 * @return bool True if execution is allowed.
-	 * @throws \Exception If this prompt is not builder-based.
+	 * @return array<string, mixed>
 	 */
-	public function check_permission_direct( array $arguments ): bool {
-		throw new \Exception( 'This prompt does not support direct permission checking' );
+	public function get_adapter_meta(): array {
+		return $this->adapter_meta;
+	}
+
+	/**
+	 * Get observability context tags for logging/metrics.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_observability_context(): array {
+		return $this->observability_context;
+	}
+
+	// =========================================================================
+	// Private Helper Methods
+	// =========================================================================
+
+	/**
+	 * Get the underlying builder instance, when builder-backed.
+	 *
+	 * @return \WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface|null
+	 */
+	public function get_builder(): ?McpPromptBuilderInterface {
+		return $this->builder;
 	}
 }

--- a/includes/Domain/Prompts/McpPromptBuilder.php
+++ b/includes/Domain/Prompts/McpPromptBuilder.php
@@ -11,7 +11,7 @@ namespace WP\MCP\Domain\Prompts;
 
 use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
 use WP\MCP\Domain\Utils\McpValidator;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 
 /**
@@ -127,9 +127,9 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * Safe to call multiple times - always returns a fresh DTO based on
 	 * the current (immutable after construction) state.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt The built prompt DTO.
+	 * @return PromptDto The built prompt DTO.
 	 */
-	public function build(): Prompt {
+	public function build(): PromptDto {
 		$argument_dtos = null;
 		if ( ! empty( $this->arguments ) ) {
 			$argument_dtos = array_map(
@@ -172,7 +172,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 			$prompt_data['icons'] = $valid_icons;
 		}
 
-		return Prompt::fromArray( $prompt_data );
+		return PromptDto::fromArray( $prompt_data );
 	}
 
 	/**

--- a/includes/Domain/Prompts/McpPromptBuilder.php
+++ b/includes/Domain/Prompts/McpPromptBuilder.php
@@ -127,7 +127,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * Safe to call multiple times - always returns a fresh DTO based on
 	 * the current (immutable after construction) state.
 	 *
-	 * @return PromptDto The built prompt DTO.
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt The built prompt DTO.
 	 */
 	public function build(): PromptDto {
 		$argument_dtos = null;

--- a/includes/Domain/Prompts/McpPromptBuilder.php
+++ b/includes/Domain/Prompts/McpPromptBuilder.php
@@ -10,24 +10,52 @@ declare( strict_types=1 );
 namespace WP\MCP\Domain\Prompts;
 
 use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
+use WP\MCP\Domain\Utils\McpValidator;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 
 /**
  * Abstract base class for building MCP prompts.
  *
- * Extend this class to create custom prompts that can be registered
- * directly with McpServer without requiring WordPress abilities.
+ * @deprecated Use {@see \WP\MCP\Domain\Prompts\McpPrompt} instead for creating prompts.
+ *
+ * The fluent API or array configuration provided by McpPrompt is simpler
+ * and more flexible than subclassing this abstract class:
+ *
+ * ```php
+ * // Fluent API (preferred)
+ * $prompt = McpPrompt::create('my-prompt')
+ *     ->title('My Prompt')
+ *     ->argument('input', 'Input text', true)
+ *     ->handler(function(array $args): array {
+ *         return ['messages' => [...]];
+ *     });
+ *
+ * // Array configuration (WordPress-style)
+ * $prompt = McpPrompt::fromArray([
+ *     'name'      => 'my-prompt',
+ *     'title'     => 'My Prompt',
+ *     'arguments' => [['name' => 'input', 'description' => 'Input text', 'required' => true]],
+ *     'handler'   => function(array $args): array { return [...]; },
+ * ]);
+ * ```
+ *
+ * This class remains functional for backward compatibility but will be
+ * removed in a future major version.
+ *
+ * @see McpPrompt For the preferred prompt creation API.
  */
 abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 
 	/**
-	 * The prompt name.
+	 * The prompt name (unique identifier).
 	 *
 	 * @var string
 	 */
-	protected string $name;
+	protected string $name = '';
 
 	/**
-	 * The prompt title.
+	 * The prompt title (human-readable display name).
 	 *
 	 * @var string|null
 	 */
@@ -43,86 +71,108 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	/**
 	 * The prompt arguments.
 	 *
-	 * @var array
+	 * @var array<int, array{name: string, title?: string, description?: string, required?: bool}>
 	 */
 	protected array $arguments = array();
 
 	/**
-	 * The prompt annotations.
+	 * The prompt icons for UI display.
 	 *
-	 * @var array
+	 * @since n.e.x.t
+	 *
+	 * @var array<int, array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}>|null
 	 */
-	protected array $annotations = array();
+	protected ?array $icons = null;
 
 	/**
-	 * Build and return the MCP prompt instance.
+	 * Additional metadata passed through to MCP clients.
 	 *
-	 * @return \WP\MCP\Domain\Prompts\McpPrompt The built prompt.
-	 * @throws \InvalidArgumentException If validation fails.
+	 * Use this to attach purpose-specific metadata that MCP clients can consume.
+	 * Keys are passed through unchanged.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var array<string, mixed>
 	 */
-	public function build(): McpPrompt {
+	protected array $meta = array();
+
+	/**
+	 * Constructor - automatically configures the prompt.
+	 *
+	 * Configuration happens exactly once during construction, ensuring
+	 * idempotent behavior. Subclasses should NOT override this constructor;
+	 * instead, implement the configure() method.
+	 *
+	 * @since n.e.x.t
+	 */
+	final public function __construct() {
 		$this->configure();
+	}
 
-		// Create a synthetic ability name for the prompt
-		// Use empty string if name is empty (validation will catch it)
-		$synthetic_ability = empty( $this->name ) ? 'synthetic/' : 'synthetic/' . $this->name;
+	/**
+	 * Configure the prompt properties.
+	 *
+	 * Subclasses must implement this method to set the name, title,
+	 * description, and arguments for the prompt. This method is called
+	 * exactly once during construction.
+	 *
+	 * @return void
+	 */
+	abstract protected function configure(): void;
 
-		// Create a builder-based prompt that completely bypasses abilities
-		$builder = $this;
-		$prompt  = new class(
-			$synthetic_ability,
-			$this->name,
-			$this->title,
-			$this->description,
-			$this->arguments,
-			$this->annotations,
-			$builder
-		) extends McpPrompt {
-			private McpPromptBuilderInterface $builder;
+	/**
+	 * Build and return the Prompt DTO instance.
+	 *
+	 * This method converts the configured state into an MCP Prompt DTO.
+	 * Safe to call multiple times - always returns a fresh DTO based on
+	 * the current (immutable after construction) state.
+	 *
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt The built prompt DTO.
+	 */
+	public function build(): Prompt {
+		$argument_dtos = null;
+		if ( ! empty( $this->arguments ) ) {
+			$argument_dtos = array_map(
+				static function ( array $arg ): PromptArgument {
+					return PromptArgument::fromArray(
+						array(
+							'name'        => $arg['name'],
+							'title'       => $arg['title'] ?? null,
+							'description' => $arg['description'] ?? null,
+							'required'    => $arg['required'] ?? null,
+						)
+					);
+				},
+				$this->arguments
+			);
+		}
 
-			public function __construct(
-				string $ability,
-				string $name,
-				?string $title,
-				?string $description,
-				array $arguments,
-				array $annotations,
-				McpPromptBuilderInterface $builder
-			) {
-				parent::__construct( $ability, $name, $title, $description, $arguments, $annotations );
-				$this->builder = $builder;
+		// Validate and prepare icons if set.
+		$valid_icons = null;
+		if ( ! empty( $this->icons ) ) {
+			$icons_result = McpValidator::validate_icons_array( $this->icons );
+			if ( ! empty( $icons_result['valid'] ) ) {
+				$valid_icons = $icons_result['valid'];
 			}
+		}
 
-			// This prompt is builder-based and doesn't need abilities
-			public function is_builder_based(): bool {
-				return true;
-			}
+		$prompt_data = array(
+			'name'        => $this->name,
+			'title'       => $this->title,
+			'description' => $this->description,
+			'arguments'   => $argument_dtos,
+		);
 
-			// Direct execution through the builder
-			public function execute_direct( array $arguments ): array {
-				return $this->builder->handle( $arguments );
-			}
+		if ( ! empty( $this->meta ) ) {
+			$prompt_data['_meta'] = $this->meta;
+		}
 
-			// Direct permission checking through the builder
-			public function check_permission_direct( array $arguments ): bool {
-				return $this->builder->has_permission( $arguments );
-			}
+		// Only include icons if valid ones exist.
+		if ( null !== $valid_icons ) {
+			$prompt_data['icons'] = $valid_icons;
+		}
 
-			/**
-			 * Fallback for ability-based execution (should not be used).
-			 *
-			 * @return \WP_Error Always returns an error as builder-based prompts don't have abilities.
-			 */
-			public function get_ability(): \WP_Error {
-				// This should not be called for builder-based prompts
-				return new \WP_Error(
-					'builder_has_no_ability',
-					esc_html__( 'Builder-based prompts do not have an associated ability.', 'mcp-adapter' )
-				);
-			}
-		};
-
-		return $prompt;
+		return Prompt::fromArray( $prompt_data );
 	}
 
 	/**
@@ -131,10 +181,6 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * @return string The prompt name.
 	 */
 	public function get_name(): string {
-		if ( empty( $this->name ) ) {
-			$this->configure();
-		}
-
 		return $this->name;
 	}
 
@@ -144,10 +190,6 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * @return string|null The prompt title.
 	 */
 	public function get_title(): ?string {
-		if ( empty( $this->name ) ) {
-			$this->configure();
-		}
-
 		return $this->title;
 	}
 
@@ -157,57 +199,87 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * @return string|null The prompt description.
 	 */
 	public function get_description(): ?string {
-		if ( empty( $this->name ) ) {
-			$this->configure();
-		}
-
 		return $this->description;
 	}
 
 	/**
 	 * Get the prompt arguments.
 	 *
-	 * @return array The prompt arguments.
+	 * @return array<int, array{name: string, title?: string, description?: string, required?: bool}> The prompt arguments.
 	 */
 	public function get_arguments(): array {
-		if ( empty( $this->name ) ) {
-			$this->configure();
-		}
-
 		return $this->arguments;
 	}
 
 	/**
-	 * Get the prompt annotations.
+	 * Get the prompt icons.
 	 *
-	 * @return array The prompt annotations.
+	 * @return array<int, array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}> The prompt icons.
+	 * @since n.e.x.t
+	 *
 	 */
-	public function get_annotations(): array {
-		if ( empty( $this->name ) ) {
-			$this->configure();
-		}
-
-		return $this->annotations;
+	public function get_icons(): array {
+		return $this->icons ?? array();
 	}
 
 	/**
-	 * Configure the prompt properties.
+	 * Set the prompt icons for UI display.
 	 *
-	 * Subclasses must implement this method to set the name, title,
-	 * description, and arguments for the prompt.
+	 * Icons are validated during build() using McpValidator::validate_icons_array().
+	 * Invalid icons are filtered out with warnings (graceful degradation).
 	 *
-	 * @return void
+	 * Per MCP 2025-11-25:
+	 * - MUST support: image/png, image/jpeg, image/jpg
+	 * - SHOULD support: image/svg+xml, image/webp
+	 *
+	 * @param array<int, array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}> $icons Array of icon definitions.
+	 *
+	 * @return self
+	 * @since n.e.x.t
+	 *
 	 */
-	abstract protected function configure(): void;
+	protected function set_icons( array $icons ): self {
+		$this->icons = $icons;
+
+		return $this;
+	}
+
+	/**
+	 * Get the additional metadata.
+	 *
+	 * @return array<string, mixed> The additional metadata.
+	 * @since n.e.x.t
+	 *
+	 */
+	public function get_meta(): array {
+		return $this->meta;
+	}
+
+	/**
+	 * Set additional metadata.
+	 *
+	 * This metadata is passed through to MCP clients unchanged.
+	 *
+	 * @param array<string, mixed> $meta Additional metadata key-value pairs.
+	 *
+	 * @return self
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function set_meta( array $meta ): self {
+		$this->meta = $meta;
+
+		return $this;
+	}
 
 	/**
 	 * Handle the prompt execution when called.
 	 *
 	 * Subclasses must implement this method to handle the prompt logic.
 	 *
-	 * @param array $arguments The arguments passed to the prompt.
+	 * @param array<string, mixed> $arguments The arguments passed to the prompt.
 	 *
-	 * @return array The prompt response.
+	 * @return array<string, mixed> The prompt response.
 	 */
 	abstract public function handle( array $arguments ): array;
 
@@ -217,7 +289,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * Default implementation allows all executions. Override this method
 	 * to implement custom permission logic.
 	 *
-	 * @param array $arguments The arguments passed to the prompt.
+	 * @param array<string, mixed> $arguments The arguments passed to the prompt.
 	 *
 	 * @return bool True if execution is allowed, false otherwise.
 	 */
@@ -228,20 +300,35 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	}
 
 	/**
+	 * Helper method to add an argument to the prompt.
+	 *
+	 * @param string $name The argument name.
+	 * @param string|null $description Optional argument description.
+	 * @param bool $required Whether the argument is required.
+	 *
+	 * @return self
+	 */
+	protected function add_argument( string $name, ?string $description = null, bool $required = false ): self {
+		$this->arguments[] = $this->create_argument( $name, $description, $required );
+
+		return $this;
+	}
+
+	/**
 	 * Helper method to create an argument definition.
 	 *
-	 * @param string      $name The argument name.
+	 * @param string $name The argument name.
 	 * @param string|null $description Optional argument description.
-	 * @param bool        $required Whether the argument is required.
+	 * @param bool $required Whether the argument is required.
 	 *
-	 * @return array The argument definition.
+	 * @return array{name: string, description?: string, required?: true} The argument definition.
 	 */
 	protected function create_argument( string $name, ?string $description = null, bool $required = false ): array {
 		$argument = array(
 			'name' => $name,
 		);
 
-		if ( ! is_null( $description ) ) {
+		if ( null !== $description ) {
 			$argument['description'] = $description;
 		}
 
@@ -250,20 +337,5 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 		}
 
 		return $argument;
-	}
-
-	/**
-	 * Helper method to add an argument to the prompt.
-	 *
-	 * @param string      $name The argument name.
-	 * @param string|null $description Optional argument description.
-	 * @param bool        $required Whether the argument is required.
-	 *
-	 * @return self
-	 */
-	protected function add_argument( string $name, ?string $description = null, bool $required = false ): self {
-		$this->arguments[] = $this->create_argument( $name, $description, $required );
-
-		return $this;
 	}
 }

--- a/includes/Domain/Prompts/McpPromptValidator.php
+++ b/includes/Domain/Prompts/McpPromptValidator.php
@@ -11,6 +11,7 @@ namespace WP\MCP\Domain\Prompts;
 
 use WP\MCP\Domain\Resources\McpResourceValidator;
 use WP\MCP\Domain\Utils\McpValidator;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
 
 /**
  * Validates MCP prompts against the Model Context Protocol specification.
@@ -18,7 +19,7 @@ use WP\MCP\Domain\Utils\McpValidator;
  * Provides minimal, resource-efficient validation to ensure prompts conform
  * to the MCP schema requirements without heavy processing overhead.
  *
- * @link https://modelcontextprotocol.io/specification/2025-06-18/server/prompts
+ * @link https://modelcontextprotocol.io/specification/2025-11-25/server/prompts
  */
 class McpPromptValidator {
 
@@ -40,7 +41,49 @@ class McpPromptValidator {
 				__( 'Prompt validation failed: %s', 'mcp-adapter' ),
 				implode( ', ', $validation_errors )
 			);
-			return new \WP_Error( 'prompt_validation_failed', esc_html( $error_message ) );
+			return new \WP_Error( 'mcp_prompt_validation_failed', esc_html( $error_message ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate a Prompt DTO against the MCP schema.
+	 *
+	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The prompt DTO to validate.
+	 *
+	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
+	 */
+	public static function validate_prompt_dto( Prompt $prompt ) {
+		$errors = array();
+
+		// Validate name.
+		if ( ! McpValidator::validate_name( $prompt->getName() ) ) {
+			$errors[] = __( 'Prompt name must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'mcp-adapter' );
+		}
+
+		// Validate icons if present.
+		$icons = $prompt->getIcons();
+		if ( ! empty( $icons ) ) {
+			$icons_array  = array_map( static fn( $icon ) => $icon->toArray(), $icons );
+			$icons_result = McpValidator::validate_icons_array( $icons_array );
+			$icons_errors = self::format_icon_validation_errors( $icons_result );
+			$errors       = array_merge( $errors, $icons_errors );
+		}
+
+		// Validate annotations if present (shared annotations).
+		// Currently Prompt DTO doesn't have annotations field in spec, but if it did, we'd validate here.
+		// BaseMetadata has title and name, handled separately.
+
+		if ( ! empty( $errors ) ) {
+			return new \WP_Error(
+				'mcp_prompt_validation_failed',
+				sprintf(
+				/* translators: %s: list of validation errors */
+					__( 'Prompt validation failed: %s', 'mcp-adapter' ),
+					implode( '; ', $errors )
+				)
+			);
 		}
 
 		return true;
@@ -50,42 +93,13 @@ class McpPromptValidator {
 	 * Validate an McpPrompt instance against the MCP schema.
 	 *
 	 * @param \WP\MCP\Domain\Prompts\McpPrompt $prompt The prompt instance to validate.
-	 * @param string    $context Optional context for error messages.
 	 *
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
-	public static function validate_prompt_instance( McpPrompt $prompt, string $context = '' ) {
-		$uniqueness_result = self::validate_prompt_uniqueness( $prompt, $context );
-		if ( is_wp_error( $uniqueness_result ) ) {
-			return $uniqueness_result;
-		}
-
-		return self::validate_prompt_data( $prompt->to_array(), $context );
+	public static function validate_prompt_instance( McpPrompt $prompt ) {
+		return self::validate_prompt_dto( $prompt->get_component() );
 	}
 
-	/**
-	 * Validate that the resource is unique within the MCP server.
-	 *
-	 * @param \WP\MCP\Domain\Prompts\McpPrompt $prompt The resource instance to validate.
-	 * @param string    $context Optional context for error messages.
-	 *
-	 * @return bool|\WP_Error True if unique, WP_Error if the prompt name is not unique.
-	 */
-	public static function validate_prompt_uniqueness( McpPrompt $prompt, string $context = '' ) {
-		$this_prompt_name  = $prompt->get_name();
-		$existing_resource = $prompt->get_mcp_server()->get_prompt( $this_prompt_name );
-		if ( $existing_resource ) {
-			$error_message  = $context ? "[{$context}] " : '';
-			$error_message .= sprintf(
-			/* translators: %s is the prompt name */
-				__( "Prompt name '%s' is not unique. It already exists in the MCP server.", 'mcp-adapter' ),
-				$this_prompt_name
-			);
-			return new \WP_Error( 'prompt_not_unique', esc_html( $error_message ) );
-		}
-
-		return true;
-	}
 
 	/**
 	 * Get validation error details for debugging purposes.
@@ -98,20 +112,9 @@ class McpPromptValidator {
 	public static function get_validation_errors( array $prompt_data ): array {
 		$errors = array();
 
-		// Sanitize string inputs
-		if ( isset( $prompt_data['name'] ) && is_string( $prompt_data['name'] ) ) {
-			$prompt_data['name'] = trim( $prompt_data['name'] );
-		}
-		if ( isset( $prompt_data['title'] ) && is_string( $prompt_data['title'] ) ) {
-			$prompt_data['title'] = trim( $prompt_data['title'] );
-		}
-		if ( isset( $prompt_data['description'] ) && is_string( $prompt_data['description'] ) ) {
-			$prompt_data['description'] = trim( $prompt_data['description'] );
-		}
-
 		// Check required fields
-		if ( empty( $prompt_data['name'] ) || ! is_string( $prompt_data['name'] ) || ! McpValidator::validate_tool_or_prompt_name( $prompt_data['name'] ) ) {
-			$errors[] = __( 'Prompt name is required and must only contain letters, numbers, hyphens (-), and underscores (_), and be 255 characters or less', 'mcp-adapter' );
+		if ( empty( $prompt_data['name'] ) || ! is_string( $prompt_data['name'] ) || ! McpValidator::validate_name( $prompt_data['name'] ) ) {
+			$errors[] = __( 'Prompt name is required and must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'mcp-adapter' );
 		}
 
 		// Check optional fields if present
@@ -128,18 +131,6 @@ class McpPromptValidator {
 			$arguments_errors = self::get_arguments_validation_errors( $prompt_data['arguments'] );
 			if ( ! empty( $arguments_errors ) ) {
 				$errors = array_merge( $errors, $arguments_errors );
-			}
-		}
-
-		// Validate annotations structure if present.
-		if ( isset( $prompt_data['annotations'] ) ) {
-			if ( ! is_array( $prompt_data['annotations'] ) ) {
-				$errors[] = __( 'Prompt annotations must be an array if provided', 'mcp-adapter' );
-			} else {
-				$annotation_errors = McpValidator::get_annotation_validation_errors( $prompt_data['annotations'] );
-				if ( ! empty( $annotation_errors ) ) {
-					$errors = array_merge( $errors, $annotation_errors );
-				}
 			}
 		}
 
@@ -182,11 +173,11 @@ class McpPromptValidator {
 				continue;
 			}
 
-			// Validate argument name format
-			if ( ! McpValidator::validate_argument_name( $argument['name'] ) ) {
+			// Validate argument name format (uses standard 128-char limit per MCP spec).
+			if ( ! McpValidator::validate_name( $argument['name'] ) ) {
 				$errors[] = sprintf(
 				/* translators: %s: argument name */
-					__( 'Prompt argument \'%s\' name must only contain letters, numbers, hyphens (-), and underscores (_), and be 64 characters or less', 'mcp-adapter' ),
+					__( 'Prompt argument \'%s\' name must only contain letters, numbers, hyphens (-), underscores (_), and dots (.), and be 128 characters or less', 'mcp-adapter' ),
 					$argument['name']
 				);
 			}
@@ -277,6 +268,32 @@ class McpPromptValidator {
 	}
 
 	/**
+	 * Format icon validation errors from the validation result.
+	 *
+	 * @param array{valid: array, errors: array} $icons_result The result from validate_icons_array.
+	 *
+	 * @return array Array of formatted error messages.
+	 */
+	private static function format_icon_validation_errors( array $icons_result ): array {
+		$errors = array();
+
+		if ( ! empty( $icons_result['errors'] ) ) {
+			foreach ( $icons_result['errors'] as $error_group ) {
+				foreach ( $error_group['errors'] as $error ) {
+					$errors[] = sprintf(
+					/* translators: 1: icon index, 2: error message */
+						__( 'Icon at index %1$d: %2$s', 'mcp-adapter' ),
+						$error_group['index'],
+						$error
+					);
+				}
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
 	 * Get validation errors for message content.
 	 *
 	 * @param array $content The content to validate.
@@ -302,10 +319,10 @@ class McpPromptValidator {
 
 		switch ( $type ) {
 			case 'text':
-				if ( empty( $content['text'] ) || ! is_string( $content['text'] ) ) {
+				if ( ! isset( $content['text'] ) || ! is_string( $content['text'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d text content must have a non-empty text field', 'mcp-adapter' ),
+						__( 'Message %d text content must have a text field', 'mcp-adapter' ),
 						$message_index
 					);
 				}
@@ -371,6 +388,85 @@ class McpPromptValidator {
 				}
 				break;
 
+			case 'resource_link':
+				// ResourceLink is a metadata-only reference (same shape as Resource + type discriminator).
+				if ( empty( $content['name'] ) || ! is_string( $content['name'] ) ) {
+					$errors[] = sprintf(
+					/* translators: %d: message index */
+						__( 'Message %d resource_link content must have a name field', 'mcp-adapter' ),
+						$message_index
+					);
+				}
+
+				if ( empty( $content['uri'] ) || ! is_string( $content['uri'] ) ) {
+					$errors[] = sprintf(
+					/* translators: %d: message index */
+						__( 'Message %d resource_link content must have a uri field', 'mcp-adapter' ),
+						$message_index
+					);
+				} elseif ( ! McpValidator::validate_resource_uri( $content['uri'] ) ) {
+					$errors[] = sprintf(
+					/* translators: %d: message index */
+						__( 'Message %d resource_link content uri must be a valid URI format', 'mcp-adapter' ),
+						$message_index
+					);
+				}
+
+				if ( isset( $content['mimeType'] ) ) {
+					if ( ! is_string( $content['mimeType'] ) ) {
+						$errors[] = sprintf(
+						/* translators: %d: message index */
+							__( 'Message %d resource_link content mimeType must be a string if provided', 'mcp-adapter' ),
+							$message_index
+						);
+					} elseif ( ! McpValidator::validate_mime_type( $content['mimeType'] ) ) {
+						$errors[] = sprintf(
+						/* translators: %d: message index */
+							__( 'Message %d resource_link content mimeType must be a valid MIME type format', 'mcp-adapter' ),
+							$message_index
+						);
+					}
+				}
+
+				if ( isset( $content['size'] ) && ! is_int( $content['size'] ) ) {
+					$errors[] = sprintf(
+					/* translators: %d: message index */
+						__( 'Message %d resource_link content size must be an integer if provided', 'mcp-adapter' ),
+						$message_index
+					);
+				}
+
+				if ( isset( $content['title'] ) && ! is_string( $content['title'] ) ) {
+					$errors[] = sprintf(
+					/* translators: %d: message index */
+						__( 'Message %d resource_link content title must be a string if provided', 'mcp-adapter' ),
+						$message_index
+					);
+				}
+
+				if ( isset( $content['description'] ) && ! is_string( $content['description'] ) ) {
+					$errors[] = sprintf(
+					/* translators: %d: message index */
+						__( 'Message %d resource_link content description must be a string if provided', 'mcp-adapter' ),
+						$message_index
+					);
+				}
+
+				if ( isset( $content['icons'] ) ) {
+					if ( ! is_array( $content['icons'] ) ) {
+						$errors[] = sprintf(
+						/* translators: %d: message index */
+							__( 'Message %d resource_link content icons must be an array if provided', 'mcp-adapter' ),
+							$message_index
+						);
+					} else {
+						$icons_result = McpValidator::validate_icons_array( $content['icons'], false );
+						$errors       = array_merge( $errors, self::format_icon_validation_errors( $icons_result ) );
+					}
+				}
+
+				break;
+
 			case 'resource':
 				if ( empty( $content['resource'] ) || ! is_array( $content['resource'] ) ) {
 					$errors[] = sprintf(
@@ -395,7 +491,7 @@ class McpPromptValidator {
 			default:
 				$errors[] = sprintf(
 				/* translators: %1$d: message index, %2$s: content type */
-					__( 'Message %1$d content type \'%2$s\' is not supported. Must be \'text\', \'image\', \'audio\', or \'resource\'', 'mcp-adapter' ),
+					__( 'Message %1$d content type \'%2$s\' is not supported. Must be \'text\', \'image\', \'audio\', \'resource\', or \'resource_link\'', 'mcp-adapter' ),
 					$message_index,
 					$type
 				);

--- a/includes/Domain/Prompts/McpPromptValidator.php
+++ b/includes/Domain/Prompts/McpPromptValidator.php
@@ -11,7 +11,7 @@ namespace WP\MCP\Domain\Prompts;
 
 use WP\MCP\Domain\Resources\McpResourceValidator;
 use WP\MCP\Domain\Utils\McpValidator;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 
 /**
  * Validates MCP prompts against the Model Context Protocol specification.
@@ -50,11 +50,11 @@ class McpPromptValidator {
 	/**
 	 * Validate a Prompt DTO against the MCP schema.
 	 *
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The prompt DTO to validate.
+	 * @param PromptDto $prompt The prompt DTO to validate.
 	 *
 	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
 	 */
-	public static function validate_prompt_dto( Prompt $prompt ) {
+	public static function validate_prompt_dto( PromptDto $prompt ) {
 		$errors = array();
 
 		// Validate name.
@@ -97,7 +97,7 @@ class McpPromptValidator {
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
 	public static function validate_prompt_instance( McpPrompt $prompt ) {
-		return self::validate_prompt_dto( $prompt->get_component() );
+		return self::validate_prompt_dto( $prompt->get_protocol_dto() );
 	}
 
 

--- a/includes/Domain/Prompts/McpPromptValidator.php
+++ b/includes/Domain/Prompts/McpPromptValidator.php
@@ -50,7 +50,7 @@ class McpPromptValidator {
 	/**
 	 * Validate a Prompt DTO against the MCP schema.
 	 *
-	 * @param PromptDto $prompt The prompt DTO to validate.
+	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The prompt DTO to validate.
 	 *
 	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
 	 */

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * RegisterAbilityAsMcpPrompt class for converting WordPress abilities to MCP prompts.
  *
@@ -7,9 +8,10 @@
 
 namespace WP\MCP\Domain\Prompts;
 
-use WP\MCP\Core\McpServer;
-use WP\MCP\Domain\Utils\McpAnnotationMapper;
-use WP_Ability;
+use WP\MCP\Domain\Utils\McpValidator;
+use WP\MCP\Domain\Utils\SchemaTransformer;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 
 /**
  * Converts WordPress abilities to MCP prompts according to the specification.
@@ -17,8 +19,11 @@ use WP_Ability;
  * This class extracts prompt data from ability properties and converts the JSON Schema
  * input_schema to MCP prompt arguments format.
  *
- * The ability must have an input_schema defined using JSON Schema format, which will
- * be automatically converted to MCP prompt arguments.
+ * Schema Handling:
+ * - Object schemas with properties: Each property becomes a PromptArgument
+ * - Flattened schemas (type: string, number, etc.): Wrapped as single argument named "input"
+ * - Empty/null schemas: No arguments
+ * - Complex schemas (oneOf/anyOf): Treated as no arguments (documented limitation)
  *
  * Example ability registration:
  * wp_register_ability(
@@ -39,89 +44,312 @@ use WP_Ability;
  *         )
  *     )
  * );
+ *
+ * @since n.e.x.t
  */
 class RegisterAbilityAsMcpPrompt {
+
 	/**
 	 * The WordPress ability instance.
 	 *
 	 * @var \WP_Ability
 	 */
-	private WP_Ability $ability;
+	private \WP_Ability $ability;
 
 	/**
-	 * The MCP server.
+	 * Tracks whether input_schema was transformed from flattened to object format.
 	 *
-	 * @var \WP\MCP\Core\McpServer
+	 * @since n.e.x.t
+	 *
+	 * @var bool
 	 */
-	private McpServer $mcp_server;
+	private bool $schema_was_transformed = false;
+
+	/**
+	 * The wrapper property name used when transforming flattened schemas.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var string|null
+	 */
+	private ?string $schema_wrapper_property = null;
+
+	/**
+	 * Tracks the source of prompt arguments.
+	 *
+	 * Possible values:
+	 * - 'explicit': Arguments came from ability.meta.mcp.arguments
+	 * - 'schema': Arguments were auto-converted from ability.input_schema
+	 * - null: No arguments present
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var string|null
+	 */
+	private ?string $arguments_source = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param \WP_Ability $ability The ability.
+	 */
+	private function __construct( \WP_Ability $ability ) {
+		$this->ability = $ability;
+	}
 
 	/**
 	 * Make a new instance of the class.
 	 *
-	 * @param \WP_Ability            $ability    The ability.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
+	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return \WP\MCP\Domain\Prompts\McpPrompt|\WP_Error Returns prompt instance or WP_Error if validation fails.
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|\WP_Error Returns Prompt DTO or WP_Error if validation fails.
 	 */
-	public static function make( WP_Ability $ability, McpServer $mcp_server ) {
-		$prompt = new self( $ability, $mcp_server );
+	public static function make( \WP_Ability $ability ) {
+		$prompt = new self( $ability );
 
 		return $prompt->get_prompt();
 	}
 
 	/**
-	 * Constructor.
+	 * Get the MCP prompt instance.
 	 *
-	 * @param \WP_Ability            $ability    The ability.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|\WP_Error Prompt DTO or WP_Error if validation fails.
+	 * @since n.e.x.t
+	 *
 	 */
-	private function __construct( WP_Ability $ability, McpServer $mcp_server ) {
-		$this->mcp_server = $mcp_server;
-		$this->ability    = $ability;
+	private function get_prompt() {
+		$built = $this->build_prompt_data();
+
+		// Propagate WP_Error from argument validation.
+		if ( is_wp_error( $built ) ) {
+			return $built;
+		}
+
+		try {
+			return Prompt::fromArray( $built['prompt_data'] );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'mcp_prompt_schema_invalid', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Build Prompt DTO data and adapter metadata.
+	 *
+	 * @return array{prompt_data: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @since n.e.x.t
+	 *
+	 */
+	private function build_prompt_data() {
+		$data = $this->get_data();
+
+		// Propagate WP_Error from argument validation.
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		// Get ability meta for icons and user _meta extraction.
+		$ability_meta = $this->ability->get_meta();
+		$mcp_meta     = $ability_meta['mcp'] ?? array();
+
+		// Map icons from ability.meta.mcp.icons if present.
+		// Uses same pattern as tools/resources for consistency.
+		if ( ! empty( $mcp_meta['icons'] ) && is_array( $mcp_meta['icons'] ) ) {
+			$icons_result = McpValidator::validate_icons_array( $mcp_meta['icons'] );
+			if ( ! empty( $icons_result['valid'] ) ) {
+				$data['icons'] = $icons_result['valid'];
+			}
+		}
+
+		// Build adapter metadata, tracking transformation when it occurred.
+		$adapter_meta = array(
+			'ability' => $this->ability->get_name(),
+		);
+
+		// Track arguments source when arguments are present.
+		if ( null !== $this->arguments_source ) {
+			$adapter_meta['arguments_source'] = $this->arguments_source;
+		}
+
+		// Record transformation metadata when schema was wrapped (matches tool behavior).
+		// Only relevant when arguments_source is 'schema'.
+		if ( $this->schema_was_transformed && 'schema' === $this->arguments_source ) {
+			$adapter_meta['input_schema_transformed'] = true;
+			$adapter_meta['input_schema_wrapper']     = $this->schema_wrapper_property;
+		}
+
+		// Preserve user-provided _meta from ability.meta.mcp._meta.
+		$prompt_meta = array();
+		if ( ! empty( $mcp_meta['_meta'] ) && is_array( $mcp_meta['_meta'] ) ) {
+			$prompt_meta = $mcp_meta['_meta'];
+		}
+		if ( ! empty( $prompt_meta ) ) {
+			$data['_meta'] = $prompt_meta;
+		}
+
+		return array(
+			'prompt_data'  => $data,
+			'adapter_meta' => $adapter_meta,
+		);
 	}
 
 	/**
 	 * Get the MCP prompt data array.
 	 *
-	 * @return array<string,mixed>
+	 * Per MCP 2025-11-25 specification, Prompt objects do NOT support annotations at the
+	 * template level. Annotations are only supported on content blocks inside prompt messages
+	 * (messages[].content.annotations).
+	 *
+	 * Arguments Resolution:
+	 * 1. If `ability.meta.mcp.arguments` is defined and non-empty, use it directly (explicit override)
+	 * 2. Otherwise, auto-convert from `ability.input_schema`
+	 *
+	 * This follows the `mcp.*` override pattern used elsewhere (mcp.uri, mcp.icons, mcp.annotations).
+	 *
+	 * @return array<string,mixed>|\WP_Error Prompt data array, or WP_Error if explicit arguments are invalid.
+	 * @since n.e.x.t
+	 *
 	 */
-	private function get_data(): array {
+	private function get_data() {
 		$ability_name = trim( $this->ability->get_name() );
 		$prompt_data  = array(
-			'ability' => $ability_name,
-			'name'    => str_replace( '/', '-', $ability_name ),
+			'name' => str_replace( '/', '-', $ability_name ),
 		);
 
-		// Add optional title from ability label
+		// Add optional title from ability label.
 		$label = trim( $this->ability->get_label() );
 		if ( ! empty( $label ) ) {
 			$prompt_data['title'] = $label;
 		}
 
-		// Add optional description
+		// Add optional description.
 		$description = trim( $this->ability->get_description() );
 		if ( ! empty( $description ) ) {
 			$prompt_data['description'] = $description;
 		}
 
-		$input_schema = $this->ability->get_input_schema();
-		if ( ! empty( $input_schema ) ) {
-			$arguments = $this->convert_input_schema_to_arguments( $input_schema );
+		// Check for explicit mcp.arguments override first.
+		$explicit_arguments = $this->get_explicit_arguments();
+		if ( is_array( $explicit_arguments ) && ! empty( $explicit_arguments ) ) {
+			$arguments = $this->convert_explicit_arguments( $explicit_arguments );
+			if ( is_wp_error( $arguments ) ) {
+				return $arguments;
+			}
 			if ( ! empty( $arguments ) ) {
 				$prompt_data['arguments'] = $arguments;
+				$this->arguments_source   = 'explicit';
 			}
+
+			return $prompt_data;
 		}
 
-		// Map annotations from ability meta to MCP format using unified mapper.
-		$ability_meta = $this->ability->get_meta();
-		if ( ! empty( $ability_meta['annotations'] ) && is_array( $ability_meta['annotations'] ) ) {
-			$mcp_annotations = McpAnnotationMapper::map( $ability_meta['annotations'], 'prompt' );
-			if ( ! empty( $mcp_annotations ) ) {
-				$prompt_data['annotations'] = $mcp_annotations;
+		// Fall back to auto-converting from input_schema.
+		$input_schema = $this->ability->get_input_schema();
+		if ( ! empty( $input_schema ) ) {
+			// Use SchemaTransformer to handle flattened schemas (consistent with tool behavior).
+			$transform = SchemaTransformer::transform_to_object_schema( $input_schema );
+
+			// Track transformation state for _meta.
+			$this->schema_was_transformed  = $transform['was_transformed'];
+			$this->schema_wrapper_property = $transform['wrapper_property'];
+
+			$arguments = $this->convert_input_schema_to_arguments( $transform['schema'] );
+			if ( ! empty( $arguments ) ) {
+				$prompt_data['arguments'] = $arguments;
+				$this->arguments_source   = 'schema';
 			}
 		}
 
 		return $prompt_data;
+	}
+
+	/**
+	 * Get explicit arguments from ability meta.mcp.arguments.
+	 *
+	 * @return array<int,array<string,mixed>>|null Explicit arguments array or null if not defined.
+	 * @since n.e.x.t
+	 *
+	 */
+	private function get_explicit_arguments(): ?array {
+		$meta = $this->ability->get_meta();
+		if ( ! isset( $meta['mcp'] ) || ! is_array( $meta['mcp'] ) ) {
+			return null;
+		}
+
+		$mcp = $meta['mcp'];
+		if ( ! isset( $mcp['arguments'] ) || ! is_array( $mcp['arguments'] ) ) {
+			return null;
+		}
+
+		return $mcp['arguments'];
+	}
+
+	/**
+	 * Convert and validate explicit arguments from ability.meta.mcp.arguments.
+	 *
+	 * Per MCP 2025-11-25 specification, PromptArgument has:
+	 * - name (string, required): Argument identifier
+	 * - title (string, optional): Human-readable display name
+	 * - description (string, optional): Human-readable description
+	 * - required (boolean, optional): Whether the argument must be provided
+	 *
+	 * @param array<int,array<string,mixed>> $explicit_arguments User-defined arguments array.
+	 *
+	 * @return array<int,\WP\McpSchema\Server\Prompts\DTO\PromptArgument>|\WP_Error PromptArgument DTOs or WP_Error.
+	 * @since n.e.x.t
+	 *
+	 */
+	private function convert_explicit_arguments( array $explicit_arguments ) {
+		$arguments = array();
+
+		foreach ( $explicit_arguments as $index => $arg ) {
+			if ( ! is_array( $arg ) ) {
+				return new \WP_Error(
+					'mcp_prompt_invalid_argument',
+					sprintf(
+					/* translators: 1: argument index, 2: ability name */
+						__( 'Argument at index %1$d must be an array for ability "%2$s".', 'mcp-adapter' ),
+						$index,
+						$this->ability->get_name()
+					)
+				);
+			}
+
+			// Validate required 'name' field.
+			if ( ! isset( $arg['name'] ) || ! is_string( $arg['name'] ) || '' === trim( $arg['name'] ) ) {
+				return new \WP_Error(
+					'mcp_prompt_argument_missing_name',
+					sprintf(
+					/* translators: 1: argument index, 2: ability name */
+						__( 'Argument at index %1$d is missing required "name" field for ability "%2$s".', 'mcp-adapter' ),
+						$index,
+						$this->ability->get_name()
+					)
+				);
+			}
+
+			$argument_data = array(
+				'name' => trim( $arg['name'] ),
+			);
+
+			// Map optional 'title' field.
+			if ( isset( $arg['title'] ) && is_string( $arg['title'] ) && '' !== trim( $arg['title'] ) ) {
+				$argument_data['title'] = trim( $arg['title'] );
+			}
+
+			// Map optional 'description' field.
+			if ( isset( $arg['description'] ) && is_string( $arg['description'] ) && '' !== trim( $arg['description'] ) ) {
+				$argument_data['description'] = trim( $arg['description'] );
+			}
+
+			// Map optional 'required' field (only emit when true, per existing pattern).
+			if ( isset( $arg['required'] ) && true === $arg['required'] ) {
+				$argument_data['required'] = true;
+			}
+
+			$arguments[] = PromptArgument::fromArray( $argument_data );
+		}
+
+		return $arguments;
 	}
 
 	/**
@@ -131,7 +359,7 @@ class RegisterAbilityAsMcpPrompt {
 	 * {
 	 *   "type": "object",
 	 *   "properties": {
-	 *     "topic": {"type": "string", "description": "..."},
+	 *     "topic": {"type": "string", "title": "Topic", "description": "..."},
 	 *     "tone": {"type": "string", "description": "..."}
 	 *   },
 	 *   "required": ["topic"]
@@ -139,55 +367,113 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * To MCP prompt arguments format:
 	 * [
-	 *   {"name": "topic", "description": "...", "required": true},
-	 *   {"name": "tone", "description": "...", "required": false}
+	 *   {"name": "topic", "title": "Topic", "description": "...", "required": true},
+	 *   {"name": "tone", "description": "..."}
 	 * ]
 	 *
+	 * Note: `required` is only emitted when true; optional arguments omit the field entirely.
+	 *
 	 * @param array<string,mixed> $input_schema The JSON Schema from ability.
-	 * @return array<int,array<string,mixed>> MCP-formatted arguments array.
+	 *
+	 * @return array<int, \WP\McpSchema\Server\Prompts\DTO\PromptArgument> Argument DTO list.
+	 * @since n.e.x.t
+	 *
 	 */
 	private function convert_input_schema_to_arguments( array $input_schema ): array {
 		$arguments = array();
 
-		// Ensure we have properties to convert
+		// Ensure we have properties to convert.
 		if ( empty( $input_schema['properties'] ) || ! is_array( $input_schema['properties'] ) ) {
 			return $arguments;
 		}
 
-		// Get the list of required properties
+		// Get the list of required properties.
 		$required_fields = array();
 		if ( isset( $input_schema['required'] ) && is_array( $input_schema['required'] ) ) {
 			$required_fields = $input_schema['required'];
 		}
 
-		// Convert each property to an MCP argument
+		// Convert each property to an MCP argument.
 		foreach ( $input_schema['properties'] as $property_name => $property_schema ) {
 			if ( ! is_array( $property_schema ) ) {
 				continue;
 			}
 
-			$argument = array(
-				'name'     => $property_name,
-				'required' => in_array( $property_name, $required_fields, true ),
+			$is_required = in_array( $property_name, $required_fields, true );
+
+			$argument_data = array(
+				'name' => $property_name,
 			);
 
-			// Add description if available
-			if ( ! empty( $property_schema['description'] ) ) {
-				$argument['description'] = $property_schema['description'];
+			// Map JSON Schema title to PromptArgument.title when present.
+			if ( ! empty( $property_schema['title'] ) && is_string( $property_schema['title'] ) ) {
+				$argument_data['title'] = $property_schema['title'];
 			}
 
-			$arguments[] = $argument;
+			// Map JSON Schema description to PromptArgument.description when present.
+			if ( ! empty( $property_schema['description'] ) && is_string( $property_schema['description'] ) ) {
+				$argument_data['description'] = $property_schema['description'];
+			}
+
+			// Only emit required when true; omit for optional arguments.
+			if ( $is_required ) {
+				$argument_data['required'] = true;
+			}
+
+			$arguments[] = PromptArgument::fromArray( $argument_data );
 		}
 
 		return $arguments;
 	}
 
 	/**
-	 * Get the MCP prompt instance.
+	 * Build a clean Prompt DTO and adapter metadata for internal wiring.
 	 *
-	 * @return \WP\MCP\Domain\Prompts\McpPrompt|\WP_Error MCP prompt instance or WP_Error if validation fails.
+	 * This method returns a protocol-only Prompt DTO and provides the adapter metadata
+	 * separately. This keeps the DTO stable across MCP spec changes and avoids coupling internal execution
+	 * wiring to protocol surfaces.
+	 *
+	 * @param \WP_Ability $ability The ability.
+	 *
+	 * @return array{prompt: \WP\McpSchema\Server\Prompts\DTO\Prompt, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @since n.e.x.t
+	 *
 	 */
-	private function get_prompt() {
-		return McpPrompt::from_array( $this->get_data(), $this->mcp_server );
+	public static function build( \WP_Ability $ability ) {
+		$prompt = new self( $ability );
+		$data   = $prompt->build_prompt_data();
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		try {
+			$prompt_dto = Prompt::fromArray( $data['prompt_data'] );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error(
+				'mcp_prompt_dto_creation_failed',
+				sprintf(
+				/* translators: %s: error message */
+					__( 'Failed to create Prompt DTO for ability %1$s: %2$s', 'mcp-adapter' ),
+					$ability->get_name(),
+					$e->getMessage()
+				),
+				array( 'exception' => $e )
+			);
+		}
+
+		// Optional deep validation if enabled.
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		if ( $mcp_validation_enabled ) {
+			$validation_result = McpPromptValidator::validate_prompt_dto( $prompt_dto );
+			if ( is_wp_error( $validation_result ) ) {
+				return $validation_result;
+			}
+		}
+
+		return array(
+			'prompt'       => $prompt_dto,
+			'adapter_meta' => $data['adapter_meta'],
+		);
 	}
 }

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -10,7 +10,7 @@ namespace WP\MCP\Domain\Prompts;
 
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Domain\Utils\SchemaTransformer;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 
 /**
@@ -102,7 +102,7 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|\WP_Error Returns Prompt DTO or WP_Error if validation fails.
+	 * @return PromptDto|\WP_Error Returns Prompt DTO or WP_Error if validation fails.
 	 */
 	public static function make( \WP_Ability $ability ) {
 		$prompt = new self( $ability );
@@ -113,7 +113,7 @@ class RegisterAbilityAsMcpPrompt {
 	/**
 	 * Get the MCP prompt instance.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|\WP_Error Prompt DTO or WP_Error if validation fails.
+	 * @return PromptDto|\WP_Error Prompt DTO or WP_Error if validation fails.
 	 * @since n.e.x.t
 	 *
 	 */
@@ -126,7 +126,7 @@ class RegisterAbilityAsMcpPrompt {
 		}
 
 		try {
-			return Prompt::fromArray( $built['prompt_data'] );
+			return PromptDto::fromArray( $built['prompt_data'] );
 		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'mcp_prompt_schema_invalid', $e->getMessage() );
 		}
@@ -435,7 +435,7 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return array{prompt: \WP\McpSchema\Server\Prompts\DTO\Prompt, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @return array{prompt: PromptDto, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since n.e.x.t
 	 *
 	 */
@@ -448,7 +448,7 @@ class RegisterAbilityAsMcpPrompt {
 		}
 
 		try {
-			$prompt_dto = Prompt::fromArray( $data['prompt_data'] );
+			$prompt_dto = PromptDto::fromArray( $data['prompt_data'] );
 		} catch ( \Throwable $e ) {
 			return new \WP_Error(
 				'mcp_prompt_dto_creation_failed',

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -102,7 +102,7 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return PromptDto|\WP_Error Returns Prompt DTO or WP_Error if validation fails.
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|\WP_Error Returns Prompt DTO or WP_Error if validation fails.
 	 */
 	public static function make( \WP_Ability $ability ) {
 		$prompt = new self( $ability );
@@ -113,7 +113,7 @@ class RegisterAbilityAsMcpPrompt {
 	/**
 	 * Get the MCP prompt instance.
 	 *
-	 * @return PromptDto|\WP_Error Prompt DTO or WP_Error if validation fails.
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|\WP_Error Prompt DTO or WP_Error if validation fails.
 	 * @since n.e.x.t
 	 *
 	 */
@@ -435,7 +435,7 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return array{prompt: PromptDto, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @return array{prompt: \WP\McpSchema\Server\Prompts\DTO\Prompt, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since n.e.x.t
 	 *
 	 */

--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * WordPress MCP Resource class for representing MCP resources according to the specification.
+ * MCP Resource component.
  *
  * @package McpAdapter
  */
@@ -9,439 +10,344 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Resources;
 
-use WP\MCP\Core\McpServer;
+use WP\MCP\Domain\Contracts\McpComponentInterface;
+use WP\MCP\Domain\Utils\McpValidator;
+use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
+use WP\MCP\Infrastructure\Observability\FailureReason;
+use WP\McpSchema\Common\Protocol\DTO\Annotations;
+use WP\McpSchema\Server\Resources\DTO\Resource;
 
 /**
- * Represents an MCP resource according to the Model Context Protocol specification.
+ * Resource component providing unified execution and permission checks.
  *
- * Resources enable models to access external data sources, such as files, databases,
- * or web APIs. Each resource is uniquely identified by a URI and includes metadata
- * describing its content type and structure.
+ * This class supports multiple ways to register resources:
  *
- * @link https://modelcontextprotocol.io/specification/2025-06-18/server/resources
+ * 1. Array configuration:
+ * ```php
+ * $resource = McpResource::fromArray([
+ *     'uri'         => 'WordPress://local/readme',
+ *     'title'       => 'README',
+ *     'description' => 'Example resource',
+ *     'handler'     => fn() => 'Hello',
+ *     'permission'  => fn() => true,
+ * ]);
+ * ```
+ *
+ * 2. From WordPress Ability (ability-backed):
+ * ```php
+ * $resource = McpResource::fromAbility($ability);
+ * ```
+ *
+ * @since n.e.x.t
  */
-class McpResource {
+final class McpResource implements McpComponentInterface {
+
+
+	// =========================================================================
+	// Runtime Properties
+	// =========================================================================
 
 	/**
-	 * The ability name.
+	 * Clean Resource DTO (protocol-only).
 	 *
-	 * @var string
+	 * @var \WP\McpSchema\Server\Resources\DTO\Resource
 	 */
-	private string $ability;
+	private Resource $mcp_resource_dto;
 
 	/**
-	 * Unique identifier for the resource.
+	 * Ability used for execution/permission checks (ability-backed resources).
 	 *
-	 * @var string
+	 * @var \WP_Ability|null
 	 */
-	private string $uri;
+	private ?\WP_Ability $ability = null;
 
 	/**
-	 * Optional human-readable name of the resource for display purposes.
+	 * Direct execution handler (callable-backed resources).
 	 *
-	 * @var string|null
+	 * @var callable|null
 	 */
-	private ?string $name;
+	private $handler = null;
 
 	/**
-	 * Optional human-readable description of the resource.
+	 * Direct permission callback (callable-backed resources).
 	 *
-	 * @var string|null
+	 * @var callable|null
 	 */
-	private ?string $description;
+	private $permission_callback = null;
 
 	/**
-	 * Optional MIME type of the resource content.
+	 * Internal adapter metadata (never exposed to clients).
 	 *
-	 * @var string|null
+	 * @var array<string, mixed>
 	 */
-	private ?string $mime_type;
+	private array $adapter_meta = array();
 
 	/**
-	 * Text content of the resource (for TextResourceContents).
+	 * Observability context tags for logging/metrics.
 	 *
-	 * @var string|null
+	 * @var array<string, mixed>
 	 */
-	private ?string $text;
+	private array $observability_context = array();
+
+	// =========================================================================
+	// Constructor
+	// =========================================================================
 
 	/**
-	 * Base64-encoded binary content of the resource (for BlobResourceContents).
+	 * Private constructor - use factory methods.
 	 *
-	 * @var string|null
+	 * @param \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto The Resource DTO.
 	 */
-	private ?string $blob;
-
-	/**
-	 * Optional properties describing resource metadata.
-	 *
-	 * @var array
-	 */
-	private array $annotations;
-
-	/**
-	 * The MCP server instance this resource belongs to.
-	 *
-	 * @var \WP\MCP\Core\McpServer|null
-	 */
-	private ?McpServer $mcp_server = null;
-
-	/**
-	 * Constructor for McpResource.
-	 *
-	 * @param string      $ability The ability name.
-	 * @param string      $uri Unique URI identifier for the resource.
-	 * @param string|null $name Optional human-readable name for display.
-	 * @param string|null $description Optional human-readable description.
-	 * @param string|null $mime_type Optional MIME type of the content.
-	 * @param string|null $text Optional text content (mutually exclusive with blob).
-	 * @param string|null $blob Optional base64-encoded binary content (mutually exclusive with text).
-	 * @param array       $annotations Optional properties describing resource metadata.
-	 */
-	public function __construct(
-		string $ability,
-		string $uri,
-		?string $name = null,
-		?string $description = null,
-		?string $mime_type = null,
-		?string $text = null,
-		?string $blob = null,
-		array $annotations = array()
-	) {
-		$this->ability     = $ability;
-		$this->uri         = $uri;
-		$this->name        = $name;
-		$this->description = $description;
-		$this->mime_type   = $mime_type;
-		$this->text        = $text;
-		$this->blob        = $blob;
-		$this->annotations = $annotations;
+	private function __construct( Resource $resource_dto ) {
+		$this->mcp_resource_dto = $resource_dto;
 	}
 
-	/**
-	 * Get the resource URI.
-	 *
-	 * @return string
-	 */
-	public function get_uri(): string {
-		return $this->uri;
-	}
+	// =========================================================================
+	// Factory Methods
+	// =========================================================================
 
 	/**
-	 * Get the resource name.
+	 * @param array $config The resource configuration array.
 	 *
-	 * @return string|null
+	 * @return self|\WP_Error
 	 */
-	public function get_name(): ?string {
-		return $this->name;
-	}
-
-	/**
-	 * Get the resource description.
-	 *
-	 * @return string|null
-	 */
-	public function get_description(): ?string {
-		return $this->description;
-	}
-
-	/**
-	 * Get the MIME type.
-	 *
-	 * @return string|null
-	 */
-	public function get_mime_type(): ?string {
-		return $this->mime_type;
-	}
-
-	/**
-	 * Get the text content.
-	 *
-	 * @return string|null
-	 */
-	public function get_text(): ?string {
-		return $this->text;
-	}
-
-	/**
-	 * Get the blob content.
-	 *
-	 * @return string|null
-	 */
-	public function get_blob(): ?string {
-		return $this->blob;
-	}
-
-	/**
-	 * Get the annotations.
-	 *
-	 * @return array
-	 */
-	public function get_annotations(): array {
-		return $this->annotations;
-	}
-
-	/**
-	 * Get the ability name.
-	 *
-	 * @return \WP_Ability|\WP_Error WP_Ability instance on success, WP_Error on failure.
-	 */
-	public function get_ability() {
-		$ability = wp_get_ability( $this->ability );
-		if ( ! $ability ) {
-			return new \WP_Error(
-				'ability_not_found',
-				sprintf(
-					/* translators: %s: ability name */
-					esc_html__( "WordPress ability '%s' does not exist.", 'mcp-adapter' ),
-					esc_html( $this->ability )
-				)
-			);
-		}
-		return $ability;
-	}
-
-	/**
-	 * Set the resource name.
-	 *
-	 * @param string|null $name The name to set.
-	 *
-	 * @return void
-	 */
-	public function set_name( ?string $name ): void {
-		$this->name = $name;
-	}
-
-	/**
-	 * Set the resource description.
-	 *
-	 * @param string|null $description The description to set.
-	 *
-	 * @return void
-	 */
-	public function set_description( ?string $description ): void {
-		$this->description = $description;
-	}
-
-	/**
-	 * Set the MIME type.
-	 *
-	 * @param string|null $mime_type The MIME type to set.
-	 *
-	 * @return void
-	 */
-	public function set_mime_type( ?string $mime_type ): void {
-		$this->mime_type = $mime_type;
-	}
-
-	/**
-	 * Set the text content.
-	 *
-	 * @param string|null $text The text content to set.
-	 *
-	 * @return void
-	 */
-	public function set_text( ?string $text ): void {
-		$this->text = $text;
-		// Clear blob content if setting text.
-		if ( is_null( $text ) ) {
-			return;
+	public static function fromArray( array $config ) {
+		if ( empty( $config['uri'] ) ) {
+			return new \WP_Error( 'mcp_resource_missing_uri', 'Resource configuration must include a "uri" field.' );
 		}
 
-		$this->blob = null;
-	}
-
-	/**
-	 * Set the blob content.
-	 *
-	 * @param string|null $blob The base64-encoded blob content to set.
-	 *
-	 * @return void
-	 */
-	public function set_blob( ?string $blob ): void {
-		$this->blob = $blob;
-		// Clear text content if setting blob.
-		if ( is_null( $blob ) ) {
-			return;
+		if ( ! isset( $config['handler'] ) || ! is_callable( $config['handler'] ) ) {
+			return new \WP_Error( 'mcp_resource_missing_handler', 'Resource configuration must include a callable "handler" field.' );
 		}
 
-		$this->text = null;
-	}
+		$uri = trim( $config['uri'] );
 
-	/**
-	 * Set the annotations.
-	 *
-	 * @param array $annotations The annotations to set.
-	 *
-	 * @return void
-	 */
-	public function set_annotations( array $annotations ): void {
-		$this->annotations = $annotations;
-	}
-
-	/**
-	 * Add an annotation.
-	 *
-	 * @param string $key The annotation key.
-	 * @param mixed  $value The annotation value.
-	 *
-	 * @return void
-	 */
-	public function add_annotation( string $key, $value ): void {
-		$this->annotations[ $key ] = $value;
-	}
-
-	/**
-	 * Remove an annotation.
-	 *
-	 * @param string $key The annotation key to remove.
-	 *
-	 * @return void
-	 */
-	public function remove_annotation( string $key ): void {
-		unset( $this->annotations[ $key ] );
-	}
-
-	/**
-	 * Get the MCP server instance this resource belongs to.
-	 *
-	 * @return \WP\MCP\Core\McpServer
-	 */
-	public function get_mcp_server(): McpServer {
-		if ( null === $this->mcp_server ) {
-			throw new \RuntimeException( 'MCP server has not been set on this resource instance.' );
+		if ( ! McpValidator::validate_resource_uri( $uri ) ) {
+			return new \WP_Error( 'mcp_resource_invalid_uri', 'Resource "uri" must be a valid RFC 3986 URI with a scheme.' );
 		}
 
-		return $this->mcp_server;
-	}
+		$name = isset( $config['name'] ) ? trim( $config['name'] ) : $uri;
+		if ( '' === $name ) {
+			return new \WP_Error( 'mcp_resource_missing_name', 'Resource "name" cannot be empty.' );
+		}
 
-	/**
-	 * Set the MCP server instance this resource belongs to.
-	 *
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server instance.
-	 *
-	 * @return void
-	 */
-	public function set_mcp_server( McpServer $mcp_server ): void {
-		$this->mcp_server = $mcp_server;
-	}
-
-	/**
-	 * Convert the resource to an array representation according to MCP specification.
-	 *
-	 * @return array
-	 */
-	public function to_array(): array {
 		$resource_data = array(
-			'uri' => $this->uri,
+			'name' => $name,
+			'uri'  => $uri,
 		);
 
-		// Add optional fields only if they have values.
-		if ( ! is_null( $this->name ) ) {
-			$resource_data['name'] = $this->name;
+		if ( isset( $config['title'] ) ) {
+			$resource_data['title'] = $config['title'];
 		}
 
-		if ( ! is_null( $this->description ) ) {
-			$resource_data['description'] = $this->description;
+		if ( isset( $config['description'] ) ) {
+			$resource_data['description'] = $config['description'];
 		}
 
-		if ( ! is_null( $this->mime_type ) ) {
-			$resource_data['mimeType'] = $this->mime_type;
+		// Include mimeType only when valid.
+		if ( isset( $config['mimeType'] ) ) {
+			$mime_type = trim( $config['mimeType'] );
+			if ( '' !== $mime_type && McpValidator::validate_mime_type( $mime_type ) ) {
+				$resource_data['mimeType'] = $mime_type;
+			}
 		}
 
-		if ( ! is_null( $this->text ) ) {
-			$resource_data['text'] = $this->text;
+		// Include size only when > 0.
+		if ( isset( $config['size'] ) && $config['size'] > 0 ) {
+			$resource_data['size'] = $config['size'];
 		}
 
-		if ( ! is_null( $this->blob ) ) {
-			$resource_data['blob'] = $this->blob;
+		// Validate and include icons if set.
+		if ( isset( $config['icons'] ) && is_array( $config['icons'] ) && ! empty( $config['icons'] ) ) {
+			$icons_result = McpValidator::validate_icons_array( $config['icons'] );
+			if ( ! empty( $icons_result['valid'] ) ) {
+				$resource_data['icons'] = $icons_result['valid'];
+			}
 		}
 
-		if ( ! empty( $this->annotations ) ) {
-			$resource_data['annotations'] = $this->annotations;
+		if ( isset( $config['meta'] ) && is_array( $config['meta'] ) && ! empty( $config['meta'] ) ) {
+			$resource_data['_meta'] = $config['meta'];
 		}
 
-		return $resource_data;
-	}
+		// Create the Resource DTO - wrap in try-catch since Annotations::fromArray() and Resource::fromArray() can throw.
+		try {
+			// Process annotations inside try-catch since Annotations::fromArray() can throw.
+			if ( isset( $config['annotations'] ) && is_array( $config['annotations'] ) && ! empty( $config['annotations'] ) ) {
+				$resource_data['annotations'] = Annotations::fromArray( $config['annotations'] );
+			}
 
-	/**
-	 * Convert the resource to JSON representation.
-	 *
-	 * @return string
-	 */
-	public function to_json(): string {
-		$json = wp_json_encode( $this->to_array() );
-		return false !== $json ? $json : '{}';
-	}
-
-	/**
-	 * Create an McpResource instance from an array.
-	 *
-	 * @param array     $data Array containing resource data.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server instance.
-	 *
-	 * @return self|\WP_Error Returns a new McpResource instance or WP_Error if validation fails.
-	 */
-	public static function from_array( array $data, McpServer $mcp_server ) {
-		$resource = new self(
-			$data['ability'] ?? '',
-			$data['uri'] ?? '',
-			$data['name'] ?? null,
-			$data['description'] ?? null,
-			$data['mimeType'] ?? null,
-			$data['text'] ?? null,
-			$data['blob'] ?? null,
-			$data['annotations'] ?? array()
-		);
-
-		$resource->mcp_server = $mcp_server;
-
-		return $resource->validate( "McpResource::from_array::{$data['uri']}" );
-	}
-
-	/**
-	 * Check if this is a text resource.
-	 *
-	 * @return bool
-	 */
-	public function is_text_resource(): bool {
-		return ! is_null( $this->text ) && is_null( $this->blob );
-	}
-
-	/**
-	 * Check if this is a blob resource.
-	 *
-	 * @return bool
-	 */
-	public function is_blob_resource(): bool {
-		return ! is_null( $this->blob ) && is_null( $this->text );
-	}
-
-	/**
-	 * Validate the resource data.
-	 *
-	 * @param string $context Optional context for error messages.
-	 *
-	 * @return \WP\MCP\Domain\Resources\McpResource|\WP_Error Resource instance on success, WP_Error on failure.
-	 */
-	public function validate( string $context = '' ) {
-		if ( null === $this->mcp_server ) {
+			$resource = Resource::fromArray( $resource_data );
+		} catch ( \Throwable $e ) {
 			return new \WP_Error(
-				'resource_missing_mcp_server',
-				esc_html__( 'MCP server must be set before validating a resource.', 'mcp-adapter' )
+				'mcp_resource_dto_creation_failed',
+				sprintf(
+				/* translators: %s: error message */
+					__( 'Failed to create Resource DTO: %s', 'mcp-adapter' ),
+					$e->getMessage()
+				),
+				array( 'exception' => $e )
 			);
 		}
 
-		if ( ! $this->mcp_server->is_mcp_validation_enabled() ) {
-			return $this;
+		// Optional deep validation if enabled.
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		if ( $mcp_validation_enabled ) {
+			$validation_result = McpResourceValidator::validate_resource_dto( $resource );
+			if ( is_wp_error( $validation_result ) ) {
+				return $validation_result;
+			}
 		}
 
-		$context_to_use    = $context ?: "McpResource::{$this->name}";
-		$validation_result = McpResourceValidator::validate_resource_instance( $this, $context_to_use );
+		$instance          = new self( $resource );
+		$instance->handler = $config['handler'];
 
-		if ( is_wp_error( $validation_result ) ) {
-			return $validation_result;
+		if ( isset( $config['permission'] ) && is_callable( $config['permission'] ) ) {
+			$instance->permission_callback = $config['permission'];
 		}
 
-		return $this;
+		$instance->observability_context = array(
+			'component_type' => 'resource',
+			'resource_uri'   => $uri,
+			'source'         => 'array',
+		);
+
+		return $instance;
+	}
+
+	/**
+	 * Create an ability-backed MCP resource.
+	 *
+	 * @param \WP_Ability $ability WordPress ability.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler.
+	 *
+	 * @return self|\WP_Error
+	 */
+	public static function fromAbility( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null ) {
+		$resource_data = RegisterAbilityAsMcpResource::build( $ability, $error_handler );
+		if ( $resource_data instanceof \WP_Error ) {
+			return $resource_data;
+		}
+
+		$instance               = new self( $resource_data['resource'] );
+		$instance->adapter_meta = $resource_data['adapter_meta'];
+		$instance->ability      = $ability;
+
+		$instance->observability_context = array(
+			'component_type' => 'resource',
+			'resource_uri'   => $resource_data['resource']->getUri(),
+			'ability_name'   => $ability->get_name(),
+			'source'         => 'ability',
+		);
+
+		return $instance;
+	}
+
+	// =========================================================================
+	// McpComponentInterface Implementation
+	// =========================================================================
+
+	/**
+	 * Get the clean protocol DTO for MCP responses.
+	 *
+	 * @return \WP\McpSchema\Server\Resources\DTO\Resource
+	 */
+	public function get_component(): Resource {
+		return $this->mcp_resource_dto;
+	}
+
+	/**
+	 * Execute the resource read.
+	 *
+	 * @param mixed $arguments Read arguments (may be empty).
+	 *
+	 * @return mixed
+	 */
+	public function execute( $arguments ) {
+		// Ability-backed resources match existing behavior: no args passed to abilities.
+		if ( null !== $this->ability ) {
+			try {
+				return $this->ability->execute();
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_execution_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		}
+
+		if ( null !== $this->handler ) {
+			try {
+				return call_user_func( $this->handler, $arguments );
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_execution_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		}
+
+		return new \WP_Error( 'mcp_resource_no_handler', 'No resource execution strategy configured.' );
+	}
+
+	/**
+	 * Check whether the current request has permission to read this resource.
+	 *
+	 * @param mixed $arguments Read arguments (may be empty).
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public function check_permission( $arguments ) {
+		// Ability-backed resources match existing behavior: no args passed to abilities.
+		if ( null !== $this->ability ) {
+			try {
+				return $this->ability->check_permissions();
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_permission_check_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		}
+
+		if ( null !== $this->permission_callback ) {
+			try {
+				$result = call_user_func( $this->permission_callback, $arguments );
+
+				return $result instanceof \WP_Error ? $result : (bool) $result;
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_permission_check_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		}
+
+		return new \WP_Error(
+			'mcp_permission_denied',
+			'Access denied.',
+			array( 'failure_reason' => FailureReason::NO_PERMISSION_STRATEGY )
+		);
+	}
+
+	/**
+	 * Get internal adapter metadata for this resource.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_adapter_meta(): array {
+		return $this->adapter_meta;
+	}
+
+	/**
+	 * Get observability context tags for logging/metrics.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_observability_context(): array {
+		return $this->observability_context;
 	}
 }

--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -54,7 +54,7 @@ final class McpResource implements McpComponentInterface {
 	/**
 	 * Clean Resource DTO (protocol-only).
 	 *
-	 * @var ResourceDto
+	 * @var \WP\McpSchema\Server\Resources\DTO\Resource
 	 */
 	private ResourceDto $mcp_resource_dto;
 
@@ -100,7 +100,7 @@ final class McpResource implements McpComponentInterface {
 	/**
 	 * Private constructor - use factory methods.
 	 *
-	 * @param ResourceDto $resource_dto The Resource DTO.
+	 * @param \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto The Resource DTO.
 	 */
 	private function __construct( ResourceDto $resource_dto ) {
 		$this->mcp_resource_dto = $resource_dto;
@@ -253,7 +253,7 @@ final class McpResource implements McpComponentInterface {
 	/**
 	 * Get the clean protocol DTO for MCP responses.
 	 *
-	 * @return ResourceDto
+	 * @return \WP\McpSchema\Server\Resources\DTO\Resource
 	 */
 	public function get_protocol_dto(): ResourceDto {
 		return $this->mcp_resource_dto;

--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -15,7 +15,7 @@ use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\Observability\FailureReason;
 use WP\McpSchema\Common\Protocol\DTO\Annotations;
-use WP\McpSchema\Server\Resources\DTO\Resource;
+use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
 /**
  * Resource component providing unified execution and permission checks.
@@ -38,6 +38,10 @@ use WP\McpSchema\Server\Resources\DTO\Resource;
  * $resource = McpResource::fromAbility($ability);
  * ```
  *
+ * McpResource wraps a protocol-only ResourceDto for MCP serialization. Internal
+ * adapter metadata and execution wiring live on this class and are never
+ * exposed to MCP clients. Use get_protocol_dto() for protocol responses.
+ *
  * @since n.e.x.t
  */
 final class McpResource implements McpComponentInterface {
@@ -50,9 +54,9 @@ final class McpResource implements McpComponentInterface {
 	/**
 	 * Clean Resource DTO (protocol-only).
 	 *
-	 * @var \WP\McpSchema\Server\Resources\DTO\Resource
+	 * @var ResourceDto
 	 */
-	private Resource $mcp_resource_dto;
+	private ResourceDto $mcp_resource_dto;
 
 	/**
 	 * Ability used for execution/permission checks (ability-backed resources).
@@ -96,9 +100,9 @@ final class McpResource implements McpComponentInterface {
 	/**
 	 * Private constructor - use factory methods.
 	 *
-	 * @param \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto The Resource DTO.
+	 * @param ResourceDto $resource_dto The Resource DTO.
 	 */
-	private function __construct( Resource $resource_dto ) {
+	private function __construct( ResourceDto $resource_dto ) {
 		$this->mcp_resource_dto = $resource_dto;
 	}
 
@@ -169,14 +173,14 @@ final class McpResource implements McpComponentInterface {
 			$resource_data['_meta'] = $config['meta'];
 		}
 
-		// Create the Resource DTO - wrap in try-catch since Annotations::fromArray() and Resource::fromArray() can throw.
+		// Create the Resource DTO - wrap in try-catch since Annotations::fromArray() and ResourceDto::fromArray() can throw.
 		try {
 			// Process annotations inside try-catch since Annotations::fromArray() can throw.
 			if ( isset( $config['annotations'] ) && is_array( $config['annotations'] ) && ! empty( $config['annotations'] ) ) {
 				$resource_data['annotations'] = Annotations::fromArray( $config['annotations'] );
 			}
 
-			$resource = Resource::fromArray( $resource_data );
+			$resource = ResourceDto::fromArray( $resource_data );
 		} catch ( \Throwable $e ) {
 			return new \WP_Error(
 				'mcp_resource_dto_creation_failed',
@@ -249,9 +253,9 @@ final class McpResource implements McpComponentInterface {
 	/**
 	 * Get the clean protocol DTO for MCP responses.
 	 *
-	 * @return \WP\McpSchema\Server\Resources\DTO\Resource
+	 * @return ResourceDto
 	 */
-	public function get_component(): Resource {
+	public function get_protocol_dto(): ResourceDto {
 		return $this->mcp_resource_dto;
 	}
 

--- a/includes/Domain/Resources/McpResourceValidator.php
+++ b/includes/Domain/Resources/McpResourceValidator.php
@@ -49,7 +49,7 @@ class McpResourceValidator {
 	/**
 	 * Validate a Resource DTO against the MCP schema.
 	 *
-	 * @param ResourceDto $resource_dto The resource DTO to validate.
+	 * @param \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto The resource DTO to validate.
 	 *
 	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
 	 */

--- a/includes/Domain/Resources/McpResourceValidator.php
+++ b/includes/Domain/Resources/McpResourceValidator.php
@@ -10,7 +10,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Domain\Resources;
 
 use WP\MCP\Domain\Utils\McpValidator;
-use WP\McpSchema\Server\Resources\DTO\Resource;
+use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
 /**
  * Validates MCP resources against the Model Context Protocol specification.
@@ -49,11 +49,11 @@ class McpResourceValidator {
 	/**
 	 * Validate a Resource DTO against the MCP schema.
 	 *
-	 * @param \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto The resource DTO to validate.
+	 * @param ResourceDto $resource_dto The resource DTO to validate.
 	 *
 	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
 	 */
-	public static function validate_resource_dto( Resource $resource_dto ) {
+	public static function validate_resource_dto( ResourceDto $resource_dto ) {
 		$errors = array();
 
 		// Validate URI.
@@ -105,7 +105,7 @@ class McpResourceValidator {
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
 	public static function validate_resource_instance( McpResource $the_resource ) {
-		return self::validate_resource_dto( $the_resource->get_component() );
+		return self::validate_resource_dto( $the_resource->get_protocol_dto() );
 	}
 
 	/**

--- a/includes/Domain/Resources/McpResourceValidator.php
+++ b/includes/Domain/Resources/McpResourceValidator.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Domain\Resources;
 
 use WP\MCP\Domain\Utils\McpValidator;
+use WP\McpSchema\Server\Resources\DTO\Resource;
 
 /**
  * Validates MCP resources against the Model Context Protocol specification.
@@ -17,7 +18,7 @@ use WP\MCP\Domain\Utils\McpValidator;
  * Provides minimal, resource-efficient validation to ensure resources conform
  * to the MCP schema requirements without heavy processing overhead.
  *
- * @link https://modelcontextprotocol.io/specification/2025-06-18/server/resources
+ * @link https://modelcontextprotocol.io/specification/2025-11-25/server/resources
  */
 class McpResourceValidator {
 
@@ -39,7 +40,58 @@ class McpResourceValidator {
 				__( 'Resource validation failed: %s', 'mcp-adapter' ),
 				implode( ', ', $validation_errors )
 			);
-			return new \WP_Error( 'resource_validation_failed', esc_html( $error_message ) );
+			return new \WP_Error( 'mcp_resource_validation_failed', esc_html( $error_message ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate a Resource DTO against the MCP schema.
+	 *
+	 * @param \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto The resource DTO to validate.
+	 *
+	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
+	 */
+	public static function validate_resource_dto( Resource $resource_dto ) {
+		$errors = array();
+
+		// Validate URI.
+		if ( ! McpValidator::validate_resource_uri( $resource_dto->getUri() ) ) {
+			$errors[] = __( 'Resource URI must be a valid URI string', 'mcp-adapter' );
+		}
+
+		// Validate the MIME type if present.
+		$mime_type = $resource_dto->getMimeType();
+		if ( $mime_type && ! McpValidator::validate_mime_type( $mime_type ) ) {
+			$errors[] = __( 'Resource MIME type is invalid', 'mcp-adapter' );
+		}
+
+		// Validate icons if present.
+		$icons = $resource_dto->getIcons();
+		if ( ! empty( $icons ) ) {
+			$icons_array  = array_map( static fn( $icon ) => $icon->toArray(), $icons );
+			$icons_result = McpValidator::validate_icons_array( $icons_array );
+			$icons_errors = self::format_icon_validation_errors( $icons_result );
+			$errors       = array_merge( $errors, $icons_errors );
+		}
+
+		// Validate annotations if present.
+		$annotations = $resource_dto->getAnnotations();
+		if ( $annotations ) {
+			$annotation_errors = McpValidator::get_annotation_validation_errors( $annotations->toArray() );
+			$errors            = array_merge( $errors, $annotation_errors );
+		}
+
+		if ( ! empty( $errors ) ) {
+			return new \WP_Error(
+				'mcp_resource_validation_failed',
+				sprintf(
+				/* translators: %s: list of validation errors */
+					__( 'Resource validation failed: %s', 'mcp-adapter' ),
+					implode( '; ', $errors )
+				)
+			);
 		}
 
 		return true;
@@ -49,43 +101,32 @@ class McpResourceValidator {
 	 * Validate an McpResource instance against the MCP schema.
 	 *
 	 * @param \WP\MCP\Domain\Resources\McpResource $the_resource The resource instance to validate.
-	 * @param string      $context Optional context for error messages.
 	 *
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
-	public static function validate_resource_instance( McpResource $the_resource, string $context = '' ) {
-		$uniqueness_result = self::validate_resource_uniqueness( $the_resource, $context );
-		if ( is_wp_error( $uniqueness_result ) ) {
-			return $uniqueness_result;
-		}
-
-		return self::validate_resource_data( $the_resource->to_array(), $context );
+	public static function validate_resource_instance( McpResource $the_resource ) {
+		return self::validate_resource_dto( $the_resource->get_component() );
 	}
 
 	/**
-	 * Get validation error details for debugging purposes.
-	 * This is the core validation method - all other validation methods use this.
+	 * Get validation errors for MCP resource contents.
 	 *
-	 * @param array $resource_data The resource data to validate.
+	 * NOTE: This validates the `resource` object used by:
+	 * - `resources/read` results (`TextResourceContents` / `BlobResourceContents`)
+	 * - `content` blocks of type `resource` (`EmbeddedResource.resource`)
+	 *
+	 * It does NOT validate the `Resource` metadata object returned by `resources/list`.
+	 * For `Resource` DTO validation (resources/list), use validate_resource_dto() instead.
+	 *
+	 * This validator focuses on the MCP-required fields and ignores unknown fields to remain
+	 * forward-compatible with future schema versions.
+	 *
+	 * @param array $resource_data The resource contents object to validate.
 	 *
 	 * @return array Array of validation errors, empty if valid.
 	 */
 	public static function get_validation_errors( array $resource_data ): array {
 		$errors = array();
-
-		// Sanitize string inputs.
-		if ( isset( $resource_data['uri'] ) && is_string( $resource_data['uri'] ) ) {
-			$resource_data['uri'] = trim( $resource_data['uri'] );
-		}
-		if ( isset( $resource_data['name'] ) && is_string( $resource_data['name'] ) ) {
-			$resource_data['name'] = trim( $resource_data['name'] );
-		}
-		if ( isset( $resource_data['description'] ) && is_string( $resource_data['description'] ) ) {
-			$resource_data['description'] = trim( $resource_data['description'] );
-		}
-		if ( isset( $resource_data['mimeType'] ) && is_string( $resource_data['mimeType'] ) ) {
-			$resource_data['mimeType'] = trim( $resource_data['mimeType'] );
-		}
 
 		// Validate the required URI field.
 		if ( empty( $resource_data['uri'] ) || ! is_string( $resource_data['uri'] ) ) {
@@ -94,35 +135,32 @@ class McpResourceValidator {
 			$errors[] = __( 'Resource URI must be a valid URI format', 'mcp-adapter' );
 		}
 
-		// Validate content - must have either text OR blob (but not both).
-		$has_text = ! empty( $resource_data['text'] );
-		$has_blob = ! empty( $resource_data['blob'] );
+		// Validate content: at least one of text/blob must be present and correctly typed.
+		// Use array_key_exists to allow empty strings as valid content.
+		$has_text_key = array_key_exists( 'text', $resource_data );
+		$has_blob_key = array_key_exists( 'blob', $resource_data );
+
+		$has_text = $has_text_key && is_string( $resource_data['text'] );
+		$has_blob = $has_blob_key && is_string( $resource_data['blob'] );
 
 		if ( ! $has_text && ! $has_blob ) {
-			$errors[] = __( 'Resource must have either text or blob content', 'mcp-adapter' );
-		} elseif ( $has_text && $has_blob ) {
-			$errors[] = __( 'Resource cannot have both text and blob content - only one is allowed', 'mcp-adapter' );
+			$errors[] = __( 'Resource contents must include at least one of: text (string) or blob (base64 string)', 'mcp-adapter' );
 		}
 
-		// Validate text content if present.
-		if ( $has_text && ! is_string( $resource_data['text'] ) ) {
-			$errors[] = __( 'Resource text content must be a string', 'mcp-adapter' );
+		if ( $has_text_key && ! is_string( $resource_data['text'] ) ) {
+			$errors[] = __( 'Resource text content must be a string when provided', 'mcp-adapter' );
 		}
 
-		// Validate blob content if present.
-		if ( $has_blob && ! is_string( $resource_data['blob'] ) ) {
-			$errors[] = __( 'Resource blob content must be a string (base64-encoded)', 'mcp-adapter' );
+		if ( $has_blob_key && ! is_string( $resource_data['blob'] ) ) {
+			$errors[] = __( 'Resource blob content must be a string when provided', 'mcp-adapter' );
 		}
 
-		// Validate optional fields if present.
-		if ( isset( $resource_data['name'] ) && ! is_string( $resource_data['name'] ) ) {
-			$errors[] = __( 'Resource name must be a string if provided', 'mcp-adapter' );
+		// Validate blob content if present and typed.
+		if ( $has_blob && ! McpValidator::validate_base64( $resource_data['blob'] ) ) {
+			$errors[] = __( 'Resource blob content must be valid base64-encoded data', 'mcp-adapter' );
 		}
 
-		if ( isset( $resource_data['description'] ) && ! is_string( $resource_data['description'] ) ) {
-			$errors[] = __( 'Resource description must be a string if provided', 'mcp-adapter' );
-		}
-
+		// Validate mimeType if present (optional).
 		if ( isset( $resource_data['mimeType'] ) ) {
 			if ( ! is_string( $resource_data['mimeType'] ) ) {
 				$errors[] = __( 'Resource mimeType must be a string if provided', 'mcp-adapter' );
@@ -131,42 +169,32 @@ class McpResourceValidator {
 			}
 		}
 
-		// Validate annotations structure if present.
-		if ( isset( $resource_data['annotations'] ) ) {
-			if ( ! is_array( $resource_data['annotations'] ) ) {
-				$errors[] = __( 'Resource annotations must be an array if provided', 'mcp-adapter' );
-			} else {
-				$annotation_errors = McpValidator::get_annotation_validation_errors( $resource_data['annotations'] );
-				if ( ! empty( $annotation_errors ) ) {
-					$errors = array_merge( $errors, $annotation_errors );
+		return $errors;
+	}
+
+	/**
+	 * Format icon validation errors from the validation result.
+	 *
+	 * @param array{valid: array, errors: array} $icons_result The result from validate_icons_array.
+	 *
+	 * @return array Array of formatted error messages.
+	 */
+	private static function format_icon_validation_errors( array $icons_result ): array {
+		$errors = array();
+
+		if ( ! empty( $icons_result['errors'] ) ) {
+			foreach ( $icons_result['errors'] as $error_group ) {
+				foreach ( $error_group['errors'] as $error ) {
+					$errors[] = sprintf(
+					/* translators: 1: icon index, 2: error message */
+						__( 'Icon at index %1$d: %2$s', 'mcp-adapter' ),
+						$error_group['index'],
+						$error
+					);
 				}
 			}
 		}
 
 		return $errors;
-	}
-
-	/**
-	 * Validate that the resource is unique within the MCP server.
-	 *
-	 * @param \WP\MCP\Domain\Resources\McpResource $the_resource The resource instance to validate.
-	 * @param string      $context Optional context for error messages.
-	 *
-	 * @return bool|\WP_Error True if unique, WP_Error if the resource URI is not unique.
-	 */
-	public static function validate_resource_uniqueness( McpResource $the_resource, string $context = '' ) {
-		$this_resource_uri = $the_resource->get_uri();
-		$existing_resource = $the_resource->get_mcp_server()->get_resource( $this_resource_uri );
-		if ( $existing_resource ) {
-			$error_message  = $context ? "[{$context}] " : '';
-			$error_message .= sprintf(
-			/* translators: %s: resource URI */
-				__( 'Resource URI \'%s\' is not unique. It already exists in the MCP server.', 'mcp-adapter' ),
-				$this_resource_uri
-			);
-			return new \WP_Error( 'resource_not_unique', esc_html( $error_message ) );
-		}
-
-		return true;
 	}
 }

--- a/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * RegisterAbilityAsMcpResource class for converting WordPress abilities to MCP resources.
  *
@@ -9,174 +10,83 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Resources;
 
-use WP\MCP\Core\McpServer;
 use WP\MCP\Domain\Utils\McpAnnotationMapper;
-use WP_Ability;
+use WP\MCP\Domain\Utils\McpValidator;
+use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
+use WP\McpSchema\Server\Resources\DTO\Resource;
 
 /**
- * Converts WordPress abilities to MCP resources according to the specification.
+ * Converts WordPress abilities to MCP Resource metadata.
  *
- * This class extracts resource URI and other properties from ability metadata.
- * The ability meta must contain a 'uri' field with the resource URI.
+ * This class builds Resource DTOs for resources/list responses.
+ * It extracts metadata only (uri, name, title, description, mimeType, size, icons, annotations).
+ * Resource content (text/blob) is resolved separately at resources/read time.
  *
- * Example ability meta structure:
- * array(
- *     'uri' => 'WordPress://mcp-adapter/my-resource',
- *     'mimeType' => 'text/plain',
- *     'annotations' => array(...)
- * )
+ * All MCP-specific ability meta should be under 'mcp' key:
+ *
+ * Required ability meta:
+ * - 'mcp.uri' (string): The resource URI (RFC 3986 format)
+ *
+ * Optional ability meta:
+ * - 'mcp.mimeType' (string): MIME type of the resource content
+ * - 'mcp.size' (int): Size of resource content in bytes
+ * - 'mcp.annotations' (array): MCP annotations (audience, priority, lastModified)
+ * - 'mcp.icons' (array): Array of icon objects for UI display
+ * - 'mcp._meta' (array): User-provided metadata to pass through
+ *
+ * Note: Top-level meta keys 'uri', 'mimeType', 'annotations' are deprecated as of n.e.x.t.
+ * They still work for backward compatibility but will trigger a `_doing_it_wrong` notice.
+ * Use 'mcp.uri', 'mcp.mimeType', 'mcp.annotations' instead.
+ *
+ * @since n.e.x.t
  */
 class RegisterAbilityAsMcpResource {
+
 	/**
 	 * The WordPress ability instance.
 	 *
 	 * @var \WP_Ability
 	 */
-	private WP_Ability $ability;
+	private \WP_Ability $ability;
 
 	/**
-	 * The MCP server.
+	 * Optional error handler for logging deprecation notices.
 	 *
-	 * @var \WP\MCP\Core\McpServer
+	 * @var \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null
 	 */
-	private McpServer $mcp_server;
+	private ?McpErrorHandlerInterface $error_handler;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param \WP_Ability $ability The ability.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler.
+	 */
+	private function __construct( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null ) {
+		$this->ability       = $ability;
+		$this->error_handler = $error_handler;
+	}
 
 	/**
 	 * Make a new instance of the class.
 	 *
-	 * @param \WP_Ability            $ability    The ability.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
+	 * @param \WP_Ability $ability The ability.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler for logging.
 	 *
-	 * @return \WP\MCP\Domain\Resources\McpResource|\WP_Error Returns resource instance or WP_Error if validation fails.
+	 * @return \WP\McpSchema\Server\Resources\DTO\Resource|\WP_Error Returns Resource DTO or WP_Error if validation fails.
 	 */
-	public static function make( WP_Ability $ability, McpServer $mcp_server ) {
-		$resource = new self( $ability, $mcp_server );
+	public static function make( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null ) {
+		$resource = new self( $ability, $error_handler );
 
 		return $resource->get_resource();
 	}
 
 	/**
-	 * Constructor.
-	 *
-	 * @param \WP_Ability            $ability    The ability.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
-	 */
-	private function __construct( WP_Ability $ability, McpServer $mcp_server ) {
-		$this->mcp_server = $mcp_server;
-		$this->ability    = $ability;
-	}
-
-	/**
-	 * Get the resource URI.
-	 *
-	 * @return string|\WP_Error URI string or WP_Error if not found in ability meta.
-	 */
-	public function get_uri() {
-		$ability_meta = $this->ability->get_meta();
-
-			// First try to get URI from ability meta and normalize whitespace.
-		if ( isset( $ability_meta['uri'] ) && is_string( $ability_meta['uri'] ) ) {
-			$uri = trim( $ability_meta['uri'] );
-			if ( '' !== $uri ) {
-				return $uri;
-			}
-		}
-
-		// If not found in meta, return error since URI should be provided in ability meta
-		return new \WP_Error(
-			'resource_uri_not_found',
-			sprintf(
-				"Resource URI not found in ability meta for '%s'. URI must be provided in ability meta data.",
-				$this->ability->get_name()
-			)
-		);
-	}
-
-	/**
-	 * Get the MCP resource data array.
-	 *
-	 * @return array<string,mixed>|\WP_Error Resource data array or WP_Error if URI is not found.
-	 */
-	private function get_data() {
-		$uri = $this->get_uri();
-		if ( is_wp_error( $uri ) ) {
-			return $uri;
-		}
-
-		$resource_data = array(
-			'ability' => $this->ability->get_name(),
-			'uri'     => $uri,
-		);
-
-		// Add optional name from ability label
-		$label = trim( $this->ability->get_label() );
-		if ( ! empty( $label ) ) {
-			$resource_data['name'] = $label;
-		}
-
-		// Add optional description
-		$description = trim( $this->ability->get_description() );
-		if ( ! empty( $description ) ) {
-			$resource_data['description'] = $description;
-		}
-
-		// Get resource content from ability
-		$content = $this->get_ability_content();
-		if ( isset( $content['text'] ) ) {
-			$resource_data['text'] = $content['text'];
-		}
-		if ( isset( $content['blob'] ) ) {
-			$resource_data['blob'] = $content['blob'];
-		}
-		if ( isset( $content['mimeType'] ) ) {
-			$resource_data['mimeType'] = $content['mimeType'];
-		}
-
-		// Map annotations from ability meta to MCP format using unified mapper.
-		$ability_meta = $this->ability->get_meta();
-		if ( ! empty( $ability_meta['annotations'] ) && is_array( $ability_meta['annotations'] ) ) {
-			$mcp_annotations = McpAnnotationMapper::map( $ability_meta['annotations'], 'resource' );
-			if ( ! empty( $mcp_annotations ) ) {
-				$resource_data['annotations'] = $mcp_annotations;
-			}
-		}
-
-		return $resource_data;
-	}
-
-	/**
-	 * Get resource content from the ability.
-	 * This method should be implemented based on how abilities provide resource content.
-	 *
-	 * @return array<string,mixed> Array with 'text', 'blob', and/or 'mimeType' keys
-	 */
-	private function get_ability_content(): array {
-		// @todo: Probably this can be improved so it will not be loaded when the resource list is called
-		$content = array();
-
-		// Check if ability has resource content methods
-		if ( method_exists( $this->ability, 'get_resource_content' ) ) {
-			$resource_content = call_user_func( array( $this->ability, 'get_resource_content' ) );
-			if ( is_array( $resource_content ) ) {
-				return $resource_content;
-			}
-		}
-
-		// Fallback: try to get content from ability description as text
-		$description = $this->ability->get_description();
-		if ( ! empty( $description ) ) {
-			$content['text']     = $description;
-			$content['mimeType'] = 'text/plain';
-		}
-
-		return $content;
-	}
-
-	/**
 	 * Get the MCP resource instance.
-	 * Uses the centralized McpResourceValidator for consistent validation.
 	 *
-	 * @return \WP\MCP\Domain\Resources\McpResource|\WP_Error Returns the MCP resource instance or WP_Error if validation fails.
+	 * Resource schema validity is enforced by the php-mcp-schema DTO constructor.
+	 *
+	 * @return \WP\McpSchema\Server\Resources\DTO\Resource|\WP_Error Returns the Resource DTO or WP_Error if validation fails.
 	 */
 	private function get_resource() {
 		$data = $this->get_data();
@@ -184,6 +94,387 @@ class RegisterAbilityAsMcpResource {
 			return $data;
 		}
 
-		return McpResource::from_array( $data, $this->mcp_server );
+		try {
+			return Resource::fromArray( $data );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error(
+				'mcp_resource_schema_invalid',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Get the MCP resource data array.
+	 *
+	 * Builds metadata-only Resource data. Content (text/blob) is NOT included here;
+	 * content is resolved at resources/read time by ResourcesHandler.
+	 *
+	 * @return array<string,mixed>|\WP_Error Resource data array or WP_Error if validation fails.
+	 */
+	private function get_data() {
+		$built = $this->build_resource_data();
+		if ( is_wp_error( $built ) ) {
+			return $built;
+		}
+
+		return $built['resource_data'];
+	}
+
+	/**
+	 * Build Resource DTO data and adapter metadata.
+	 *
+	 * @return array{resource_data: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @since n.e.x.t
+	 *
+	 */
+	private function build_resource_data() {
+		$uri = $this->get_uri();
+		if ( is_wp_error( $uri ) ) {
+			return $uri;
+		}
+
+		$ability_meta = $this->ability->get_meta();
+		$mcp_meta     = $ability_meta['mcp'] ?? array();
+
+		// Required fields.
+		$resource_data = array(
+			'name' => $this->resolve_resource_name(),
+			'uri'  => $uri,
+		);
+
+		// Optional: title from ability label (human-readable display name).
+		$label = trim( $this->ability->get_label() );
+		if ( '' !== $label ) {
+			$resource_data['title'] = $label;
+		}
+
+		// Optional: description.
+		$description = trim( $this->ability->get_description() );
+		if ( '' !== $description ) {
+			$resource_data['description'] = $description;
+		}
+
+		// Optional: mimeType from ability meta (with validation).
+		$mime_type = $this->get_mcp_meta( 'mimeType', 'string' );
+		if ( null !== $mime_type ) {
+			$mime_type = trim( $mime_type );
+			if ( McpValidator::validate_mime_type( $mime_type ) ) {
+				$resource_data['mimeType'] = $mime_type;
+			}
+		}
+
+		// Optional: size from ability meta (bytes count for UI display).
+		$size = $this->get_mcp_meta( 'size', 'int' );
+		if ( null !== $size && $size > 0 ) {
+			$resource_data['size'] = $size;
+		}
+
+		// Optional: annotations from ability meta (standardized location: mcp.annotations).
+		$annotations = $this->get_mcp_meta( 'annotations', 'array' );
+		if ( null !== $annotations ) {
+			$mcp_annotations = McpAnnotationMapper::map( $annotations, 'resource' );
+			if ( ! empty( $mcp_annotations ) ) {
+				// Validate annotation values per MCP specification.
+				$validation_errors = McpValidator::get_annotation_validation_errors( $mcp_annotations );
+				if ( ! empty( $validation_errors ) ) {
+					// Log the issue but don't fail registration - drop invalid annotations.
+					$this->log_deprecation(
+						self::class . '::get_data',
+						sprintf(
+						/* translators: 1: ability name, 2: validation errors */
+							__( 'Invalid annotations for resource ability "%1$s" will be dropped: %2$s', 'mcp-adapter' ),
+							$this->ability->get_name(),
+							implode( '; ', $validation_errors )
+						),
+						array( 'validation_errors' => $validation_errors )
+					);
+				} else {
+					$resource_data['annotations'] = $mcp_annotations;
+				}
+			}
+		}
+
+		// Optional: icons from mcp.icons (already in correct location).
+		if ( ! empty( $mcp_meta['icons'] ) && is_array( $mcp_meta['icons'] ) ) {
+			$icons_result = McpValidator::validate_icons_array( $mcp_meta['icons'] );
+			if ( ! empty( $icons_result['valid'] ) ) {
+				$resource_data['icons'] = $icons_result['valid'];
+			}
+		}
+
+		// Build Resource `_meta`:
+		// - Preserve user-provided `_meta` from ability.meta.mcp._meta.
+		// - Adapter metadata is NEVER included in protocol DTO meta; it is returned separately in adapter_meta.
+		$resource_meta = array();
+		if ( ! empty( $mcp_meta['_meta'] ) && is_array( $mcp_meta['_meta'] ) ) {
+			$resource_meta = $mcp_meta['_meta'];
+		}
+		if ( ! empty( $resource_meta ) ) {
+			$resource_data['_meta'] = $resource_meta;
+		}
+
+		$adapter_meta = array(
+			'ability' => $this->ability->get_name(),
+		);
+
+		return array(
+			'resource_data' => $resource_data,
+			'adapter_meta'  => $adapter_meta,
+		);
+	}
+
+	/**
+	 * Get the resource URI with validation.
+	 *
+	 * @return string|\WP_Error URI string or WP_Error if not found or invalid.
+	 */
+	private function get_uri() {
+		$uri = $this->get_mcp_meta( 'uri', 'string' );
+
+		if ( null === $uri ) {
+			return new \WP_Error(
+				'resource_uri_not_found',
+				sprintf(
+				/* translators: %s: ability name */
+					__( "Resource URI not found in ability meta for '%s'. URI must be provided at 'mcp.uri'.", 'mcp-adapter' ),
+					$this->ability->get_name()
+				)
+			);
+		}
+
+		$uri = trim( $uri );
+
+		// Validate URI format (RFC 3986).
+		if ( ! McpValidator::validate_resource_uri( $uri ) ) {
+			return new \WP_Error(
+				'resource_uri_invalid',
+				sprintf(
+				/* translators: 1: ability name, 2: invalid URI */
+					__( "Invalid resource URI '%2\$s' for ability '%1\$s'. URI must be RFC 3986 compliant with a scheme.", 'mcp-adapter' ),
+					$this->ability->get_name(),
+					$uri
+				)
+			);
+		}
+
+		/**
+		 * Filters the MCP resource URI derived from an ability.
+		 *
+		 * @param string $uri The validated resource URI.
+		 * @param \WP_Ability $ability The source ability instance.
+		 *
+		 * @since n.e.x.t
+		 *
+		 */
+		$filtered_uri = apply_filters( 'mcp_adapter_resource_uri', $uri, $this->ability );
+
+		// Validate post-filter.
+		if ( ! is_string( $filtered_uri ) || ! McpValidator::validate_resource_uri( $filtered_uri ) ) {
+			return new \WP_Error(
+				'mcp_resource_uri_filter_invalid',
+				sprintf(
+				/* translators: %s: invalid URI returned by filter */
+					__( 'Filter returned invalid MCP resource URI: %s', 'mcp-adapter' ),
+					is_string( $filtered_uri ) ? $filtered_uri : gettype( $filtered_uri )
+				)
+			);
+		}
+
+		return $filtered_uri;
+	}
+
+	/**
+	 * Get a value from ability meta with standardized lookup.
+	 *
+	 * Looks in 'mcp' namespace first (preferred), then falls back to top-level (deprecated).
+	 * Logs deprecation notice when using top-level location.
+	 *
+	 * @param string $key The key to look up.
+	 * @param string $type Expected type: 'string', 'int', 'array'.
+	 * @param mixed $default_value Default value if not found.
+	 *
+	 * @return mixed The value or default.
+	 */
+	private function get_mcp_meta( string $key, string $type = 'string', $default_value = null ) {
+		$ability_meta = $this->ability->get_meta();
+		$mcp_meta     = $ability_meta['mcp'] ?? array();
+
+		// Preferred: Check mcp.{key} first.
+		if ( isset( $mcp_meta[ $key ] ) ) {
+			$value = $mcp_meta[ $key ];
+			if ( $this->validate_type( $value, $type ) ) {
+				return $value;
+			}
+		}
+
+		// Deprecated fallback: Check top-level meta.{key}.
+		if ( isset( $ability_meta[ $key ] ) ) {
+			$value = $ability_meta[ $key ];
+			if ( $this->validate_type( $value, $type ) ) {
+				// Log deprecation notice.
+				$this->log_deprecation(
+					__METHOD__,
+					sprintf(
+					/* translators: 1: deprecated meta key, 2: new meta key path */
+						__( 'Ability meta key "%1$s" is deprecated. Use "mcp.%1$s" instead.', 'mcp-adapter' ),
+						$key
+					),
+					array( 'deprecated_key' => $key )
+				);
+
+				return $value;
+			}
+		}
+
+		return $default_value;
+	}
+
+	/**
+	 * Validate a value against expected type.
+	 *
+	 * @param mixed $value The value to validate.
+	 * @param string $type Expected type.
+	 *
+	 * @return bool True if valid.
+	 */
+	private function validate_type( $value, string $type ): bool {
+		switch ( $type ) {
+			case 'string':
+				return is_string( $value ) && '' !== trim( $value );
+			case 'int':
+				return is_int( $value ) && $value >= 0;
+			case 'array':
+				// Array must be non-empty AND have at least one non-null, non-empty value.
+				// This prevents false positives when WordPress adds default empty annotations.
+				if ( ! is_array( $value ) || empty( $value ) ) {
+					return false;
+				}
+				// Check if any value in the array is actually meaningful (non-null, non-empty string).
+				foreach ( $value as $item ) {
+					if ( null !== $item && '' !== $item && array() !== $item ) {
+						return true;
+					}
+				}
+
+				return false;
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Log a deprecation notice via both WordPress _doing_it_wrong and McpErrorHandler.
+	 *
+	 * This ensures deprecation notices are visible both as HTTP headers (WordPress REST API)
+	 * and in debug.log (McpErrorHandler).
+	 *
+	 * @param string $method The method name where deprecation occurred.
+	 * @param string $message The deprecation message.
+	 * @param array $context Additional context for error handler.
+	 *
+	 * @return void
+	 */
+	private function log_deprecation( string $method, string $message, array $context = array() ): void {
+		// WordPress standard deprecation notice (appears as X-WP-DoingItWrong header in REST API).
+		_doing_it_wrong( esc_html( $method ), esc_html( $message ), 'n.e.x.t' );
+
+		// Also log via McpErrorHandler for debug.log visibility.
+		if ( ! $this->error_handler ) {
+			return;
+		}
+
+		$this->error_handler->log(
+			$message,
+			array_merge(
+				array( 'ability' => $this->ability->get_name() ),
+				$context
+			),
+			'warning'
+		);
+	}
+
+	/**
+	 * Resolve the MCP resource name from ability.
+	 *
+	 * Resource names have no charset restrictions (unlike Tool names).
+	 *
+	 * @return string The resolved resource name.
+	 */
+	private function resolve_resource_name(): string {
+		$name = $this->ability->get_name();
+
+		/**
+		 * Filters the MCP resource name derived from an ability.
+		 *
+		 * Unlike tools, resource names have no charset restrictions.
+		 *
+		 * @param string $name The resource name.
+		 * @param \WP_Ability $ability The source ability instance.
+		 *
+		 * @since n.e.x.t
+		 *
+		 */
+		$filtered_name = apply_filters( 'mcp_adapter_resource_name', $name, $this->ability );
+
+		// Resource names have no charset restrictions, so just ensure it's a non-empty string.
+		if ( is_string( $filtered_name ) && '' !== trim( $filtered_name ) ) {
+			return $filtered_name;
+		}
+
+		// Fall back to original name if filter returns invalid value.
+		return $name;
+	}
+
+	/**
+	 * Build a clean Resource DTO and adapter metadata for internal wiring.
+	 *
+	 * This method returns a protocol-only Resource DTO and provides the adapter metadata
+	 * separately. This keeps the DTO stable across MCP spec changes and avoids coupling internal execution
+	 * wiring to protocol surfaces.
+	 *
+	 * @param \WP_Ability $ability The ability.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler.
+	 *
+	 * @return array{resource: \WP\McpSchema\Server\Resources\DTO\Resource, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @since n.e.x.t
+	 *
+	 */
+	public static function build( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null ) {
+		$resource = new self( $ability, $error_handler );
+		$data     = $resource->build_resource_data();
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		try {
+			$resource_dto = Resource::fromArray( $data['resource_data'] );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error(
+				'mcp_resource_dto_creation_failed',
+				sprintf(
+				/* translators: %s: error message */
+					__( 'Failed to create Resource DTO for ability %1$s: %2$s', 'mcp-adapter' ),
+					$ability->get_name(),
+					$e->getMessage()
+				),
+				array( 'exception' => $e )
+			);
+		}
+
+		// Optional deep validation if enabled.
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		if ( $mcp_validation_enabled ) {
+			$validation_result = McpResourceValidator::validate_resource_dto( $resource_dto );
+			if ( is_wp_error( $validation_result ) ) {
+				return $validation_result;
+			}
+		}
+
+		return array(
+			'resource'     => $resource_dto,
+			'adapter_meta' => $data['adapter_meta'],
+		);
 	}
 }

--- a/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -73,7 +73,7 @@ class RegisterAbilityAsMcpResource {
 	 * @param \WP_Ability $ability The ability.
 	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler for logging.
 	 *
-	 * @return ResourceDto|\WP_Error Returns Resource DTO or WP_Error if validation fails.
+	 * @return \WP\McpSchema\Server\Resources\DTO\Resource|\WP_Error Returns Resource DTO or WP_Error if validation fails.
 	 */
 	public static function make( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null ) {
 		$resource = new self( $ability, $error_handler );
@@ -86,7 +86,7 @@ class RegisterAbilityAsMcpResource {
 	 *
 	 * Resource schema validity is enforced by the php-mcp-schema DTO constructor.
 	 *
-	 * @return ResourceDto|\WP_Error Returns the Resource DTO or WP_Error if validation fails.
+	 * @return \WP\McpSchema\Server\Resources\DTO\Resource|\WP_Error Returns the Resource DTO or WP_Error if validation fails.
 	 */
 	private function get_resource() {
 		$data = $this->get_data();
@@ -436,7 +436,7 @@ class RegisterAbilityAsMcpResource {
 	 * @param \WP_Ability $ability The ability.
 	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler.
 	 *
-	 * @return array{resource: ResourceDto, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @return array{resource: \WP\McpSchema\Server\Resources\DTO\Resource, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since n.e.x.t
 	 *
 	 */

--- a/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -13,7 +13,7 @@ namespace WP\MCP\Domain\Resources;
 use WP\MCP\Domain\Utils\McpAnnotationMapper;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
-use WP\McpSchema\Server\Resources\DTO\Resource;
+use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
 /**
  * Converts WordPress abilities to MCP Resource metadata.
@@ -73,7 +73,7 @@ class RegisterAbilityAsMcpResource {
 	 * @param \WP_Ability $ability The ability.
 	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler for logging.
 	 *
-	 * @return \WP\McpSchema\Server\Resources\DTO\Resource|\WP_Error Returns Resource DTO or WP_Error if validation fails.
+	 * @return ResourceDto|\WP_Error Returns Resource DTO or WP_Error if validation fails.
 	 */
 	public static function make( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null ) {
 		$resource = new self( $ability, $error_handler );
@@ -86,7 +86,7 @@ class RegisterAbilityAsMcpResource {
 	 *
 	 * Resource schema validity is enforced by the php-mcp-schema DTO constructor.
 	 *
-	 * @return \WP\McpSchema\Server\Resources\DTO\Resource|\WP_Error Returns the Resource DTO or WP_Error if validation fails.
+	 * @return ResourceDto|\WP_Error Returns the Resource DTO or WP_Error if validation fails.
 	 */
 	private function get_resource() {
 		$data = $this->get_data();
@@ -95,7 +95,7 @@ class RegisterAbilityAsMcpResource {
 		}
 
 		try {
-			return Resource::fromArray( $data );
+			return ResourceDto::fromArray( $data );
 		} catch ( \Throwable $e ) {
 			return new \WP_Error(
 				'mcp_resource_schema_invalid',
@@ -436,7 +436,7 @@ class RegisterAbilityAsMcpResource {
 	 * @param \WP_Ability $ability The ability.
 	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler.
 	 *
-	 * @return array{resource: \WP\McpSchema\Server\Resources\DTO\Resource, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @return array{resource: ResourceDto, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since n.e.x.t
 	 *
 	 */
@@ -449,7 +449,7 @@ class RegisterAbilityAsMcpResource {
 		}
 
 		try {
-			$resource_dto = Resource::fromArray( $data['resource_data'] );
+			$resource_dto = ResourceDto::fromArray( $data['resource_data'] );
 		} catch ( \Throwable $e ) {
 			return new \WP_Error(
 				'mcp_resource_dto_creation_failed',

--- a/includes/Domain/Tools/McpTool.php
+++ b/includes/Domain/Tools/McpTool.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * WordPress MCP Tool class for representing MCP tools according to the specification.
+ * MCP Tool component.
  *
  * @package McpAdapter
  */
@@ -9,392 +10,402 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Tools;
 
-use WP\MCP\Core\McpServer;
+use WP\MCP\Domain\Contracts\McpComponentInterface;
+use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
+use WP\MCP\Domain\Utils\McpValidator;
+use WP\MCP\Infrastructure\Observability\FailureReason;
+use WP\McpSchema\Server\Tools\DTO\Tool;
+use WP\McpSchema\Server\Tools\DTO\ToolAnnotations;
 
 /**
- * Represents an MCP tool according to the Model Context Protocol specification.
+ * Tool component providing unified execution and permission checks.
  *
- * Tools enable models to interact with external systems, such as querying databases,
- * calling APIs, or performing computations. Each tool is uniquely identified by a name
- * and includes metadata describing its schema.
+ * This class provides multiple flexible ways to create MCP tools:
  *
- * @link https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+ * 1. Array configuration:
+ * ```php
+ * $tool = McpTool::fromArray([
+ *     'name'        => 'uppercase-text',
+ *     'title'       => 'Uppercase Text',
+ *     'description' => 'Converts text to uppercase',
+ *     'inputSchema' => ['type' => 'object', 'properties' => [...]],
+ *     'handler'     => fn($args) => ['result' => strtoupper($args['text'])],
+ *     'permission'  => fn() => true,
+ *     'annotations' => ['readOnlyHint' => true],
+ * ]);
+ * ```
+ *
+ * 2. From WordPress Ability (ability-backed):
+ * ```php
+ * $tool = McpTool::fromAbility($ability);
+ * ```
+ *
+ * @since n.e.x.t
  */
-class McpTool {
+final class McpTool implements McpComponentInterface {
+
+
+	// =========================================================================
+	// Runtime Properties
+	// =========================================================================
 
 	/**
-	 * Ability name for the tool, used for registration.
+	 * Clean Tool DTO (protocol-only).
 	 *
-	 * @var string
+	 * @var \WP\McpSchema\Server\Tools\DTO\Tool
 	 */
-	private string $ability;
+	private Tool $tool;
 
 	/**
-	 * Unique identifier for the tool.
+	 * Ability used for execution/permission checks (ability-backed tools).
 	 *
-	 * @var string
+	 * @var \WP_Ability|null
 	 */
-	private string $name;
+	private ?\WP_Ability $ability = null;
 
 	/**
-	 * Optional human-readable name of the tool for display purposes.
+	 * Direct execution handler (callable-backed tools).
 	 *
-	 * @var string|null
+	 * @var callable|null
 	 */
-	private ?string $title;
+	private $handler = null;
 
 	/**
-	 * Human-readable description of functionality.
+	 * Direct permission callback (callable-backed tools).
 	 *
-	 * @var string
+	 * @var callable|null
 	 */
-	private string $description;
+	private $permission_callback = null;
 
 	/**
-	 * JSON Schema defining expected parameters.
+	 * Internal adapter metadata (never exposed to clients).
 	 *
-	 * @var array
+	 * @var array<string, mixed>
 	 */
-	private array $input_schema;
+	private array $adapter_meta = array();
 
 	/**
-	 * Optional JSON Schema defining expected output structure.
+	 * Observability context tags for logging/metrics.
 	 *
-	 * @var array|null
+	 * @var array<string, mixed>
 	 */
-	private ?array $output_schema;
+	private array $observability_context = array();
+
+	// =========================================================================
+	// Constructor
+	// =========================================================================
 
 	/**
-	 * Optional properties describing tool behavior.
+	 * Private constructor - use factory methods.
 	 *
-	 * @var array
+	 * @param \WP\McpSchema\Server\Tools\DTO\Tool $tool The Tool DTO.
 	 */
-	private array $annotations;
-
-	/**
-	 * Internal metadata used by the server (not exposed to MCP clients).
-	 *
-	 * @var array
-	 */
-	private array $metadata;
-
-	/**
-	 * The MCP server instance this tool belongs to.
-	 *
-	 * @var \WP\MCP\Core\McpServer|null
-	 */
-	private ?McpServer $mcp_server = null;
-
-	/**
-	 * Constructor for McpTool.
-	 *
-	 * @param string      $ability The ability name.
-	 * @param string      $name Unique identifier for the tool.
-	 * @param string      $description Human-readable description of functionality.
-	 * @param array       $input_schema JSON Schema defining expected parameters.
-	 * @param string|null $title Optional human-readable name for display.
-	 * @param array|null  $output_schema Optional JSON Schema for output structure.
-	 * @param array       $annotations Optional properties describing tool behavior.
-	 * @param array       $metadata Internal metadata used by the server (not returned to clients).
-	 */
-	public function __construct(
-		string $ability,
-		string $name,
-		string $description,
-		array $input_schema,
-		?string $title = null,
-		?array $output_schema = null,
-		array $annotations = array(),
-		array $metadata = array()
-	) {
-		$this->ability       = $ability;
-		$this->name          = $name;
-		$this->title         = $title;
-		$this->description   = $description;
-		$this->input_schema  = $input_schema;
-		$this->output_schema = $output_schema;
-		$this->annotations   = $annotations;
-		$this->metadata      = $metadata;
+	private function __construct( Tool $tool ) {
+		$this->tool = $tool;
 	}
 
-	/**
-	 * Get the ability name.
-	 *
-	 * @return \WP_Ability|\WP_Error WP_Ability instance on success, WP_Error on failure.
-	 */
-	public function get_ability() {
-		$ability = wp_get_ability( $this->ability );
-		if ( ! $ability ) {
-			return new \WP_Error(
-				'ability_not_found',
-				sprintf(
-					/* translators: %s: ability name */
-					esc_html__( "WordPress ability '%s' does not exist.", 'mcp-adapter' ),
-					esc_html( $this->ability )
-				)
-			);
-		}
-		return $ability;
-	}
+	// =========================================================================
+	// Factory Methods
+	// =========================================================================
 
 	/**
-	 * Get the tool name.
+	 * Create a tool definition from an array configuration.
 	 *
-	 * @return string
+	 * @param array $config The tool configuration array.
+	 *
+	 * @return self|\WP_Error
 	 */
-	public function get_name(): string {
-		return $this->name;
-	}
-
-	/**
-	 * Get the tool title.
-	 *
-	 * @return string|null
-	 */
-	public function get_title(): ?string {
-		return $this->title;
-	}
-
-	/**
-	 * Get the tool description.
-	 *
-	 * @return string
-	 */
-	public function get_description(): string {
-		return $this->description;
-	}
-
-	/**
-	 * Get the input schema.
-	 *
-	 * @return array
-	 */
-	public function get_input_schema(): array {
-		return $this->input_schema;
-	}
-
-	/**
-	 * Get the output schema.
-	 *
-	 * @return array|null
-	 */
-	public function get_output_schema(): ?array {
-		return $this->output_schema;
-	}
-
-	/**
-	 * Get the annotations.
-	 *
-	 * @return array
-	 */
-	public function get_annotations(): array {
-		return $this->annotations;
-	}
-
-	/**
-	 * Get internal metadata for server-side processing.
-	 *
-	 * @return array
-	 */
-	public function get_metadata(): array {
-		return $this->metadata;
-	}
-
-	/**
-	 * Set the tool title.
-	 *
-	 * @param string|null $title The title to set.
-	 *
-	 * @return void
-	 */
-	public function set_title( ?string $title ): void {
-		$this->title = $title;
-	}
-
-	/**
-	 * Set the tool description.
-	 *
-	 * @param string $description The description to set.
-	 *
-	 * @return void
-	 */
-	public function set_description( string $description ): void {
-		$this->description = $description;
-	}
-
-	/**
-	 * Set the input schema.
-	 *
-	 * @param array $input_schema The input schema to set.
-	 *
-	 * @return void
-	 */
-	public function set_input_schema( array $input_schema ): void {
-		$this->input_schema = $input_schema;
-	}
-
-	/**
-	 * Set the output schema.
-	 *
-	 * @param array|null $output_schema The output schema to set.
-	 *
-	 * @return void
-	 */
-	public function set_output_schema( ?array $output_schema ): void {
-		$this->output_schema = $output_schema;
-	}
-
-	/**
-	 * Set the annotations.
-	 *
-	 * @param array $annotations The annotations to set.
-	 *
-	 * @return void
-	 */
-	public function set_annotations( array $annotations ): void {
-		$this->annotations = $annotations;
-	}
-
-	/**
-	 * Set internal metadata.
-	 *
-	 * @param array $metadata Internal metadata values.
-	 *
-	 * @return void
-	 */
-	public function set_metadata( array $metadata ): void {
-		$this->metadata = $metadata;
-	}
-
-	/**
-	 * Add an annotation.
-	 *
-	 * @param string $key The annotation key.
-	 * @param mixed  $value The annotation value.
-	 *
-	 * @return void
-	 */
-	public function add_annotation( string $key, $value ): void {
-		$this->annotations[ $key ] = $value;
-	}
-
-	/**
-	 * Remove an annotation.
-	 *
-	 * @param string $key The annotation key to remove.
-	 *
-	 * @return void
-	 */
-	public function remove_annotation( string $key ): void {
-		unset( $this->annotations[ $key ] );
-	}
-
-	/**
-	 * Get the MCP server instance this tool belongs to.
-	 *
-	 * @return \WP\MCP\Core\McpServer
-	 */
-	public function get_mcp_server(): McpServer {
-		if ( null === $this->mcp_server ) {
-			throw new \RuntimeException( 'MCP server has not been set on this tool instance.' );
+	public static function fromArray( array $config ) {
+		if ( empty( $config['name'] ) ) {
+			return new \WP_Error( 'mcp_tool_missing_name', 'Tool configuration must include a "name" field.' );
 		}
 
-		return $this->mcp_server;
-	}
+		if ( ! isset( $config['handler'] ) || ! is_callable( $config['handler'] ) ) {
+			return new \WP_Error( 'mcp_tool_missing_handler', 'Tool configuration must include a callable "handler" field.' );
+		}
 
-	/**
-	 * Set the MCP server instance this tool belongs to.
-	 *
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server instance.
-	 *
-	 * @return void
-	 */
-	public function set_mcp_server( McpServer $mcp_server ): void {
-		$this->mcp_server = $mcp_server;
-	}
+		// Prepare input schema - ensure it's an object type for MCP compliance.
+		$input_schema = $config['inputSchema'] ?? array( 'type' => 'object' );
+		if ( ! isset( $input_schema['type'] ) ) {
+			$input_schema['type'] = 'object';
+		}
 
-	/**
-	 * Convert the tool to an array representation according to MCP specification.
-	 *
-	 * @return array
-	 */
-	public function to_array(): array {
-		$input_schema_for_json = empty( $this->input_schema )
-			? array( 'type' => 'object' )
-			: $this->input_schema;
-
+		// Build tool data array.
 		$tool_data = array(
-			'name'        => $this->name,
-			'description' => $this->description,
-			'inputSchema' => $input_schema_for_json,
+			'name'        => $config['name'],
+			'inputSchema' => $input_schema,
 		);
 
-		if ( ! is_null( $this->title ) ) {
-			$tool_data['title'] = $this->title;
+		// Optional fields.
+		if ( isset( $config['title'] ) ) {
+			$tool_data['title'] = $config['title'];
 		}
 
-		if ( ! is_null( $this->output_schema ) ) {
-			$tool_data['outputSchema'] = $this->output_schema;
+		if ( isset( $config['description'] ) ) {
+			$tool_data['description'] = $config['description'];
 		}
 
-		if ( ! empty( $this->annotations ) ) {
-			$tool_data['annotations'] = $this->annotations;
+		if ( isset( $config['outputSchema'] ) && is_array( $config['outputSchema'] ) ) {
+			$tool_data['outputSchema'] = $config['outputSchema'];
 		}
 
-		return $tool_data;
-	}
+		// Validate and prepare icons if set.
+		if ( isset( $config['icons'] ) && is_array( $config['icons'] ) && ! empty( $config['icons'] ) ) {
+			$icons_result = McpValidator::validate_icons_array( $config['icons'] );
+			if ( ! empty( $icons_result['valid'] ) ) {
+				$tool_data['icons'] = $icons_result['valid'];
+			}
+		}
 
-	/**
-	 * Create an McpTool instance from an array.
-	 *
-	 * @param array     $data Array containing tool data.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server instance.
-	 *
-	 * @return self|\WP_Error Returns a new McpTool instance or WP_Error if validation fails.
-	 */
-	public static function from_array( array $data, McpServer $mcp_server ) {
-		$tool = new self(
-			$data['ability'] ?? '',
-			$data['name'] ?? '',
-			$data['description'] ?? '',
-			$data['inputSchema'] ?? array(),
-			$data['title'] ?? null,
-			$data['outputSchema'] ?? null,
-			$data['annotations'] ?? array(),
-			$data['_metadata'] ?? array()
-		);
-		$tool->set_mcp_server( $mcp_server );
+		// Preserve user-provided _meta as-is.
+		if ( isset( $config['meta'] ) && is_array( $config['meta'] ) && ! empty( $config['meta'] ) ) {
+			$tool_data['_meta'] = $config['meta'];
+		}
 
-		return $tool->validate( "McpTool::from_array::{$data['name']}" );
-	}
+		// Create the Tool DTO - wrap in try-catch since ToolAnnotations::fromArray() and Tool::fromArray() can throw.
+		try {
+			// Process annotations inside try-catch since ToolAnnotations::fromArray() can throw.
+			if ( isset( $config['annotations'] ) && is_array( $config['annotations'] ) && ! empty( $config['annotations'] ) ) {
+				$tool_data['annotations'] = ToolAnnotations::fromArray( $config['annotations'] );
+			}
 
-	/**
-	 * Validate the tool according to MCP specification requirements.
-	 * Uses the centralized McpToolValidator for consistent validation.
-	 *
-	 * @param string $context Optional context for error messages.
-	 *
-	 * @return self|\WP_Error Returns the validated tool instance or WP_Error if validation fails.
-	 */
-	public function validate( string $context = '' ) {
-		if ( null === $this->mcp_server ) {
+			$tool = Tool::fromArray( $tool_data );
+		} catch ( \Throwable $e ) {
 			return new \WP_Error(
-				'tool_missing_mcp_server',
-				esc_html__( 'MCP server must be set before validating a tool.', 'mcp-adapter' )
+				'mcp_tool_dto_creation_failed',
+				sprintf(
+				/* translators: %s: error message */
+					__( 'Failed to create Tool DTO: %s', 'mcp-adapter' ),
+					$e->getMessage()
+				),
+				array( 'exception' => $e )
 			);
 		}
 
-		if ( ! $this->mcp_server->is_mcp_validation_enabled() ) {
-			return $this;
+		// Optional deep validation if enabled.
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		if ( $mcp_validation_enabled ) {
+			$validation_result = McpToolValidator::validate_tool_dto( $tool );
+			if ( is_wp_error( $validation_result ) ) {
+				return $validation_result;
+			}
 		}
 
-		$context_to_use    = $context ?: "McpTool::{$this->name}";
-		$validation_result = McpToolValidator::validate_tool_instance( $this, $context_to_use );
+		$instance          = new self( $tool );
+		$instance->handler = $config['handler'];
 
-		if ( is_wp_error( $validation_result ) ) {
-			return $validation_result;
+		if ( isset( $config['permission'] ) && is_callable( $config['permission'] ) ) {
+			$instance->permission_callback = $config['permission'];
 		}
 
-		return $this;
+		$instance->observability_context = array(
+			'component_type' => 'tool',
+			'tool_name'      => $config['name'],
+			'source'         => 'array',
+		);
+
+		return $instance;
+	}
+
+	/**
+	 * Create an ability-backed MCP tool.
+	 *
+	 * @param \WP_Ability $ability WordPress ability.
+	 *
+	 * @return self|\WP_Error
+	 */
+	public static function fromAbility( \WP_Ability $ability ) {
+		$tool_data = RegisterAbilityAsMcpTool::build( $ability );
+		if ( $tool_data instanceof \WP_Error ) {
+			return $tool_data;
+		}
+
+		$instance               = new self( $tool_data['tool'] );
+		$instance->adapter_meta = $tool_data['adapter_meta'];
+		$instance->ability      = $ability;
+
+		$instance->observability_context = array(
+			'component_type' => 'tool',
+			'tool_name'      => $tool_data['tool']->getName(),
+			'ability_name'   => $ability->get_name(),
+			'source'         => 'ability',
+		);
+
+		return $instance;
+	}
+
+	// =========================================================================
+	// McpComponentInterface Implementation
+	// =========================================================================
+
+	/**
+	 * Get the clean protocol DTO for MCP responses.
+	 *
+	 * @return \WP\McpSchema\Server\Tools\DTO\Tool
+	 */
+	public function get_component(): Tool {
+		return $this->tool;
+	}
+
+	/**
+	 * Execute the tool.
+	 *
+	 * @param mixed $arguments Tool arguments.
+	 *
+	 * @return mixed
+	 */
+	public function execute( $arguments ) {
+		$args = $this->unwrap_input_if_needed( $arguments );
+
+		if ( null !== $this->ability ) {
+			$args = AbilityArgumentNormalizer::normalize( $this->ability, $args );
+
+			try {
+				$result = $this->ability->execute( $args );
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_execution_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		} elseif ( null !== $this->handler ) {
+			try {
+				$result = call_user_func( $this->handler, $args );
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_execution_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		} else {
+			return new \WP_Error( 'mcp_tool_no_handler', 'No tool execution strategy configured.' );
+		}
+
+		if ( $result instanceof \WP_Error ) {
+			return $result;
+		}
+
+		$result = $this->wrap_output_if_needed( $result );
+
+		if ( ! is_array( $result ) ) {
+			$result = array( 'result' => $result );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Unwrap tool input arguments when the input schema was transformed (flattened → object wrapper).
+	 *
+	 * @param mixed $arguments Raw tool arguments.
+	 *
+	 * @return mixed
+	 */
+	private function unwrap_input_if_needed( $arguments ) {
+		$is_transformed = true === ( $this->adapter_meta['input_schema_transformed'] ?? false );
+
+		if ( ! $is_transformed ) {
+			return $arguments;
+		}
+
+		$wrapper = $this->adapter_meta['input_schema_wrapper'] ?? 'input';
+		$wrapper = is_string( $wrapper ) && '' !== trim( $wrapper ) ? $wrapper : 'input';
+
+		return is_array( $arguments ) ? ( $arguments[ $wrapper ] ?? null ) : null;
+	}
+
+	/**
+	 * Wrap tool results when the output schema was transformed (flattened → object wrapper).
+	 *
+	 * @param mixed $result Raw result.
+	 *
+	 * @return mixed
+	 */
+	private function wrap_output_if_needed( $result ) {
+		$is_transformed = true === ( $this->adapter_meta['output_schema_transformed'] ?? false );
+
+		if ( ! $is_transformed ) {
+			return $result;
+		}
+
+		$wrapper = $this->adapter_meta['output_schema_wrapper'] ?? 'result';
+		$wrapper = is_string( $wrapper ) && '' !== trim( $wrapper ) ? $wrapper : 'result';
+
+		return array( $wrapper => $result );
+	}
+
+	/**
+	 * Check whether the current request has permission to execute this tool.
+	 *
+	 * @param mixed $arguments Tool arguments.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public function check_permission( $arguments ) {
+		$args = $this->unwrap_input_if_needed( $arguments );
+
+		// Ability-backed tools delegate to the ability's permission system.
+		if ( null !== $this->ability ) {
+			$args = AbilityArgumentNormalizer::normalize( $this->ability, $args );
+
+			try {
+				return $this->ability->check_permissions( $args );
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_permission_check_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		}
+
+		// Callable-backed tools use their required permission callback.
+		if ( null !== $this->permission_callback ) {
+			try {
+				$result = call_user_func( $this->permission_callback, $args );
+
+				return $result instanceof \WP_Error ? $result : (bool) $result;
+			} catch ( \Throwable $throwable ) {
+				return new \WP_Error(
+					'mcp_permission_check_failed',
+					$throwable->getMessage(),
+					array( 'error_type' => get_class( $throwable ) )
+				);
+			}
+		}
+
+		// Defensive fallback: should never reach here if factories are used correctly.
+		return new \WP_Error(
+			'mcp_permission_denied',
+			'Access denied.',
+			array(
+				'failure_reason' => FailureReason::NO_PERMISSION_STRATEGY,
+				'tool_name'      => $this->tool->getName(),
+			)
+		);
+	}
+
+	// =========================================================================
+	// Private Helper Methods
+	// =========================================================================
+
+	/**
+	 * Get internal adapter metadata for this tool.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_adapter_meta(): array {
+		return $this->adapter_meta;
+	}
+
+	/**
+	 * Get observability context tags for logging/metrics.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_observability_context(): array {
+		return $this->observability_context;
 	}
 }

--- a/includes/Domain/Tools/McpTool.php
+++ b/includes/Domain/Tools/McpTool.php
@@ -14,7 +14,7 @@ use WP\MCP\Domain\Contracts\McpComponentInterface;
 use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\Observability\FailureReason;
-use WP\McpSchema\Server\Tools\DTO\Tool;
+use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 use WP\McpSchema\Server\Tools\DTO\ToolAnnotations;
 
 /**
@@ -40,6 +40,10 @@ use WP\McpSchema\Server\Tools\DTO\ToolAnnotations;
  * $tool = McpTool::fromAbility($ability);
  * ```
  *
+ * McpTool wraps a protocol-only ToolDto for MCP serialization. Internal
+ * adapter metadata and execution wiring live on this class and are never
+ * exposed to MCP clients. Use get_protocol_dto() for protocol responses.
+ *
  * @since n.e.x.t
  */
 final class McpTool implements McpComponentInterface {
@@ -52,9 +56,9 @@ final class McpTool implements McpComponentInterface {
 	/**
 	 * Clean Tool DTO (protocol-only).
 	 *
-	 * @var \WP\McpSchema\Server\Tools\DTO\Tool
+	 * @var ToolDto
 	 */
-	private Tool $tool;
+	private ToolDto $tool;
 
 	/**
 	 * Ability used for execution/permission checks (ability-backed tools).
@@ -98,9 +102,9 @@ final class McpTool implements McpComponentInterface {
 	/**
 	 * Private constructor - use factory methods.
 	 *
-	 * @param \WP\McpSchema\Server\Tools\DTO\Tool $tool The Tool DTO.
+	 * @param ToolDto $tool The Tool DTO.
 	 */
-	private function __construct( Tool $tool ) {
+	private function __construct( ToolDto $tool ) {
 		$this->tool = $tool;
 	}
 
@@ -162,14 +166,14 @@ final class McpTool implements McpComponentInterface {
 			$tool_data['_meta'] = $config['meta'];
 		}
 
-		// Create the Tool DTO - wrap in try-catch since ToolAnnotations::fromArray() and Tool::fromArray() can throw.
+		// Create the Tool DTO - wrap in try-catch since ToolAnnotations::fromArray() and ToolDto::fromArray() can throw.
 		try {
 			// Process annotations inside try-catch since ToolAnnotations::fromArray() can throw.
 			if ( isset( $config['annotations'] ) && is_array( $config['annotations'] ) && ! empty( $config['annotations'] ) ) {
 				$tool_data['annotations'] = ToolAnnotations::fromArray( $config['annotations'] );
 			}
 
-			$tool = Tool::fromArray( $tool_data );
+			$tool = ToolDto::fromArray( $tool_data );
 		} catch ( \Throwable $e ) {
 			return new \WP_Error(
 				'mcp_tool_dto_creation_failed',
@@ -241,9 +245,9 @@ final class McpTool implements McpComponentInterface {
 	/**
 	 * Get the clean protocol DTO for MCP responses.
 	 *
-	 * @return \WP\McpSchema\Server\Tools\DTO\Tool
+	 * @return ToolDto
 	 */
-	public function get_component(): Tool {
+	public function get_protocol_dto(): ToolDto {
 		return $this->tool;
 	}
 

--- a/includes/Domain/Tools/McpTool.php
+++ b/includes/Domain/Tools/McpTool.php
@@ -56,7 +56,7 @@ final class McpTool implements McpComponentInterface {
 	/**
 	 * Clean Tool DTO (protocol-only).
 	 *
-	 * @var ToolDto
+	 * @var \WP\McpSchema\Server\Tools\DTO\Tool
 	 */
 	private ToolDto $tool;
 
@@ -102,7 +102,7 @@ final class McpTool implements McpComponentInterface {
 	/**
 	 * Private constructor - use factory methods.
 	 *
-	 * @param ToolDto $tool The Tool DTO.
+	 * @param \WP\McpSchema\Server\Tools\DTO\Tool $tool The Tool DTO.
 	 */
 	private function __construct( ToolDto $tool ) {
 		$this->tool = $tool;
@@ -245,7 +245,7 @@ final class McpTool implements McpComponentInterface {
 	/**
 	 * Get the clean protocol DTO for MCP responses.
 	 *
-	 * @return ToolDto
+	 * @return \WP\McpSchema\Server\Tools\DTO\Tool
 	 */
 	public function get_protocol_dto(): ToolDto {
 		return $this->tool;

--- a/includes/Domain/Tools/McpToolValidator.php
+++ b/includes/Domain/Tools/McpToolValidator.php
@@ -10,7 +10,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Domain\Tools;
 
 use WP\MCP\Domain\Utils\McpValidator;
-use stdClass;
+use WP\McpSchema\Server\Tools\DTO\Tool;
 
 /**
  * Validates MCP tools against the Model Context Protocol specification.
@@ -18,9 +18,22 @@ use stdClass;
  * Provides minimal, resource-efficient validation to ensure tools conform
  * to the MCP schema requirements without heavy processing overhead.
  *
- * @link https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+ * @link https://modelcontextprotocol.io/specification/2025-11-25/server/tools
  */
 class McpToolValidator {
+
+	/**
+	 * Valid task support values for tool execution.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var array<string>
+	 */
+	private static array $valid_task_support_values = array(
+		'forbidden',
+		'optional',
+		'required',
+	);
 
 	/**
 	 * Validate the MCP tool data array against the MCP schema.
@@ -34,13 +47,13 @@ class McpToolValidator {
 		$validation_errors = self::get_validation_errors( $tool_data );
 
 		if ( ! empty( $validation_errors ) ) {
-			$error_message  = $context ? "[{$context}] " : '';
+			$error_message  = $context ? "[$context] " : '';
 			$error_message .= sprintf(
 			/* translators: %s: comma-separated list of validation errors */
 				__( 'Tool validation failed: %s', 'mcp-adapter' ),
 				implode( ', ', $validation_errors )
 			);
-			return new \WP_Error( 'tool_validation_failed', esc_html( $error_message ) );
+			return new \WP_Error( 'mcp_tool_validation_failed', esc_html( $error_message ) );
 		}
 
 		return true;
@@ -55,12 +68,81 @@ class McpToolValidator {
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
 	public static function validate_tool_instance( McpTool $tool, string $context = '' ) {
-		$uniqueness_result = self::validate_tool_uniqueness( $tool, $context );
-		if ( is_wp_error( $uniqueness_result ) ) {
-			return $uniqueness_result;
+		return self::validate_tool_data( $tool->get_component()->toArray(), $context );
+	}
+
+	/**
+	 * Validate a Tool DTO against the MCP schema.
+	 *
+	 * @param \WP\McpSchema\Server\Tools\DTO\Tool $tool The tool DTO to validate.
+	 *
+	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
+	 */
+	public static function validate_tool_dto( Tool $tool ) {
+		$errors = array();
+
+		// Validate name (required, 1-128 chars, alphanumeric + _.-).
+		if ( ! McpValidator::validate_name( $tool->getName() ) ) {
+			$errors[] = __( 'Tool name must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'mcp-adapter' );
 		}
 
-		return self::validate_tool_data( $tool->to_array(), $context );
+		// Validate icons if present.
+		$icons = $tool->getIcons();
+		if ( ! empty( $icons ) ) {
+			// Convert DTO icons to arrays for validation.
+			$icons_array  = array_map( static fn( $icon ) => $icon->toArray(), $icons );
+			$icons_result = McpValidator::validate_icons_array( $icons_array );
+			$icons_errors = self::format_icon_validation_errors( $icons_result );
+			$errors       = array_merge( $errors, $icons_errors );
+		}
+
+		// Validate annotations if present (tool-specific only).
+		$annotations = $tool->getAnnotations();
+		if ( $annotations ) {
+			$annotations_array = $annotations->toArray();
+			$annotation_errors = self::get_tool_annotation_validation_errors( $annotations_array );
+			$errors            = array_merge( $errors, $annotation_errors );
+		}
+
+		// Validate execution if present.
+		$execution = $tool->getExecution();
+		if ( $execution ) {
+			$execution_array  = $execution->toArray();
+			$execution_errors = self::get_execution_validation_errors( $execution_array );
+			$errors           = array_merge( $errors, $execution_errors );
+		}
+
+		// Validate schemas (inputSchema and outputSchema).
+		$tool_array = $tool->toArray();
+
+		// Validate inputSchema (required field).
+		$input_schema_errors = self::get_schema_validation_errors(
+			$tool_array['inputSchema'] ?? null,
+			'inputSchema'
+		);
+		$errors              = array_merge( $errors, $input_schema_errors );
+
+		// Validate outputSchema if present (optional field).
+		if ( isset( $tool_array['outputSchema'] ) ) {
+			$output_schema_errors = self::get_schema_validation_errors(
+				$tool_array['outputSchema'],
+				'outputSchema'
+			);
+			$errors               = array_merge( $errors, $output_schema_errors );
+		}
+
+		if ( ! empty( $errors ) ) {
+			return new \WP_Error(
+				'mcp_tool_validation_failed',
+				sprintf(
+				/* translators: %s: list of validation errors */
+					__( 'Tool validation failed: %s', 'mcp-adapter' ),
+					implode( '; ', $errors )
+				)
+			);
+		}
+
+		return true;
 	}
 
 	/**
@@ -74,24 +156,14 @@ class McpToolValidator {
 	public static function get_validation_errors( array $tool_data ): array {
 		$errors = array();
 
-		// Sanitize string inputs.
-		if ( isset( $tool_data['name'] ) && is_string( $tool_data['name'] ) ) {
-			$tool_data['name'] = trim( $tool_data['name'] );
-		}
-		if ( isset( $tool_data['description'] ) && is_string( $tool_data['description'] ) ) {
-			$tool_data['description'] = trim( $tool_data['description'] );
-		}
-		if ( isset( $tool_data['title'] ) && is_string( $tool_data['title'] ) ) {
-			$tool_data['title'] = trim( $tool_data['title'] );
+		// Check the required field: name.
+		if ( empty( $tool_data['name'] ) || ! is_string( $tool_data['name'] ) || ! McpValidator::validate_name( $tool_data['name'] ) ) {
+			$errors[] = __( 'Tool name is required and must only contain letters, numbers, hyphens (-), underscores (_), and dots (.), and be 128 characters or less', 'mcp-adapter' );
 		}
 
-		// Check the required fields.
-		if ( empty( $tool_data['name'] ) || ! is_string( $tool_data['name'] ) || ! McpValidator::validate_tool_or_prompt_name( $tool_data['name'] ) ) {
-			$errors[] = __( 'Tool name is required and must only contain letters, numbers, hyphens (-), and underscores (_), and be 255 characters or less', 'mcp-adapter' );
-		}
-
-		if ( empty( $tool_data['description'] ) || ! is_string( $tool_data['description'] ) ) {
-			$errors[] = __( 'Tool description is required and must be a non-empty string', 'mcp-adapter' );
+		// Description is optional per MCP 2025-11-25 spec, but validate if present.
+		if ( isset( $tool_data['description'] ) && ! is_string( $tool_data['description'] ) ) {
+			$errors[] = __( 'Tool description must be a string if provided', 'mcp-adapter' );
 		}
 
 		// Validate inputSchema (required field).
@@ -113,23 +185,38 @@ class McpToolValidator {
 			}
 		}
 
-		// Validate annotations structure if present.
+		// Validate icons (optional field, new in 2025-11-25).
+		if ( isset( $tool_data['icons'] ) ) {
+			$icons_errors = self::get_icons_validation_errors( $tool_data['icons'] );
+			if ( ! empty( $icons_errors ) ) {
+				$errors = array_merge( $errors, $icons_errors );
+			}
+		}
+
+		// Validate execution (optional field, new in 2025-11-25).
+		if ( isset( $tool_data['execution'] ) ) {
+			$execution_errors = self::get_execution_validation_errors( $tool_data['execution'] );
+			if ( ! empty( $execution_errors ) ) {
+				$errors = array_merge( $errors, $execution_errors );
+			}
+		}
+
+		// Validate annotations structure if present (tool-specific annotations only).
 		if ( isset( $tool_data['annotations'] ) ) {
 			if ( ! is_array( $tool_data['annotations'] ) ) {
 				$errors[] = __( 'Tool annotations must be an array if provided', 'mcp-adapter' );
 			} else {
-				// Validate shared annotations (audience, lastModified, priority).
-				$shared_annotation_errors = McpValidator::get_annotation_validation_errors( $tool_data['annotations'] );
-				if ( ! empty( $shared_annotation_errors ) ) {
-					$errors = array_merge( $errors, $shared_annotation_errors );
-				}
-
 				// Validate tool-specific annotations (readOnlyHint, destructiveHint, etc.).
-				$tool_annotation_errors = McpValidator::get_tool_annotation_validation_errors( $tool_data['annotations'] );
+				$tool_annotation_errors = self::get_tool_annotation_validation_errors( $tool_data['annotations'] );
 				if ( ! empty( $tool_annotation_errors ) ) {
 					$errors = array_merge( $errors, $tool_annotation_errors );
 				}
 			}
+		}
+
+		// Validate _meta (optional field).
+		if ( isset( $tool_data['_meta'] ) && ! is_array( $tool_data['_meta'] ) ) {
+			$errors[] = __( 'Tool _meta must be an object/array if provided', 'mcp-adapter' );
 		}
 
 		return $errors;
@@ -144,8 +231,8 @@ class McpToolValidator {
 	 * @return array Array of validation errors, empty if valid.
 	 */
 	private static function get_schema_validation_errors( $schema, string $field_name ): array {
-		// Normalize stdClass to array for validation, and reject scalars/null.
-		if ( $schema instanceof stdClass ) {
+		// Normalize stdClass to array for validation and reject scalars/null.
+		if ( $schema instanceof \stdClass ) {
 			$schema = (array) $schema;
 		}
 
@@ -162,12 +249,17 @@ class McpToolValidator {
 
 		$errors = array();
 
-		// Input schemas commonly describe an object of arguments. Allow omitted type (empty schema) or type 'object'.
-		// For output schemas, do not enforce a specific type; any valid JSON Schema is acceptable per MCP.
-		if ( 'inputSchema' === $field_name && isset( $schema['type'] ) && 'object' !== $schema['type'] ) {
+		// MCP Tool inputSchema and outputSchema are currently restricted to a root type of "object".
+		if ( ! isset( $schema['type'] ) ) {
 			$errors[] = sprintf(
 			/* translators: %s: field name */
-				__( 'Tool %s, if specifying a type, must use type \'object\'', 'mcp-adapter' ),
+				__( 'Tool %s must specify a root type of \'object\'', 'mcp-adapter' ),
+				$field_name
+			);
+		} elseif ( ! is_string( $schema['type'] ) || 'object' !== $schema['type'] ) {
+			$errors[] = sprintf(
+			/* translators: %s: field name */
+				__( 'Tool %s root type must be \'object\'', 'mcp-adapter' ),
 				$field_name
 			);
 		}
@@ -193,6 +285,11 @@ class McpToolValidator {
 		// If properties are provided, validate their basic structure.
 		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
 			foreach ( $schema['properties'] as $property_name => $property ) {
+				// Normalize stdClass to array for property validation.
+				if ( $property instanceof \stdClass ) {
+					$property = (array) $property;
+				}
+
 				if ( ! is_array( $property ) ) {
 					$errors[] = sprintf(
 					/* translators: %1$s: field name, %2$s: property name */
@@ -208,7 +305,7 @@ class McpToolValidator {
 					continue;
 				}
 
-				// If type is neither string nor array, it's invalid.
+				// If the type is neither string nor array, it's invalid.
 				$errors[] = sprintf(
 				/* translators: %1$s: field name, %2$s: property name */
 					__( 'Tool %1$s property \'%2$s\' type must be a string or array of strings (union type)', 'mcp-adapter' ),
@@ -218,7 +315,7 @@ class McpToolValidator {
 			}
 		}
 
-		// If required array is provided, validate its structure.
+		// If the required array is provided, validate its structure.
 		if ( isset( $schema['required'] ) && is_array( $schema['required'] ) ) {
 			foreach ( $schema['required'] as $required_field ) {
 				if ( ! is_string( $required_field ) ) {
@@ -248,30 +345,137 @@ class McpToolValidator {
 	}
 
 	/**
-	 * Validate that the tool name is unique within the server.
+	 * Get validation errors for tool icons array.
 	 *
-	 * @param \WP\MCP\Domain\Tools\McpTool $tool The tool instance to validate.
-	 * @param string  $context Optional context for error messages.
+	 * @param mixed $icons The icons data to validate.
 	 *
-	 * @return bool|\WP_Error True if unique, WP_Error if the tool name is not unique.
+	 * @return array Array of validation errors, empty if valid.
 	 */
-	public static function validate_tool_uniqueness( McpTool $tool, string $context = '' ) {
-		$this_tool_name = $tool->get_name();
-		$server         = $tool->get_mcp_server();
-		$existing_tool  = $server->get_tool( $this_tool_name );
-
-		// Check if a tool with this name already exists.
-		if ( $existing_tool ) {
-			$error_message  = $context ? "[{$context}] " : '';
-			$error_message .= sprintf(
-			/* translators: %1$s: tool name, %2$s: server ID */
-				__( 'Tool name \'%1$s\' is not unique. A tool with this name already exists on server \'%2$s\'.', 'mcp-adapter' ),
-				$this_tool_name,
-				$server->get_server_id()
-			);
-			return new \WP_Error( 'tool_not_unique', esc_html( $error_message ) );
+	private static function get_icons_validation_errors( $icons ): array {
+		if ( ! is_array( $icons ) ) {
+			return array( __( 'Tool icons must be an array if provided', 'mcp-adapter' ) );
 		}
 
-		return true;
+		$icons_result = McpValidator::validate_icons_array( $icons, false );
+
+		return self::format_icon_validation_errors( $icons_result );
+	}
+
+	/**
+	 * Format icon validation errors from the validation result.
+	 *
+	 * @param array{valid: array, errors: array} $icons_result The result from validate_icons_array.
+	 *
+	 * @return array Array of formatted error messages.
+	 */
+	private static function format_icon_validation_errors( array $icons_result ): array {
+		$errors = array();
+
+		if ( ! empty( $icons_result['errors'] ) ) {
+			foreach ( $icons_result['errors'] as $error_group ) {
+				foreach ( $error_group['errors'] as $error ) {
+					$errors[] = sprintf(
+					/* translators: 1: icon index, 2: error message */
+						__( 'Icon at index %1$d: %2$s', 'mcp-adapter' ),
+						$error_group['index'],
+						$error
+					);
+				}
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Get validation errors for tool execution properties.
+	 *
+	 * Validates execution-related properties per MCP 2025-11-25 specification:
+	 * - taskSupport must be one of: "forbidden", "optional", "required"
+	 *
+	 * @param mixed $execution The execution data to validate.
+	 *
+	 * @return array Array of validation errors, empty if valid.
+	 */
+	public static function get_execution_validation_errors( $execution ): array {
+		if ( ! is_array( $execution ) ) {
+			return array( __( 'Tool execution must be an object/array if provided', 'mcp-adapter' ) );
+		}
+
+		$errors = array();
+
+		// Validate taskSupport if present.
+		if ( isset( $execution['taskSupport'] ) ) {
+			if ( ! is_string( $execution['taskSupport'] ) ) {
+				$errors[] = __( 'Tool execution taskSupport must be a string', 'mcp-adapter' );
+			} elseif ( ! in_array( $execution['taskSupport'], self::$valid_task_support_values, true ) ) {
+				$errors[] = sprintf(
+				/* translators: %s: comma-separated list of valid values */
+					__( 'Tool execution taskSupport must be one of: %s', 'mcp-adapter' ),
+					implode( ', ', self::$valid_task_support_values )
+				);
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Get validation errors for tool-specific MCP annotations.
+	 *
+	 * Validates tool annotation fields per MCP 2025-11-25 specification:
+	 * - readOnlyHint, destructiveHint, idempotentHint, openWorldHint must be booleans
+	 * - title must be a non-empty string
+	 *
+	 * Note: Tools use ToolAnnotations which is different from the shared Annotations class.
+	 * ToolAnnotations does NOT include audience, lastModified, or priority fields.
+	 *
+	 * @param array $annotations The annotations to validate.
+	 *
+	 * @return array Array of validation errors, empty if valid.
+	 */
+	public static function get_tool_annotation_validation_errors( array $annotations ): array {
+		$errors = array();
+
+		foreach ( $annotations as $field => $value ) {
+			switch ( $field ) {
+				case 'readOnlyHint':
+				case 'destructiveHint':
+				case 'idempotentHint':
+				case 'openWorldHint':
+					if ( ! is_bool( $value ) ) {
+						$errors[] = sprintf(
+						/* translators: %s: annotation field name */
+							__( 'Tool annotation field %s must be a boolean', 'mcp-adapter' ),
+							$field
+						);
+					}
+					break;
+
+				case 'title':
+					if ( ! is_string( $value ) ) {
+						$errors[] = sprintf(
+						/* translators: %s: annotation field name */
+							__( 'Tool annotation field %s must be a string', 'mcp-adapter' ),
+							$field
+						);
+						break;
+					}
+					if ( empty( trim( $value ) ) ) {
+						$errors[] = sprintf(
+						/* translators: %s: annotation field name */
+							__( 'Tool annotation field %s must be a non-empty string', 'mcp-adapter' ),
+							$field
+						);
+					}
+					break;
+
+				default:
+					// Unknown fields are ignored to allow forward compatibility.
+					break;
+			}
+		}
+
+		return $errors;
 	}
 }

--- a/includes/Domain/Tools/McpToolValidator.php
+++ b/includes/Domain/Tools/McpToolValidator.php
@@ -74,7 +74,7 @@ class McpToolValidator {
 	/**
 	 * Validate a Tool DTO against the MCP schema.
 	 *
-	 * @param ToolDto $tool The tool DTO to validate.
+	 * @param \WP\McpSchema\Server\Tools\DTO\Tool $tool The tool DTO to validate.
 	 *
 	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
 	 */

--- a/includes/Domain/Tools/McpToolValidator.php
+++ b/includes/Domain/Tools/McpToolValidator.php
@@ -10,7 +10,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Domain\Tools;
 
 use WP\MCP\Domain\Utils\McpValidator;
-use WP\McpSchema\Server\Tools\DTO\Tool;
+use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 /**
  * Validates MCP tools against the Model Context Protocol specification.
@@ -68,17 +68,17 @@ class McpToolValidator {
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
 	public static function validate_tool_instance( McpTool $tool, string $context = '' ) {
-		return self::validate_tool_data( $tool->get_component()->toArray(), $context );
+		return self::validate_tool_data( $tool->get_protocol_dto()->toArray(), $context );
 	}
 
 	/**
 	 * Validate a Tool DTO against the MCP schema.
 	 *
-	 * @param \WP\McpSchema\Server\Tools\DTO\Tool $tool The tool DTO to validate.
+	 * @param ToolDto $tool The tool DTO to validate.
 	 *
 	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
 	 */
-	public static function validate_tool_dto( Tool $tool ) {
+	public static function validate_tool_dto( ToolDto $tool ) {
 		$errors = array();
 
 		// Validate name (required, 1-128 chars, alphanumeric + _.-).

--- a/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -52,7 +52,7 @@ class RegisterAbilityAsMcpTool {
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return array{tool: ToolDto, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @return array{tool: \WP\McpSchema\Server\Tools\DTO\Tool, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since n.e.x.t
 	 *
 	 */

--- a/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -14,7 +14,7 @@ use WP\MCP\Domain\Utils\McpAnnotationMapper;
 use WP\MCP\Domain\Utils\McpNameSanitizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Domain\Utils\SchemaTransformer;
-use WP\McpSchema\Server\Tools\DTO\Tool;
+use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 /**
  * RegisterAbilityAsMcpTool class.
@@ -52,7 +52,7 @@ class RegisterAbilityAsMcpTool {
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return array{tool: \WP\McpSchema\Server\Tools\DTO\Tool, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @return array{tool: ToolDto, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since n.e.x.t
 	 *
 	 */
@@ -65,7 +65,7 @@ class RegisterAbilityAsMcpTool {
 		}
 
 		try {
-			$tool_dto = Tool::fromArray( $data['tool_data'] );
+			$tool_dto = ToolDto::fromArray( $data['tool_data'] );
 		} catch ( \Throwable $e ) {
 			return new \WP_Error(
 				'mcp_tool_dto_creation_failed',

--- a/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * RegisterAbilityAsMcpTool class for converting WordPress abilities to MCP tools.
  *
@@ -9,72 +10,111 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Tools;
 
-use WP\MCP\Core\McpServer;
 use WP\MCP\Domain\Utils\McpAnnotationMapper;
+use WP\MCP\Domain\Utils\McpNameSanitizer;
+use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Domain\Utils\SchemaTransformer;
-use WP_Ability;
+use WP\McpSchema\Server\Tools\DTO\Tool;
 
 /**
  * RegisterAbilityAsMcpTool class.
  *
  * This class registers a WordPress ability as an MCP tool.
  *
+ * @internal
+ *
  * @package McpAdapter
  */
 class RegisterAbilityAsMcpTool {
+
 	/**
 	 * The WordPress ability instance.
 	 *
 	 * @var \WP_Ability
 	 */
-	private WP_Ability $ability;
-
-	/**
-	 * The MCP server.
-	 *
-	 * @var \WP\MCP\Core\McpServer
-	 */
-	private McpServer $mcp_server;
-
-	/**
-	 * Make a new instance of the class.
-	 *
-	 * @param \WP_Ability            $ability    The ability.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
-	 *
-	 * @return \WP\MCP\Domain\Tools\McpTool|\WP_Error Returns a new instance of McpTool or WP_Error if validation fails.
-	 */
-	public static function make( WP_Ability $ability, McpServer $mcp_server ) {
-		$tool = new self( $ability, $mcp_server );
-
-		return $tool->get_tool();
-	}
+	private \WP_Ability $ability;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param \WP_Ability            $ability    The ability.
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server.
+	 * @param \WP_Ability $ability The ability.
 	 */
-	private function __construct( WP_Ability $ability, McpServer $mcp_server ) {
-		$this->mcp_server = $mcp_server;
-		$this->ability    = $ability;
+	private function __construct( \WP_Ability $ability ) {
+		$this->ability = $ability;
 	}
 
 	/**
-	 * Get the MCP tool data array.
+	 * Build a clean Tool DTO and adapter metadata for internal wiring.
 	 *
-	 * @return array<string,mixed>
+	 * This method returns a protocol-only Tool DTO and provides the adapter metadata
+	 * separately. This keeps the DTO stable across MCP spec changes and avoids coupling internal execution
+	 * wiring to protocol surfaces.
+	 *
+	 * @param \WP_Ability $ability The ability.
+	 *
+	 * @return array{tool: \WP\McpSchema\Server\Tools\DTO\Tool, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @since n.e.x.t
+	 *
 	 */
-	private function get_data(): array {
-		// Transform input schema to MCP-compatible object format
+	public static function build( \WP_Ability $ability ) {
+		$tool = new self( $ability );
+		$data = $tool->build_tool_data();
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		try {
+			$tool_dto = Tool::fromArray( $data['tool_data'] );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error(
+				'mcp_tool_dto_creation_failed',
+				sprintf(
+				/* translators: %s: error message */
+					__( 'Failed to create Tool DTO for ability %1$s: %2$s', 'mcp-adapter' ),
+					$ability->get_name(),
+					$e->getMessage()
+				),
+				array( 'exception' => $e )
+			);
+		}
+
+		// Optional deep validation if enabled.
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		if ( $mcp_validation_enabled ) {
+			$validation_result = McpToolValidator::validate_tool_dto( $tool_dto );
+			if ( is_wp_error( $validation_result ) ) {
+				return $validation_result;
+			}
+		}
+
+		return array(
+			'tool'         => $tool_dto,
+			'adapter_meta' => $data['adapter_meta'],
+		);
+	}
+
+	/**
+	 * Build Tool DTO data and adapter metadata.
+	 *
+	 * @return array{tool_data: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @since n.e.x.t
+	 *
+	 */
+	private function build_tool_data() {
+		// Resolve tool name first (can fail).
+		$tool_name = $this->resolve_tool_name();
+		if ( is_wp_error( $tool_name ) ) {
+			return $tool_name;
+		}
+
+		// Transform input schema to MCP-compatible object format.
 		$input_transform = SchemaTransformer::transform_to_object_schema(
 			$this->ability->get_input_schema()
 		);
 
 		$tool_data = array(
-			'ability'     => $this->ability->get_name(),
-			'name'        => str_replace( '/', '-', trim( $this->ability->get_name() ) ),
+			'name'        => $tool_name,
 			'description' => trim( $this->ability->get_description() ),
 			'inputSchema' => $input_transform['schema'],
 		);
@@ -112,29 +152,90 @@ class RegisterAbilityAsMcpTool {
 		}
 
 		// Store transformation metadata as internal metadata (stripped before responding to clients).
-		if ( $input_transform['was_transformed'] || ( $output_transform && $output_transform['was_transformed'] ) ) {
-			$tool_data['_metadata'] = array();
+		// Only record keys when semantically meaningful to keep metadata minimal and accurate.
+		$adapter_meta = array(
+			'ability' => $this->ability->get_name(),
+		);
 
-			if ( $input_transform['was_transformed'] ) {
-				$tool_data['_metadata']['_input_schema_transformed'] = true;
-				$tool_data['_metadata']['_input_schema_wrapper']     = $input_transform['wrapper_property'] ?? 'input';
-			}
+		// Only record input transformation metadata when a wrapper was actually applied.
+		if ( ! empty( $input_transform['was_transformed'] ) ) {
+			$adapter_meta['input_schema_transformed'] = true;
+			$adapter_meta['input_schema_wrapper']     = $input_transform['wrapper_property'];
+		}
 
-			if ( $output_transform && $output_transform['was_transformed'] ) {
-				$tool_data['_metadata']['_output_schema_transformed'] = true;
-				$tool_data['_metadata']['_output_schema_wrapper']     = $output_transform['wrapper_property'] ?? 'result';
+		// Only record output transformation metadata when outputSchema exists.
+		// Record wrapper only when transformation actually occurred.
+		if ( null !== $output_transform && ! empty( $output_transform['was_transformed'] ) ) {
+			$adapter_meta['output_schema_transformed'] = true;
+			$adapter_meta['output_schema_wrapper']     = $output_transform['wrapper_property'];
+		}
+
+		// Map icons from ability.meta.mcp.icons if present.
+		$mcp_meta = $ability_meta['mcp'] ?? array();
+		if ( ! empty( $mcp_meta['icons'] ) && is_array( $mcp_meta['icons'] ) ) {
+			$icons_result = McpValidator::validate_icons_array( $mcp_meta['icons'] );
+			if ( ! empty( $icons_result['valid'] ) ) {
+				$tool_data['icons'] = $icons_result['valid'];
 			}
 		}
 
-		return $tool_data;
+		// Build Tool `_meta`:
+		// - Preserve user-provided `_meta` from ability.meta.mcp._meta.
+		// - Adapter metadata is NEVER included in protocol DTO meta; it is returned separately in adapter_meta.
+		$tool_meta = array();
+		if ( ! empty( $mcp_meta['_meta'] ) && is_array( $mcp_meta['_meta'] ) ) {
+			$tool_meta = $mcp_meta['_meta'];
+		}
+		if ( ! empty( $tool_meta ) ) {
+			$tool_data['_meta'] = $tool_meta;
+		}
+
+		return array(
+			'tool_data'    => $tool_data,
+			'adapter_meta' => $adapter_meta,
+		);
 	}
 
 	/**
-	 * Get the MCP tool instance.
+	 * Resolve the MCP tool name from ability.
 	 *
-	 * @return \WP\MCP\Domain\Tools\McpTool|\WP_Error The validated MCP tool instance or WP_Error if validation fails.
+	 * Sanitizes the ability name to MCP-valid format, applies filter, and validates result.
+	 *
+	 * @return string|\WP_Error Valid tool name or error.
+	 * @since n.e.x.t
+	 *
 	 */
-	private function get_tool() {
-		return McpTool::from_array( $this->get_data(), $this->mcp_server );
+	private function resolve_tool_name() {
+		// Sanitize ability name to MCP-valid format.
+		$sanitized_name = McpNameSanitizer::sanitize_name( $this->ability->get_name() );
+
+		if ( is_wp_error( $sanitized_name ) ) {
+			return $sanitized_name;
+		}
+
+		/**
+		 * Filters the MCP tool name derived from an ability.
+		 *
+		 * @param string $name The sanitized tool name.
+		 * @param \WP_Ability $ability The source ability instance.
+		 *
+		 * @since n.e.x.t
+		 *
+		 */
+		$filtered_name = apply_filters( 'mcp_adapter_tool_name', $sanitized_name, $this->ability );
+
+		// Validate post-filter (in case filter broke it).
+		if ( ! is_string( $filtered_name ) || ! McpValidator::validate_name( $filtered_name ) ) {
+			return new \WP_Error(
+				'mcp_tool_name_filter_invalid',
+				sprintf(
+				/* translators: %s: invalid tool name returned by filter */
+					__( 'Filter returned invalid MCP tool name: %s', 'mcp-adapter' ),
+					is_string( $filtered_name ) ? $filtered_name : gettype( $filtered_name )
+				)
+			);
+		}
+
+		return $filtered_name;
 	}
 }

--- a/tests/Unit/Domain/Prompts/McpPromptValidatorTest.php
+++ b/tests/Unit/Domain/Prompts/McpPromptValidatorTest.php
@@ -1,216 +1,1165 @@
 <?php
-/**
- * Tests for McpPromptValidator class.
- *
- * @package WP\MCP\Tests
- */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Domain\Prompts;
 
-use WP\MCP\Domain\Prompts\McpPrompt;
 use WP\MCP\Domain\Prompts\McpPromptValidator;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
 
 /**
- * Test McpPromptValidator functionality.
+ * Tests for McpPromptValidator class.
+ *
+ * @covers \WP\MCP\Domain\Prompts\McpPromptValidator
  */
 final class McpPromptValidatorTest extends TestCase {
 
-	public function test_validate_prompt_data_with_valid_data(): void {
-		$valid_prompt_data = array(
-			'name'        => 'test-prompt',
-			'title'       => 'Test Prompt',
-			'description' => 'A test prompt for validation',
-			'arguments'   => array(
-				array(
-					'name'        => 'input',
-					'description' => 'Input parameter',
-					'required'    => true,
-				),
-				array(
-					'name'        => 'optional',
-					'description' => 'Optional parameter',
-				),
-			),
-			'annotations' => array( 'priority' => 0.5 ),
+	// =========================================================================
+	// validate_prompt_dto Tests
+	// =========================================================================
+
+	public function test_validate_prompt_dto_with_valid_prompt(): void {
+		$prompt = Prompt::fromArray(
+			array(
+				'name' => 'test-prompt',
+			)
 		);
 
-		$result = McpPromptValidator::validate_prompt_data( $valid_prompt_data, 'test-context' );
+		$result = McpPromptValidator::validate_prompt_dto( $prompt );
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_prompt_data_with_missing_name(): void {
-		$invalid_prompt_data = array(
+	public function test_validate_prompt_dto_rejects_invalid_name(): void {
+		$prompt = Prompt::fromArray(
+			array(
+				'name' => 'invalid/name',
+			)
+		);
+
+		$result = McpPromptValidator::validate_prompt_dto( $prompt );
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_prompt_validation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'Prompt name', $result->get_error_message() );
+	}
+
+	public function test_validate_prompt_dto_rejects_invalid_icons(): void {
+		$prompt = Prompt::fromArray(
+			array(
+				'name'  => 'test-prompt',
+				'icons' => array(
+					array(
+						'src'      => 'https://example.com/icon.png',
+						'mimeType' => 'image/png',
+					),
+					array( 'src' => 'invalid-url' ), // Invalid src
+				),
+			)
+		);
+
+		$result = McpPromptValidator::validate_prompt_dto( $prompt );
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'Icon at index 1', $result->get_error_message() );
+	}
+
+	// =========================================================================
+	// validate_prompt_data Tests
+	// =========================================================================
+
+	public function test_validate_prompt_data_with_valid_data(): void {
+		$prompt_data = array(
+			'name'        => 'test-prompt',
 			'title'       => 'Test Prompt',
 			'description' => 'A test prompt',
 		);
 
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Prompt validation failed', $result->get_error_message() );
-		$this->assertStringContainsString( 'Prompt name is required', $result->get_error_message() );
+		$result = McpPromptValidator::validate_prompt_data( $prompt_data );
+		$this->assertTrue( $result );
 	}
 
-	public function test_validate_prompt_data_with_invalid_name(): void {
-		$invalid_prompt_data = array(
-			'name'        => 'invalid name with spaces!',
+	public function test_validate_prompt_data_with_context_in_error_message(): void {
+		$prompt_data = array(
+			'name' => '', // Invalid empty name
+		);
+
+		$result = McpPromptValidator::validate_prompt_data( $prompt_data, 'TestContext' );
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( '[TestContext]', $result->get_error_message() );
+	}
+
+	// =========================================================================
+	// get_validation_errors Tests
+	// =========================================================================
+
+	public function test_get_validation_errors_with_valid_prompt_data(): void {
+		$prompt_data = array(
+			'name'        => 'test-prompt',
+			'title'       => 'Test Prompt',
 			'description' => 'A test prompt',
 		);
 
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Prompt name is required and must only contain letters, numbers, hyphens (-), and underscores (_)', $result->get_error_message() );
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertEmpty( $errors );
 	}
 
-	public function test_validate_prompt_data_with_invalid_title(): void {
-		$invalid_prompt_data = array(
+	public function test_get_validation_errors_with_missing_name(): void {
+		$prompt_data = array(
+			'title' => 'Test',
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'name is required', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_empty_name(): void {
+		$prompt_data = array(
+			'name' => '',
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'name is required', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_non_string_name(): void {
+		$prompt_data = array(
+			'name' => 123,
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'name is required', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_invalid_name_format(): void {
+		$prompt_data = array(
+			'name' => 'invalid/name',
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'name is required', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_non_string_title(): void {
+		$prompt_data = array(
 			'name'  => 'test-prompt',
-			'title' => 123, // Should be string
+			'title' => 123,
 		);
 
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Prompt title must be a string if provided', $result->get_error_message() );
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'title must be a string', $errors[0] );
 	}
 
-	public function test_validate_prompt_data_with_invalid_description(): void {
-		$invalid_prompt_data = array(
+	public function test_get_validation_errors_with_non_string_description(): void {
+		$prompt_data = array(
 			'name'        => 'test-prompt',
-			'description' => array(), // Should be string
+			'description' => array( 'desc' ),
 		);
 
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Prompt description must be a string if provided', $result->get_error_message() );
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'description must be a string', $errors[0] );
 	}
 
-	public function test_validate_prompt_data_with_invalid_arguments(): void {
-		$invalid_prompt_data = array(
-			'name'      => 'test-prompt',
-			'arguments' => 'not-an-array',
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Prompt arguments must be an array if provided', $result->get_error_message() );
-	}
-
-	public function test_validate_prompt_data_with_invalid_argument_structure(): void {
-		$invalid_prompt_data = array(
-			'name'      => 'test-prompt',
-			'arguments' => array(
-				'not-an-object', // Should be an array/object
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Prompt argument at index 0 must be an object', $result->get_error_message() );
-	}
-
-	public function test_validate_prompt_data_with_missing_argument_name(): void {
-		$invalid_prompt_data = array(
-			'name'      => 'test-prompt',
-			'arguments' => array(
-				array(
-					'description' => 'Missing name',
-				),
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Prompt argument at index 0 must have a non-empty name string', $result->get_error_message() );
-	}
-
-	public function test_validate_prompt_data_with_invalid_argument_name(): void {
-		$invalid_prompt_data = array(
-			'name'      => 'test-prompt',
-			'arguments' => array(
-				array(
-					'name'        => 'invalid name with spaces!',
-					'description' => 'Invalid argument name',
-				),
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'name must only contain letters, numbers, hyphens (-), and underscores (_)', $result->get_error_message() );
-	}
-
-	public function test_validate_prompt_data_with_invalid_annotations(): void {
-		$invalid_prompt_data = array(
+	public function test_get_validation_errors_ignores_annotations_field(): void {
+		// MCP prompt templates do not have an annotations field in the 2025-11-25 schema.
+		$prompt_data = array(
 			'name'        => 'test-prompt',
 			'annotations' => 'not-an-array',
 		);
 
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Prompt annotations must be an array if provided', $result->get_error_message() );
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertEmpty( $errors );
 	}
 
-	public function test_is_valid_prompt_data(): void {
-		$valid_data = array(
-			'name' => 'valid-prompt',
+	// =========================================================================
+	// Arguments Validation Tests
+	// =========================================================================
+
+	public function test_get_validation_errors_with_non_array_arguments(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => 'not-an-array',
 		);
 
-		$this->assertTrue( empty( McpPromptValidator::get_validation_errors( $valid_data ) ) );
-
-		$invalid_data = array(
-			'name' => '',
-		);
-
-		$this->assertFalse( empty( McpPromptValidator::get_validation_errors( $invalid_data ) ) );
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'arguments must be an array', $errors[0] );
 	}
 
-	public function test_validate_prompt_messages_with_valid_messages(): void {
-		$valid_messages = array(
+	public function test_get_validation_errors_with_valid_arguments(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => array(
+				array(
+					'name'        => 'arg1',
+					'description' => 'First argument',
+					'required'    => true,
+				),
+				array(
+					'name'        => 'arg2',
+					'description' => 'Second argument',
+					'required'    => false,
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_get_validation_errors_with_non_object_argument(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => array(
+				'not-an-object',
+			),
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'argument at index 0 must be an object', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_missing_argument_name(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => array(
+				array(
+					'description' => 'Test arg',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'argument at index 0 must have a non-empty name', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_empty_argument_name(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => array(
+				array(
+					'name' => '',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'argument at index 0 must have a non-empty name', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_invalid_argument_name_format(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => array(
+				array(
+					'name' => 'invalid/name',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'invalid/name', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_non_string_argument_description(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => array(
+				array(
+					'name'        => 'arg1',
+					'description' => 123,
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'arg1', $errors[0] );
+		$this->assertStringContainsString( 'description must be a string', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_non_boolean_argument_required(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => array(
+				array(
+					'name'     => 'arg1',
+					'required' => 'true', // Should be boolean
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'arg1', $errors[0] );
+		$this->assertStringContainsString( 'required field must be a boolean', $errors[0] );
+	}
+
+	public function test_get_validation_errors_allows_missing_argument_required_field(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => array(
+				array(
+					'name' => 'arg1',
+					// 'required' is optional
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertEmpty( $errors );
+	}
+
+	// =========================================================================
+	// validate_prompt_messages Tests
+	// =========================================================================
+
+	public function test_validate_prompt_messages_with_valid_text_message(): void {
+		$messages = array(
 			array(
 				'role'    => 'user',
 				'content' => array(
 					'type' => 'text',
-					'text' => 'Hello, world!',
+					'text' => 'Hello',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_validate_prompt_messages_with_valid_roles(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'text',
+					'text' => 'User message',
 				),
 			),
 			array(
 				'role'    => 'assistant',
 				'content' => array(
+					'type' => 'text',
+					'text' => 'Assistant message',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_validate_prompt_messages_with_non_object_message(): void {
+		$messages = array( 'not-an-object' );
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'Message at index 0 must be an object', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_missing_role(): void {
+		$messages = array(
+			array(
+				'content' => array(
+					'type' => 'text',
+					'text' => 'Hello',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'Message at index 0 must have a role field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_invalid_role(): void {
+		$messages = array(
+			array(
+				'role'    => 'system', // Invalid role
+				'content' => array(
+					'type' => 'text',
+					'text' => 'Hello',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'role must be either \'user\' or \'assistant\'', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_missing_content(): void {
+		$messages = array(
+			array(
+				'role' => 'user',
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'Message at index 0 must have a content object', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_missing_content_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'text' => 'Hello',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'content must have a type field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_invalid_text_content(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'text',
+					'text' => 123, // Should be string
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'text content must have a text field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_allows_empty_text_content(): void {
+		// MCP spec allows empty text content - empty string is valid.
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'text',
+					'text' => '', // Empty string is valid per MCP spec
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertEmpty( $errors, 'Empty text content should be valid per MCP spec' );
+	}
+
+	public function test_validate_prompt_messages_with_valid_image_content(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
 					'type'     => 'image',
-					'data'     => 'SGVsbG8gV29ybGQ=',
+					'data'     => base64_encode( 'image-data' ),
 					'mimeType' => 'image/png',
 				),
 			),
 		);
 
-		$errors = McpPromptValidator::validate_prompt_messages( $valid_messages );
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
 		$this->assertEmpty( $errors );
 	}
 
-	public function test_validate_prompt_messages_with_invalid_role(): void {
-		$invalid_messages = array(
+	public function test_validate_prompt_messages_with_invalid_image_mime_type(): void {
+		$messages = array(
 			array(
-				'role'    => 'invalid-role',
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'image',
+					'data'     => base64_encode( 'image-data' ),
+					'mimeType' => 'text/plain', // Invalid for image
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'image content must have a valid image MIME type', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_valid_audio_content(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'audio',
+					'data'     => base64_encode( 'audio-data' ),
+					'mimeType' => 'audio/mpeg',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_validate_prompt_messages_with_invalid_audio_mime_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'audio',
+					'data'     => base64_encode( 'audio-data' ),
+					'mimeType' => 'text/plain', // Invalid for audio
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'audio content must have a valid audio MIME type', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_valid_resource_content(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'resource',
+					'resource' => array(
+						'uri'  => 'test://resource',
+						'text' => 'Resource content',
+					),
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_validate_prompt_messages_with_valid_resource_link_content(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type'        => 'resource_link',
+					'name'        => 'test-resource',
+					'uri'         => 'test://resource',
+					'title'       => 'Test Resource',
+					'description' => 'A resource reference',
+					'mimeType'    => 'application/json',
+					'size'        => 123,
+					'annotations' => array(
+						'audience' => array( 'user' ),
+						'priority' => 0.5,
+					),
+					'icons'       => array(
+						array(
+							'src'      => 'https://example.com/icon.png',
+							'mimeType' => 'image/png',
+						),
+					),
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_validate_prompt_messages_with_invalid_resource_link_missing_uri(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type' => 'resource_link',
+					'name' => 'test-resource',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource_link content must have a uri field', implode( ' ', $errors ) );
+	}
+
+	public function test_validate_prompt_messages_with_invalid_resource_content(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'resource',
+					'resource' => array(
+						'uri' => 'invalid uri', // Invalid URI
+					),
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'embedded resource', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_unsupported_content_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'unsupported',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'content type \'unsupported\' is not supported', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_invalid_content_annotations(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'        => 'text',
+					'text'        => 'Hello',
+					'annotations' => 'not-an-array',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'content annotations must be an array', $errors[0] );
+	}
+
+	// =========================================================================
+	// Edge Cases and Multiple Errors
+	// =========================================================================
+
+	public function test_get_validation_errors_reports_multiple_errors(): void {
+		$prompt_data = array(
+			'name'        => '', // Invalid
+			'title'       => 123, // Invalid
+			'description' => array(), // Invalid
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertCount( 3, $errors, 'Should report all validation errors' );
+	}
+
+	public function test_validate_prompt_messages_reports_multiple_message_errors(): void {
+		$messages = array(
+			array( 'role' => 'invalid' ), // Missing content, invalid role
+			array( 'role' => 'user' ), // Missing content
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertGreaterThan( 1, count( $errors ), 'Should report multiple errors' );
+	}
+
+	// =========================================================================
+	// validate_prompt_instance Tests
+	// =========================================================================
+
+	public function test_validate_prompt_instance_with_valid_prompt(): void {
+		$mcp_prompt = \WP\MCP\Domain\Prompts\McpPrompt::fromArray(
+			array(
+				'name'    => 'test-prompt',
+				'handler' => function () {
+					return array( 'messages' => array() );
+				},
+			)
+		);
+
+		// Ensure prompt was created successfully
+		$this->assertNotWPError( $mcp_prompt );
+
+		$result = McpPromptValidator::validate_prompt_instance( $mcp_prompt );
+		$this->assertTrue( $result );
+	}
+
+	public function test_validate_prompt_instance_with_invalid_prompt(): void {
+		// We cannot create an McpPrompt with invalid name via fromArray
+		// because the Prompt DTO allows any name. Instead, let's test
+		// validate_prompt_dto directly with an invalid name
+		$prompt_dto = Prompt::fromArray( array( 'name' => 'invalid/name' ) );
+
+		$result = McpPromptValidator::validate_prompt_dto( $prompt_dto );
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_prompt_validation_failed', $result->get_error_code() );
+	}
+
+	// =========================================================================
+	// Additional Image Content Validation Tests
+	// =========================================================================
+
+	public function test_validate_prompt_messages_with_image_missing_data(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'image',
+					'mimeType' => 'image/png',
+					// Missing 'data' field
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'image content must have a data field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_image_invalid_base64(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'image',
+					'data'     => '!!!not-valid-base64!!!',
+					'mimeType' => 'image/png',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'image content data must be valid base64', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_image_missing_mime_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'image',
+					'data' => base64_encode( 'image-data' ),
+					// Missing 'mimeType' field
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'image content must have a mimeType field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_image_non_string_data(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'image',
+					'data'     => 12345, // Not a string
+					'mimeType' => 'image/png',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'image content must have a data field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_image_non_string_mime_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'image',
+					'data'     => base64_encode( 'image-data' ),
+					'mimeType' => 12345, // Not a string
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'image content must have a mimeType field', $errors[0] );
+	}
+
+	// =========================================================================
+	// Additional Audio Content Validation Tests
+	// =========================================================================
+
+	public function test_validate_prompt_messages_with_audio_missing_data(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'audio',
+					'mimeType' => 'audio/mpeg',
+					// Missing 'data' field
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'audio content must have a data field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_audio_invalid_base64(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'audio',
+					'data'     => '!!!not-valid-base64!!!',
+					'mimeType' => 'audio/mpeg',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'audio content data must be valid base64', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_audio_missing_mime_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'audio',
+					'data' => base64_encode( 'audio-data' ),
+					// Missing 'mimeType' field
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'audio content must have a mimeType field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_audio_non_string_data(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'audio',
+					'data'     => 12345, // Not a string
+					'mimeType' => 'audio/mpeg',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'audio content must have a data field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_audio_non_string_mime_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'audio',
+					'data'     => base64_encode( 'audio-data' ),
+					'mimeType' => 12345, // Not a string
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'audio content must have a mimeType field', $errors[0] );
+	}
+
+	// =========================================================================
+	// Additional Resource Link Content Validation Tests
+	// =========================================================================
+
+	public function test_validate_prompt_messages_with_resource_link_missing_name(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type' => 'resource_link',
+					'uri'  => 'test://resource',
+					// Missing 'name' field
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource_link content must have a name field', implode( ' ', $errors ) );
+	}
+
+	public function test_validate_prompt_messages_with_resource_link_invalid_uri(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type' => 'resource_link',
+					'name' => 'test-resource',
+					'uri'  => 'invalid uri with spaces',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource_link content uri must be a valid URI format', implode( ' ', $errors ) );
+	}
+
+	public function test_validate_prompt_messages_with_resource_link_non_string_mime_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type'     => 'resource_link',
+					'name'     => 'test-resource',
+					'uri'      => 'test://resource',
+					'mimeType' => 12345, // Not a string
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource_link content mimeType must be a string', implode( ' ', $errors ) );
+	}
+
+	public function test_validate_prompt_messages_with_resource_link_invalid_mime_type_format(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type'     => 'resource_link',
+					'name'     => 'test-resource',
+					'uri'      => 'test://resource',
+					'mimeType' => 'invalid-mime-type',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource_link content mimeType must be a valid MIME type format', implode( ' ', $errors ) );
+	}
+
+	public function test_validate_prompt_messages_with_resource_link_invalid_size(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type' => 'resource_link',
+					'name' => 'test-resource',
+					'uri'  => 'test://resource',
+					'size' => 'not-an-integer', // Should be int
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource_link content size must be an integer', implode( ' ', $errors ) );
+	}
+
+	public function test_validate_prompt_messages_with_resource_link_invalid_title(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type'  => 'resource_link',
+					'name'  => 'test-resource',
+					'uri'   => 'test://resource',
+					'title' => 12345, // Should be string
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource_link content title must be a string', implode( ' ', $errors ) );
+	}
+
+	public function test_validate_prompt_messages_with_resource_link_invalid_description(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type'        => 'resource_link',
+					'name'        => 'test-resource',
+					'uri'         => 'test://resource',
+					'description' => 12345, // Should be string
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource_link content description must be a string', implode( ' ', $errors ) );
+	}
+
+	public function test_validate_prompt_messages_with_resource_link_invalid_icons_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type'  => 'resource_link',
+					'name'  => 'test-resource',
+					'uri'   => 'test://resource',
+					'icons' => 'not-an-array', // Should be array
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource_link content icons must be an array', implode( ' ', $errors ) );
+	}
+
+	public function test_validate_prompt_messages_with_resource_link_invalid_icons_content(): void {
+		$messages = array(
+			array(
+				'role'    => 'assistant',
+				'content' => array(
+					'type'  => 'resource_link',
+					'name'  => 'test-resource',
+					'uri'   => 'test://resource',
+					'icons' => array(
+						array( 'src' => 'invalid-url' ), // Invalid icon src
+					),
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'Icon at index', implode( ' ', $errors ) );
+	}
+
+	// =========================================================================
+	// Additional Resource Content Validation Tests
+	// =========================================================================
+
+	public function test_validate_prompt_messages_with_resource_missing_resource_object(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'resource',
+					// Missing 'resource' field
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource content must have a resource object', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_resource_non_array_resource(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'     => 'resource',
+					'resource' => 'not-an-array',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'resource content must have a resource object', $errors[0] );
+	}
+
+	// =========================================================================
+	// Additional Text Content Validation Tests
+	// =========================================================================
+
+	public function test_validate_prompt_messages_with_text_missing_text_field(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'text',
+					// Missing 'text' field
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'text content must have a text field', $errors[0] );
+	}
+
+	// =========================================================================
+	// Additional Content Annotations Tests
+	// =========================================================================
+
+	public function test_validate_prompt_messages_with_valid_content_annotations(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type'        => 'text',
+					'text'        => 'Hello',
+					'annotations' => array(
+						'audience' => array( 'user' ),
+						'priority' => 0.5,
+					),
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertEmpty( $errors );
+	}
+
+	// =========================================================================
+	// Additional Arguments Edge Case Tests
+	// =========================================================================
+
+	public function test_get_validation_errors_with_non_string_argument_name(): void {
+		$prompt_data = array(
+			'name'      => 'test-prompt',
+			'arguments' => array(
+				array(
+					'name' => 12345, // Should be string
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::get_validation_errors( $prompt_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'argument at index 0 must have a non-empty name', $errors[0] );
+	}
+
+	// =========================================================================
+	// Content Type Edge Cases
+	// =========================================================================
+
+	public function test_validate_prompt_messages_with_non_string_content_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 12345, // Should be string
+					'text' => 'Hello',
+				),
+			),
+		);
+
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'content must have a type field', $errors[0] );
+	}
+
+	public function test_validate_prompt_messages_with_non_string_role(): void {
+		$messages = array(
+			array(
+				'role'    => 12345, // Should be string
 				'content' => array(
 					'type' => 'text',
 					'text' => 'Hello',
@@ -218,217 +1167,21 @@ final class McpPromptValidatorTest extends TestCase {
 			),
 		);
 
-		$errors = McpPromptValidator::validate_prompt_messages( $invalid_messages );
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
 		$this->assertNotEmpty( $errors );
-		$this->assertStringContainsString( 'role must be either \'user\' or \'assistant\'', implode( ' ', $errors ) );
+		$this->assertStringContainsString( 'Message at index 0 must have a role field', $errors[0] );
 	}
 
-	public function test_validate_prompt_messages_with_missing_content(): void {
-		$invalid_messages = array(
-			array(
-				'role' => 'user',
-				// Missing content
-			),
-		);
-
-		$errors = McpPromptValidator::validate_prompt_messages( $invalid_messages );
-		$this->assertNotEmpty( $errors );
-		$this->assertStringContainsString( 'must have a content object', implode( ' ', $errors ) );
-	}
-
-	public function test_validate_prompt_messages_with_invalid_content_type(): void {
-		$invalid_messages = array(
+	public function test_validate_prompt_messages_with_non_array_content(): void {
+		$messages = array(
 			array(
 				'role'    => 'user',
-				'content' => array(
-					'type' => 'invalid-type',
-					'text' => 'Hello',
-				),
+				'content' => 'not-an-array',
 			),
 		);
 
-		$errors = McpPromptValidator::validate_prompt_messages( $invalid_messages );
+		$errors = McpPromptValidator::validate_prompt_messages( $messages );
 		$this->assertNotEmpty( $errors );
-		$this->assertStringContainsString( 'content type \'invalid-type\' is not supported', implode( ' ', $errors ) );
-	}
-
-	public function test_validate_prompt_messages_with_invalid_embedded_resource(): void {
-		$invalid_messages = array(
-			array(
-				'role'    => 'assistant',
-				'content' => array(
-					'type'     => 'resource',
-					'resource' => array(
-						// Missing URI should trigger McpResourceValidator errors.
-						'text' => 'Some content',
-					),
-				),
-			),
-		);
-
-		$errors = McpPromptValidator::validate_prompt_messages( $invalid_messages );
-		$this->assertNotEmpty( $errors );
-		$this->assertStringContainsString( 'Resource URI is required', implode( ' ', $errors ) );
-	}
-
-	public function test_validate_prompt_instance_with_valid_prompt(): void {
-		$server = $this->makeServer();
-
-		$prompt = new McpPrompt(
-			'test/valid-prompt',
-			'valid-prompt',
-			'Valid Prompt',
-			'A valid test prompt'
-		);
-		$prompt->set_mcp_server( $server );
-
-		$result = McpPromptValidator::validate_prompt_instance( $prompt, 'test-context' );
-		$this->assertTrue( $result );
-	}
-
-	public function test_validate_prompt_requires_server(): void {
-		$prompt = new McpPrompt(
-			'test/missing-server',
-			'prompt-without-server'
-		);
-
-		$result = $prompt->validate();
-		$this->assertWPError( $result );
-		$this->assertSame( 'prompt_missing_mcp_server', $result->get_error_code() );
-	}
-
-	public function test_validate_prompt_uniqueness_method_exists(): void {
-		// Test that the uniqueness validation method exists and is callable
-		$server = $this->makeServer();
-
-		$prompt_data = array(
-			'ability'     => 'test/test-prompt',
-			'name'        => 'test-prompt',
-			'title'       => 'Test Prompt',
-			'description' => 'Test prompt',
-		);
-		$prompt      = McpPrompt::from_array( $prompt_data, $server );
-
-		// The method should exist and be callable
-		$this->assertTrue( method_exists( McpPromptValidator::class, 'validate_prompt_uniqueness' ) );
-
-		// Should return true for unique prompt
-		$result = McpPromptValidator::validate_prompt_uniqueness( $prompt, 'test-context' );
-		$this->assertTrue( $result );
-	}
-
-	public function test_get_validation_errors_returns_array(): void {
-		$invalid_data = array(
-			'name'        => '',
-			'title'       => 123,
-			'annotations' => 'not-an-array',
-		);
-
-		$errors = McpPromptValidator::get_validation_errors( $invalid_data );
-
-		$this->assertIsArray( $errors );
-		$this->assertNotEmpty( $errors );
-		$this->assertGreaterThan( 2, count( $errors ) ); // Should have multiple validation errors
-	}
-
-	public function test_validate_prompt_data_with_valid_mcp_annotations(): void {
-		$valid_prompt_data = array(
-			'name'        => 'test-prompt',
-			'annotations' => array(
-				'audience'     => array( 'user', 'assistant' ),
-				'lastModified' => '2024-01-15T10:30:00Z',
-				'priority'     => 0.8,
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $valid_prompt_data );
-		$this->assertTrue( $result );
-	}
-
-	public function test_validate_prompt_data_with_unknown_annotation_field_name(): void {
-		// Unknown fields should be ignored (filtered out by mapper before validation)
-		$valid_prompt_data = array(
-			'name'        => 'test-prompt',
-			'annotations' => array(
-				'invalidField' => 'value', // Unknown field, should be ignored
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $valid_prompt_data );
-
-		$this->assertTrue( $result, 'Unknown annotation fields should be ignored' );
-	}
-
-	public function test_validate_prompt_data_with_invalid_audience_type(): void {
-		$invalid_prompt_data = array(
-			'name'        => 'test-prompt',
-			'annotations' => array(
-				'audience' => 'not-an-array', // Should be array
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Annotation field audience must be an array', $result->get_error_message() );
-	}
-
-	public function test_validate_prompt_data_with_invalid_audience_role(): void {
-		$invalid_prompt_data = array(
-			'name'        => 'test-prompt',
-			'annotations' => array(
-				'audience' => array( 'invalid-role' ), // Invalid role
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'audience must contain only valid roles', $result->get_error_message() );
-	}
-
-	public function test_validate_prompt_data_with_invalid_lastModified_format(): void {
-		$invalid_prompt_data = array(
-			'name'        => 'test-prompt',
-			'annotations' => array(
-				'lastModified' => 'not-a-date', // Invalid ISO 8601 format
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'lastModified must be a valid ISO 8601 timestamp', $result->get_error_message() );
-	}
-
-	public function test_validate_prompt_data_with_invalid_priority_range(): void {
-		$invalid_prompt_data = array(
-			'name'        => 'test-prompt',
-			'annotations' => array(
-				'priority' => 2.0, // Out of range (should be 0-1)
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $invalid_prompt_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'prompt_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'priority must be between 0.0 and 1.0', $result->get_error_message() );
-	}
-
-	public function test_validate_prompt_data_with_partial_annotations(): void {
-		// Should be valid - not all annotation fields are required
-		$valid_prompt_data = array(
-			'name'        => 'test-prompt',
-			'annotations' => array(
-				'priority' => 0.5,
-			),
-		);
-
-		$result = McpPromptValidator::validate_prompt_data( $valid_prompt_data );
-		$this->assertTrue( $result );
+		$this->assertStringContainsString( 'Message at index 0 must have a content object', $errors[0] );
 	}
 }

--- a/tests/Unit/Domain/Prompts/McpPromptValidatorTest.php
+++ b/tests/Unit/Domain/Prompts/McpPromptValidatorTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Domain\Prompts;
 
 use WP\MCP\Domain\Prompts\McpPromptValidator;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 
 /**
  * Tests for McpPromptValidator class.
@@ -20,7 +20,7 @@ final class McpPromptValidatorTest extends TestCase {
 	// =========================================================================
 
 	public function test_validate_prompt_dto_with_valid_prompt(): void {
-		$prompt = Prompt::fromArray(
+		$prompt = PromptDto::fromArray(
 			array(
 				'name' => 'test-prompt',
 			)
@@ -31,7 +31,7 @@ final class McpPromptValidatorTest extends TestCase {
 	}
 
 	public function test_validate_prompt_dto_rejects_invalid_name(): void {
-		$prompt = Prompt::fromArray(
+		$prompt = PromptDto::fromArray(
 			array(
 				'name' => 'invalid/name',
 			)
@@ -44,7 +44,7 @@ final class McpPromptValidatorTest extends TestCase {
 	}
 
 	public function test_validate_prompt_dto_rejects_invalid_icons(): void {
-		$prompt = Prompt::fromArray(
+		$prompt = PromptDto::fromArray(
 			array(
 				'name'  => 'test-prompt',
 				'icons' => array(
@@ -667,7 +667,7 @@ final class McpPromptValidatorTest extends TestCase {
 	// =========================================================================
 
 	public function test_validate_prompt_instance_with_valid_prompt(): void {
-		$mcp_prompt = \WP\MCP\Domain\Prompts\McpPrompt::fromArray(
+		$mcp_prompt = \WP\MCP\Domain\Prompts\McpPromptDto::fromArray(
 			array(
 				'name'    => 'test-prompt',
 				'handler' => function () {
@@ -687,7 +687,7 @@ final class McpPromptValidatorTest extends TestCase {
 		// We cannot create an McpPrompt with invalid name via fromArray
 		// because the Prompt DTO allows any name. Instead, let's test
 		// validate_prompt_dto directly with an invalid name
-		$prompt_dto = Prompt::fromArray( array( 'name' => 'invalid/name' ) );
+		$prompt_dto = PromptDto::fromArray( array( 'name' => 'invalid/name' ) );
 
 		$result = McpPromptValidator::validate_prompt_dto( $prompt_dto );
 		$this->assertWPError( $result );

--- a/tests/Unit/Domain/Resources/McpResourceValidatorTest.php
+++ b/tests/Unit/Domain/Resources/McpResourceValidatorTest.php
@@ -1,403 +1,361 @@
 <?php
-/**
- * Tests for McpResourceValidator class.
- *
- * @package WP\MCP\Tests
- */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Domain\Resources;
 
-use WP\MCP\Domain\Resources\McpResource;
 use WP\MCP\Domain\Resources\McpResourceValidator;
-use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Resources\DTO\Resource;
 
 /**
- * Test McpResourceValidator functionality.
+ * Tests for McpResourceValidator class.
+ *
+ * @covers \WP\MCP\Domain\Resources\McpResourceValidator
  */
 final class McpResourceValidatorTest extends TestCase {
 
-	public function test_validate_resource_data_with_valid_text_resource(): void {
-		$valid_resource_data = array(
-			'uri'         => 'WordPress://local/test-resource',
-			'name'        => 'Test Resource',
-			'description' => 'A test resource for validation',
-			'text'        => 'This is test content',
-			'mimeType'    => 'text/plain',
-			'annotations' => array( 'priority' => 0.5 ),
+	// =========================================================================
+	// validate_resource_dto Tests
+	// =========================================================================
+
+	public function test_validate_resource_dto_with_valid_resource(): void {
+		$resource = Resource::fromArray(
+			array(
+				'uri'  => 'test://resource',
+				'name' => 'test-resource',
+			)
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $valid_resource_data, 'test-context' );
+		$result = McpResourceValidator::validate_resource_dto( $resource );
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_resource_data_with_valid_blob_resource(): void {
-		$valid_resource_data = array(
-			'uri'         => 'WordPress://local/test-blob',
-			'name'        => 'Test Blob',
-			'description' => 'A test blob resource',
-			'blob'        => 'SGVsbG8gV29ybGQ=', // Base64 encoded "Hello World"
-			'mimeType'    => 'application/octet-stream',
+	public function test_validate_resource_dto_rejects_invalid_uri(): void {
+		$resource = Resource::fromArray(
+			array(
+				'uri'  => 'not a valid uri',
+				'name' => 'test-resource',
+			)
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $valid_resource_data );
+		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_resource_validation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'URI must be a valid URI', $result->get_error_message() );
+	}
+
+	public function test_validate_resource_dto_rejects_invalid_mime_type(): void {
+		$resource = Resource::fromArray(
+			array(
+				'uri'      => 'test://resource',
+				'name'     => 'test-resource',
+				'mimeType' => 'invalid-mime',
+			)
+		);
+
+		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'MIME type is invalid', $result->get_error_message() );
+	}
+
+	public function test_validate_resource_dto_accepts_valid_mime_type(): void {
+		$resource = Resource::fromArray(
+			array(
+				'uri'      => 'test://resource',
+				'name'     => 'test-resource',
+				'mimeType' => 'application/json',
+			)
+		);
+
+		$result = McpResourceValidator::validate_resource_dto( $resource );
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_resource_data_with_missing_uri(): void {
-		$invalid_resource_data = array(
-			'name'        => 'Test Resource',
-			'description' => 'Missing URI',
-			'text'        => 'Content',
+	public function test_validate_resource_dto_rejects_invalid_icons(): void {
+		$resource = Resource::fromArray(
+			array(
+				'uri'   => 'test://resource',
+				'name'  => 'test-resource',
+				'icons' => array(
+					array(
+						'src'      => 'https://example.com/icon.png',
+						'mimeType' => 'image/png',
+					),
+					array( 'src' => 'invalid-url' ), // Invalid src
+				),
+			)
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
+		$result = McpResourceValidator::validate_resource_dto( $resource );
 		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Resource validation failed', $result->get_error_message() );
-		$this->assertStringContainsString( 'Resource URI is required', $result->get_error_message() );
+		$this->assertStringContainsString( 'Icon at index 1', $result->get_error_message() );
 	}
 
-	public function test_validate_resource_data_with_invalid_uri(): void {
-		$invalid_resource_data = array(
-			'uri'  => 'not-a-valid-uri',
-			'text' => 'Content',
+	public function test_validate_resource_dto_rejects_invalid_annotation_values(): void {
+		// Note: The DTO validates structure (e.g., audience must be array).
+		// Our validator tests for invalid VALUES within valid structure.
+		$resource = Resource::fromArray(
+			array(
+				'uri'         => 'test://resource',
+				'name'        => 'test-resource',
+				'annotations' => array(
+					'audience' => array( 'admin' ), // Invalid role - should be 'user' or 'assistant'
+				),
+			)
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
+		$result = McpResourceValidator::validate_resource_dto( $resource );
 		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Resource URI must be a valid URI format', $result->get_error_message() );
+		$this->assertStringContainsString( 'valid roles', $result->get_error_message() );
 	}
 
-	public function test_validate_resource_data_with_no_content(): void {
-		$invalid_resource_data = array(
-			'uri'         => 'WordPress://local/no-content',
-			'name'        => 'No Content Resource',
-			'description' => 'Missing both text and blob',
+	public function test_validate_resource_dto_rejects_invalid_annotation_priority(): void {
+		$resource = Resource::fromArray(
+			array(
+				'uri'         => 'test://resource',
+				'name'        => 'test-resource',
+				'annotations' => array(
+					'priority' => 1.5, // Out of range - should be 0.0 to 1.0
+				),
+			)
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
+		$result = McpResourceValidator::validate_resource_dto( $resource );
 		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Resource must have either text or blob content', $result->get_error_message() );
+		$this->assertStringContainsString( 'priority must be between', $result->get_error_message() );
 	}
 
-	public function test_validate_resource_data_with_both_text_and_blob(): void {
-		$invalid_resource_data = array(
-			'uri'  => 'WordPress://local/conflicting-content',
-			'text' => 'Text content',
-			'blob' => 'SGVsbG8=', // Both text and blob (not allowed)
+	public function test_validate_resource_dto_accepts_valid_annotations(): void {
+		$resource = Resource::fromArray(
+			array(
+				'uri'         => 'test://resource',
+				'name'        => 'test-resource',
+				'annotations' => array(
+					'audience' => array( 'user', 'assistant' ),
+					'priority' => 0.8,
+				),
+			)
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Resource cannot have both text and blob content', $result->get_error_message() );
+		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$this->assertTrue( $result );
 	}
 
-	public function test_validate_resource_data_with_invalid_mime_type(): void {
-		$invalid_resource_data = array(
-			'uri'      => 'WordPress://local/invalid-mime',
-			'text'     => 'Content',
-			'mimeType' => 'invalid-mime-type',
-		);
+	// =========================================================================
+	// validate_resource_data Tests
+	// =========================================================================
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Resource mimeType must be a valid MIME type format', $result->get_error_message() );
-	}
-
-	public function test_validate_resource_uri_with_valid_uris(): void {
-		$valid_uris = array(
-			'WordPress://local/resource',
-			'https://example.com/resource',
-			'file:///path/to/resource',
-			'custom-protocol://resource-id',
-			'ftp://server.com/file.txt',
-		);
-
-		foreach ( $valid_uris as $uri ) {
-			$this->assertTrue( McpValidator::validate_resource_uri( $uri ), "URI '{$uri}' should be valid" );
-		}
-	}
-
-	public function test_validate_resource_uri_with_invalid_uris(): void {
-		$invalid_uris = array(
-			'',                           // Empty
-			'not-a-uri',                 // No scheme
-			'://missing-scheme',         // Missing scheme
-			'123://invalid-scheme',      // Scheme can't start with number
-			str_repeat( 'a', 2049 ),     // Too long
-		);
-
-		foreach ( $invalid_uris as $uri ) {
-			$this->assertFalse( McpValidator::validate_resource_uri( $uri ), "URI '{$uri}' should be invalid" );
-		}
-	}
-
-	public function test_validate_mime_type_with_valid_types(): void {
-		$valid_types = array(
-			'text/plain',
-			'application/json',
-			'image/jpeg',
-			'audio/mp3',
-			'video/mp4',
-			'application/octet-stream',
-			'text/html',
-		);
-
-		foreach ( $valid_types as $type ) {
-			$this->assertTrue( McpValidator::validate_mime_type( $type ), "MIME type '{$type}' should be valid" );
-		}
-	}
-
-	public function test_validate_mime_type_with_invalid_types(): void {
-		$invalid_types = array(
-			'',
-			'text',                      // Missing subtype
-			'text/',                     // Empty subtype
-			'/plain',                    // Missing type
-			'text/plain/extra',          // Too many parts
-			'invalid-mime-type',         // No slash
-		);
-
-		foreach ( $invalid_types as $type ) {
-			$this->assertFalse( McpValidator::validate_mime_type( $type ), "MIME type '{$type}' should be invalid" );
-		}
-	}
-
-	public function test_validate_resource_instance_with_valid_resource(): void {
-		$server = $this->makeServer();
-
+	public function test_validate_resource_data_with_valid_text_content(): void {
 		$resource_data = array(
-			'ability'     => 'test/valid-resource',
-			'uri'         => 'WordPress://local/valid-resource',
-			'name'        => 'Valid Resource',
-			'description' => 'A valid test resource',
-			'mimeType'    => 'text/plain',
-			'text'        => 'This is test content',
+			'uri'  => 'test://resource',
+			'text' => 'Test content',
 		);
 
-		$resource = McpResource::from_array( $resource_data, $server );
-
-		$result = McpResourceValidator::validate_resource_instance( $resource, 'test-context' );
+		$result = McpResourceValidator::validate_resource_data( $resource_data );
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_resource_requires_server_before_validation(): void {
-		$resource = new McpResource(
-			'test/missing-server',
-			'WordPress://local/missing-server'
-		);
-
-		$result = $resource->validate();
-		$this->assertWPError( $result );
-		$this->assertSame( 'resource_missing_mcp_server', $result->get_error_code() );
-	}
-
-	public function test_validate_resource_uniqueness_method_exists(): void {
-		// Test that the uniqueness validation method exists and is callable
-		$server = $this->makeServer();
-
+	public function test_validate_resource_data_with_valid_blob_content(): void {
 		$resource_data = array(
-			'ability'     => 'test/test-resource',
-			'uri'         => 'WordPress://local/test-resource',
-			'name'        => 'Test Resource',
-			'description' => 'Test resource',
-			'text'        => 'Test content',
+			'uri'  => 'test://resource',
+			'blob' => base64_encode( 'Test content' ),
 		);
-		$resource      = McpResource::from_array( $resource_data, $server );
 
-		// The method should exist and be callable
-		$this->assertTrue( method_exists( McpResourceValidator::class, 'validate_resource_uniqueness' ) );
-
-		// Should return true for unique resource
-		$result = McpResourceValidator::validate_resource_uniqueness( $resource, 'test-context' );
+		$result = McpResourceValidator::validate_resource_data( $resource_data );
 		$this->assertTrue( $result );
-	}
-
-	public function test_get_validation_errors_returns_array(): void {
-		$invalid_data = array(
-			'uri'         => '',
-			'name'        => 123,
-			'mimeType'    => 'invalid-type',
-			'annotations' => 'not-an-array',
-		);
-
-		$errors = McpResourceValidator::get_validation_errors( $invalid_data );
-
-		$this->assertIsArray( $errors );
-		$this->assertNotEmpty( $errors );
-		$this->assertGreaterThan( 3, count( $errors ) ); // Should have multiple validation errors
 	}
 
 	public function test_validate_resource_data_with_context_in_error_message(): void {
-		$invalid_resource_data = array(
-			'uri' => '',
+		$resource_data = array(
+			'uri' => 'invalid uri',
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data, 'custom-context' );
-
+		$result = McpResourceValidator::validate_resource_data( $resource_data, 'TestContext' );
 		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( '[custom-context]', $result->get_error_message() );
-		$this->assertStringContainsString( 'Resource validation failed', $result->get_error_message() );
+		$this->assertStringContainsString( '[TestContext]', $result->get_error_message() );
 	}
 
-	public function test_validate_resource_data_sanitizes_string_inputs(): void {
-		$resource_data_with_whitespace = array(
-			'uri'         => '  WordPress://local/test  ',
-			'name'        => '  Test Resource  ',
-			'description' => '  Test description  ',
-			'mimeType'    => '  text/plain  ',
+	// =========================================================================
+	// get_validation_errors Tests
+	// =========================================================================
+
+	public function test_get_validation_errors_with_valid_resource_data(): void {
+		$resource_data = array(
+			'uri'         => 'test://resource',
 			'text'        => 'Content',
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $resource_data_with_whitespace );
-		$this->assertTrue( $result );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertEmpty( $errors );
 	}
 
-	public function test_validate_resource_data_with_invalid_text_type(): void {
-		$invalid_resource_data = array(
-			'uri'  => 'WordPress://local/invalid-text',
-			'text' => 123, // Should be string
+	public function test_get_validation_errors_with_missing_uri(): void {
+		$resource_data = array(
+			'text' => 'Content',
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Resource text content must be a string', $result->get_error_message() );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'URI is required', $errors[0] );
 	}
 
-	public function test_validate_resource_data_with_invalid_blob_type(): void {
-		$invalid_resource_data = array(
-			'uri'  => 'WordPress://local/invalid-blob',
-			'blob' => array(), // Should be string, but also need to have content
-			'text' => '', // This will trigger the "must have either text or blob" error first
+	public function test_get_validation_errors_with_empty_uri(): void {
+		$resource_data = array(
+			'uri'  => '',
+			'text' => 'Content',
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Resource must have either text or blob content', $result->get_error_message() );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'URI is required', $errors[0] );
 	}
 
-	public function test_validate_resource_data_with_valid_mcp_annotations(): void {
-		$valid_resource_data = array(
-			'uri'         => 'WordPress://local/annotated-resource',
-			'text'        => 'Test content',
-			'annotations' => array(
-				'audience'     => array( 'user', 'assistant' ),
-				'lastModified' => '2024-01-15T10:30:00Z',
-				'priority'     => 0.8,
-			),
+	public function test_get_validation_errors_with_non_string_uri(): void {
+		$resource_data = array(
+			'uri'  => 123,
+			'text' => 'Content',
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $valid_resource_data );
-		$this->assertTrue( $result );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'URI is required', $errors[0] );
 	}
 
-	public function test_validate_resource_data_with_unknown_annotation_field_name(): void {
-		// Unknown fields should be ignored (filtered out by mapper before validation)
-		$valid_resource_data = array(
-			'uri'         => 'WordPress://local/unknown-annotations',
-			'text'        => 'Test content',
-			'annotations' => array(
-				'invalidField' => 'value', // Unknown field, should be ignored
-			),
+	public function test_get_validation_errors_with_invalid_uri_format(): void {
+		$resource_data = array(
+			'uri'  => 'not a valid uri',
+			'text' => 'Content',
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $valid_resource_data );
-
-		$this->assertTrue( $result, 'Unknown annotation fields should be ignored' );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'URI must be a valid URI format', $errors[0] );
 	}
 
-	public function test_validate_resource_data_with_invalid_audience_type(): void {
-		$invalid_resource_data = array(
-			'uri'         => 'WordPress://local/invalid-audience',
-			'text'        => 'Test content',
-			'annotations' => array(
-				'audience' => 'not-an-array', // Should be array
-			),
+	public function test_get_validation_errors_with_missing_content(): void {
+		$resource_data = array(
+			'uri' => 'test://resource',
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Annotation field audience must be an array', $result->get_error_message() );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'must include at least one of', $errors[0] );
 	}
 
-	public function test_validate_resource_data_with_invalid_audience_role(): void {
-		$invalid_resource_data = array(
-			'uri'         => 'WordPress://local/invalid-audience-role',
-			'text'        => 'Test content',
-			'annotations' => array(
-				'audience' => array( 'invalid-role' ), // Invalid role
-			),
+	public function test_get_validation_errors_with_both_text_and_blob(): void {
+		$resource_data = array(
+			'uri'  => 'test://resource',
+			'text' => 'Text content',
+			'blob' => base64_encode( 'Blob content' ),
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'audience must contain only valid roles', $result->get_error_message() );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertEmpty( $errors );
 	}
 
-	public function test_validate_resource_data_with_invalid_lastModified_format(): void {
-		$invalid_resource_data = array(
-			'uri'         => 'WordPress://local/invalid-date',
-			'text'        => 'Test content',
-			'annotations' => array(
-				'lastModified' => 'not-a-date', // Invalid ISO 8601 format
-			),
+	public function test_get_validation_errors_with_non_string_text(): void {
+		$resource_data = array(
+			'uri'  => 'test://resource',
+			'text' => 123,
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'lastModified must be a valid ISO 8601 timestamp', $result->get_error_message() );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'text content must be a string', implode( ' ', $errors ) );
 	}
 
-	public function test_validate_resource_data_with_invalid_priority_range(): void {
-		$invalid_resource_data = array(
-			'uri'         => 'WordPress://local/invalid-priority',
-			'text'        => 'Test content',
-			'annotations' => array(
-				'priority' => 2.0, // Out of range (should be 0-1)
-			),
+	public function test_get_validation_errors_with_non_string_blob(): void {
+		$resource_data = array(
+			'uri'  => 'test://resource',
+			'blob' => array( 'data' ),
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $invalid_resource_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'resource_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'priority must be between 0.0 and 1.0', $result->get_error_message() );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'blob content must be a string', implode( ' ', $errors ) );
 	}
 
-	public function test_validate_resource_data_with_partial_annotations(): void {
-		// Should be valid - not all annotation fields are required
-		$valid_resource_data = array(
-			'uri'         => 'WordPress://local/partial-annotations',
-			'text'        => 'Test content',
-			'annotations' => array(
-				'priority' => 0.5,
-			),
+	public function test_get_validation_errors_rejects_invalid_base64_blob(): void {
+		$resource_data = array(
+			'uri'  => 'test://resource',
+			'blob' => 'not-valid-base64!!!',
 		);
 
-		$result = McpResourceValidator::validate_resource_data( $valid_resource_data );
-		$this->assertTrue( $result );
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'valid base64', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_non_string_mime_type(): void {
+		$resource_data = array(
+			'uri'      => 'test://resource',
+			'text'     => 'Content',
+			'mimeType' => 123,
+		);
+
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'mimeType must be a string', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_invalid_mime_type_format(): void {
+		$resource_data = array(
+			'uri'      => 'test://resource',
+			'text'     => 'Content',
+			'mimeType' => 'invalid-mime',
+		);
+
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'mimeType must be a valid MIME type format', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_valid_mime_type(): void {
+		$resource_data = array(
+			'uri'      => 'test://resource',
+			'text'     => 'Content',
+			'mimeType' => 'application/json',
+		);
+
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertEmpty( $errors );
+	}
+
+	// =========================================================================
+	// Edge Cases and Multiple Errors
+	// =========================================================================
+
+	public function test_get_validation_errors_reports_multiple_errors(): void {
+		$resource_data = array(
+			'uri'         => 'invalid uri',
+			'mimeType'    => 'invalid-mime',
+			// Missing text/blob content
+		);
+
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertCount( 3, $errors, 'Should report all validation errors: invalid URI, invalid mimeType, and missing content' );
+	}
+
+	public function test_get_validation_errors_allows_empty_string_text(): void {
+		$resource_data = array(
+			'uri'  => 'test://resource',
+			'text' => '', // Empty but string type - valid per array_key_exists check
+		);
+
+		// Empty string IS valid content after the fix - array_key_exists allows it.
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertEmpty( $errors, 'Empty string text content should be valid' );
+	}
+
+	public function test_get_validation_errors_allows_optional_fields_when_omitted(): void {
+		$resource_data = array(
+			'uri'  => 'test://resource',
+			'text' => 'Content',
+			// mimeType omitted - should be valid (optional)
+		);
+
+		$errors = McpResourceValidator::get_validation_errors( $resource_data );
+		$this->assertEmpty( $errors );
 	}
 }

--- a/tests/Unit/Domain/Resources/McpResourceValidatorTest.php
+++ b/tests/Unit/Domain/Resources/McpResourceValidatorTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Domain\Resources;
 
 use WP\MCP\Domain\Resources\McpResourceValidator;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Resources\DTO\Resource;
+use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
 /**
  * Tests for McpResourceValidator class.
@@ -20,7 +20,7 @@ final class McpResourceValidatorTest extends TestCase {
 	// =========================================================================
 
 	public function test_validate_resource_dto_with_valid_resource(): void {
-		$resource = Resource::fromArray(
+		$resource = ResourceDto::fromArray(
 			array(
 				'uri'  => 'test://resource',
 				'name' => 'test-resource',
@@ -32,7 +32,7 @@ final class McpResourceValidatorTest extends TestCase {
 	}
 
 	public function test_validate_resource_dto_rejects_invalid_uri(): void {
-		$resource = Resource::fromArray(
+		$resource = ResourceDto::fromArray(
 			array(
 				'uri'  => 'not a valid uri',
 				'name' => 'test-resource',
@@ -46,7 +46,7 @@ final class McpResourceValidatorTest extends TestCase {
 	}
 
 	public function test_validate_resource_dto_rejects_invalid_mime_type(): void {
-		$resource = Resource::fromArray(
+		$resource = ResourceDto::fromArray(
 			array(
 				'uri'      => 'test://resource',
 				'name'     => 'test-resource',
@@ -60,7 +60,7 @@ final class McpResourceValidatorTest extends TestCase {
 	}
 
 	public function test_validate_resource_dto_accepts_valid_mime_type(): void {
-		$resource = Resource::fromArray(
+		$resource = ResourceDto::fromArray(
 			array(
 				'uri'      => 'test://resource',
 				'name'     => 'test-resource',
@@ -73,7 +73,7 @@ final class McpResourceValidatorTest extends TestCase {
 	}
 
 	public function test_validate_resource_dto_rejects_invalid_icons(): void {
-		$resource = Resource::fromArray(
+		$resource = ResourceDto::fromArray(
 			array(
 				'uri'   => 'test://resource',
 				'name'  => 'test-resource',
@@ -95,7 +95,7 @@ final class McpResourceValidatorTest extends TestCase {
 	public function test_validate_resource_dto_rejects_invalid_annotation_values(): void {
 		// Note: The DTO validates structure (e.g., audience must be array).
 		// Our validator tests for invalid VALUES within valid structure.
-		$resource = Resource::fromArray(
+		$resource = ResourceDto::fromArray(
 			array(
 				'uri'         => 'test://resource',
 				'name'        => 'test-resource',
@@ -111,7 +111,7 @@ final class McpResourceValidatorTest extends TestCase {
 	}
 
 	public function test_validate_resource_dto_rejects_invalid_annotation_priority(): void {
-		$resource = Resource::fromArray(
+		$resource = ResourceDto::fromArray(
 			array(
 				'uri'         => 'test://resource',
 				'name'        => 'test-resource',
@@ -127,7 +127,7 @@ final class McpResourceValidatorTest extends TestCase {
 	}
 
 	public function test_validate_resource_dto_accepts_valid_annotations(): void {
-		$resource = Resource::fromArray(
+		$resource = ResourceDto::fromArray(
 			array(
 				'uri'         => 'test://resource',
 				'name'        => 'test-resource',

--- a/tests/Unit/Domain/Tools/McpToolValidatorTest.php
+++ b/tests/Unit/Domain/Tools/McpToolValidatorTest.php
@@ -1,428 +1,321 @@
 <?php
-/**
- * Tests for McpToolValidator class.
- *
- * @package WP\MCP\Tests
- */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Domain\Tools;
 
-use WP\MCP\Domain\Tools\McpTool;
 use WP\MCP\Domain\Tools\McpToolValidator;
-use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Tools\DTO\Tool;
 
 /**
- * Test McpToolValidator functionality.
+ * Tests for McpToolValidator class.
+ *
+ * @covers \WP\MCP\Domain\Tools\McpToolValidator
  */
 final class McpToolValidatorTest extends TestCase {
 
-	public function test_validate_tool_data_with_valid_data(): void {
-		$valid_tool_data = array(
-			'name'        => 'test-tool',
-			'description' => 'A test tool for validation',
-			'inputSchema' => array(
-				'type'       => 'object',
-				'properties' => array(
-					'param1' => array( 'type' => 'string' ),
-					'param2' => array( 'type' => 'number' ),
-				),
-				'required'   => array( 'param1' ),
-			),
-			'title'       => 'Test Tool',
-			'annotations' => array( 'readOnlyHint' => true ),
+	// =========================================================================
+	// validate_tool_dto Tests
+	// =========================================================================
+
+	public function test_validate_tool_dto_with_valid_tool(): void {
+		$tool = Tool::fromArray(
+			array(
+				'name'        => 'test-tool',
+				'inputSchema' => array( 'type' => 'object' ),
+			)
 		);
 
-		$result = McpToolValidator::validate_tool_data( $valid_tool_data, 'test-context' );
+		$result = McpToolValidator::validate_tool_dto( $tool );
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_tool_data_with_missing_name(): void {
-		$invalid_tool_data = array(
-			'description' => 'A test tool',
-			'inputSchema' => array( 'type' => 'object' ),
+	public function test_validate_tool_dto_rejects_invalid_name(): void {
+		$tool = Tool::fromArray(
+			array(
+				'name'        => 'invalid/name',
+				'inputSchema' => array( 'type' => 'object' ),
+			)
 		);
 
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
+		$result = McpToolValidator::validate_tool_dto( $tool );
 		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Tool validation failed', $result->get_error_message() );
-		$this->assertStringContainsString( 'Tool name is required', $result->get_error_message() );
+		$this->assertSame( 'mcp_tool_validation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'Tool name', $result->get_error_message() );
 	}
 
-	public function test_validate_tool_data_with_invalid_name(): void {
-		$invalid_tool_data = array(
-			'name'        => 'invalid name with spaces!',
-			'description' => 'A test tool',
-			'inputSchema' => array( 'type' => 'object' ),
-		);
-
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Tool name is required and must only contain letters, numbers, hyphens (-), and underscores (_)', $result->get_error_message() );
-	}
-
-	public function test_validate_tool_data_with_missing_description(): void {
-		$invalid_tool_data = array(
-			'name'        => 'test-tool',
-			'inputSchema' => array( 'type' => 'object' ),
-		);
-
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Tool description is required', $result->get_error_message() );
-	}
-
-	public function test_validate_tool_data_with_invalid_input_schema(): void {
-		$invalid_tool_data = array(
-			'name'        => 'test-tool',
-			'description' => 'A test tool',
-			'inputSchema' => 'not-an-object',
-		);
-
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Tool inputSchema must be a valid JSON schema object', $result->get_error_message() );
-	}
-
-	public function test_validate_tool_data_with_invalid_input_schema_type(): void {
-		$invalid_tool_data = array(
-			'name'        => 'test-tool',
-			'description' => 'A test tool',
-			'inputSchema' => array(
-				'type' => 'string', // Should be 'object' for input schemas
-			),
-		);
-
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'must use type', $result->get_error_message() );
-	}
-
-	public function test_validate_tool_data_with_invalid_output_schema(): void {
-		$invalid_tool_data = array(
-			'name'         => 'test-tool',
-			'description'  => 'A test tool',
-			'inputSchema'  => array( 'type' => 'object' ),
-			'outputSchema' => 'not-an-object',
-		);
-
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Tool outputSchema must be a valid JSON schema object', $result->get_error_message() );
-	}
-
-	public function test_validate_tool_data_with_invalid_annotations(): void {
-		$invalid_tool_data = array(
-			'name'        => 'test-tool',
-			'description' => 'A test tool',
-			'inputSchema' => array( 'type' => 'object' ),
-			'annotations' => 'not-an-array',
-		);
-
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Tool annotations must be an array if provided', $result->get_error_message() );
-	}
-
-	public function test_validate_tool_name_with_valid_names(): void {
-		$valid_names = array(
-			'simple-tool',
-			'tool_with_underscores',
-			'tool123',
-			'a',
-			'very-long-tool-name-that-is-still-under-255-characters',
-		);
-
-		foreach ( $valid_names as $name ) {
-			$this->assertTrue( McpValidator::validate_tool_or_prompt_name( $name ), "Name '{$name}' should be valid" );
-		}
-	}
-
-	public function test_validate_tool_name_with_invalid_names(): void {
-		$invalid_names = array(
-			'',                           // Empty
-			'tool with spaces',           // Spaces
-			'tool@invalid',              // Special characters
-			'tool.invalid',              // Dots
-			str_repeat( 'a', 256 ),      // Too long
-		);
-
-		foreach ( $invalid_names as $name ) {
-			$this->assertFalse( McpValidator::validate_tool_or_prompt_name( $name ), "Name '{$name}' should be invalid" );
-		}
-	}
-
-	public function test_validate_tool_instance_with_valid_tool(): void {
-		$server = $this->makeServer();
-
-		$tool = new McpTool(
-			'test/valid-tool',
-			'valid-tool',
-			'A valid test tool',
-			array( 'type' => 'object' ),
-			'Valid Tool'
-		);
-		$tool->set_mcp_server( $server );
-
-		$result = McpToolValidator::validate_tool_instance( $tool, 'test-context' );
-		$this->assertTrue( $result );
-	}
-
-	public function test_validate_tool_requires_server_before_validation(): void {
-		$tool = new McpTool(
-			'test/missing-server',
-			'missing-server',
-			'A tool without a server',
-			array( 'type' => 'object' )
-		);
-
-		$result = $tool->validate();
-		$this->assertWPError( $result );
-		$this->assertSame( 'tool_missing_mcp_server', $result->get_error_code() );
-	}
-
-	public function test_validate_tool_uniqueness_method_exists(): void {
-		// Test that the uniqueness validation method exists and is callable
-		$server = $this->makeServer();
-		$tool   = new McpTool(
-			'test/test-tool',
-			'test-tool',
-			'Test tool',
-			array( 'type' => 'object' )
-		);
-		$tool->set_mcp_server( $server );
-
-		// The method should exist and be callable
-		$this->assertTrue( method_exists( McpToolValidator::class, 'validate_tool_uniqueness' ) );
-
-		// Should return true for unique tool
-		$result = McpToolValidator::validate_tool_uniqueness( $tool, 'test-context' );
-		$this->assertTrue( $result );
-	}
-
-	public function test_get_validation_errors_returns_array(): void {
-		$invalid_data = array(
-			'name'        => '',
-			'description' => '',
-			'inputSchema' => null,
-		);
-
-		$errors = McpToolValidator::get_validation_errors( $invalid_data );
-
-		$this->assertIsArray( $errors );
-		$this->assertNotEmpty( $errors );
-		$this->assertGreaterThan( 2, count( $errors ) ); // Should have multiple validation errors
-	}
-
-	public function test_is_valid_tool_data_with_valid_data(): void {
-		$valid_data = array(
-			'name'        => 'valid-tool',
-			'description' => 'A valid tool',
-			'inputSchema' => array( 'type' => 'object' ),
-		);
-
-		$this->assertTrue( empty( McpToolValidator::get_validation_errors( $valid_data ) ) );
-	}
-
-	public function test_is_valid_tool_data_with_invalid_data(): void {
-		$invalid_data = array(
-			'name'        => '',
-			'description' => '',
-		);
-
-		$this->assertFalse( empty( McpToolValidator::get_validation_errors( $invalid_data ) ) );
-	}
-
-	public function test_validate_tool_data_with_complex_schema(): void {
-		$complex_tool_data = array(
-			'name'         => 'complex-tool',
-			'description'  => 'A complex tool with detailed schema',
-			'inputSchema'  => array(
-				'type'       => 'object',
-				'properties' => array(
-					'stringParam' => array(
-						'type'        => 'string',
-						'description' => 'A string parameter',
+	public function test_validate_tool_dto_rejects_invalid_icons(): void {
+		$tool = Tool::fromArray(
+			array(
+				'name'        => 'test-tool',
+				'inputSchema' => array( 'type' => 'object' ),
+				'icons'       => array(
+					array(
+						'src'      => 'https://example.com/icon.png',
+						'mimeType' => 'image/png',
 					),
-					'numberParam' => array(
-						'type'    => 'number',
-						'minimum' => 0,
-					),
-					'arrayParam'  => array(
-						'type'  => 'array',
-						'items' => array( 'type' => 'string' ),
-					),
+					array( 'src' => 'invalid-url' ), // Invalid src
 				),
-				'required'   => array( 'stringParam', 'numberParam' ),
-			),
-			'outputSchema' => array(
-				'type'       => 'object',
-				'properties' => array(
-					'result' => array( 'type' => 'string' ),
-					'status' => array( 'type' => 'boolean' ),
-				),
-			),
+			)
 		);
 
-		$result = McpToolValidator::validate_tool_data( $complex_tool_data );
-		$this->assertTrue( $result );
+		$result = McpToolValidator::validate_tool_dto( $tool );
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'Icon at index 1', $result->get_error_message() );
 	}
 
-	public function test_validate_tool_data_with_invalid_required_field_reference(): void {
-		$invalid_tool_data = array(
-			'name'        => 'test-tool',
-			'description' => 'A test tool',
-			'inputSchema' => array(
-				'type'       => 'object',
-				'properties' => array(
-					'param1' => array( 'type' => 'string' ),
+	public function test_validate_tool_dto_validates_input_schema(): void {
+		$tool = Tool::fromArray(
+			array(
+				'name'        => 'test-tool',
+				'inputSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'test_prop' => array( 'type' => 'string' ),
+					),
+					'required'   => array( 'nonexistent_prop' ), // Required prop not in properties
 				),
-				'required'   => array( 'param1', 'nonexistent_param' ), // References non-existent property
-			),
+			)
 		);
 
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
+		$result = McpToolValidator::validate_tool_dto( $tool );
 		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'inputSchema', $result->get_error_message() );
 		$this->assertStringContainsString( 'does not exist in properties', $result->get_error_message() );
 	}
 
-	public function test_validate_tool_data_with_valid_mcp_annotations(): void {
-		$valid_tool_data = array(
-			'name'        => 'test-tool',
-			'description' => 'A test tool with MCP annotations',
-			'inputSchema' => array( 'type' => 'object' ),
-			'annotations' => array(
-				'readOnlyHint'    => true,
-				'destructiveHint' => false,
-				'idempotentHint'  => true,
-				'openWorldHint'   => false,
-				'title'           => 'Test Annotation',
-			),
+	public function test_validate_tool_dto_validates_output_schema(): void {
+		$tool = Tool::fromArray(
+			array(
+				'name'         => 'test-tool',
+				'inputSchema'  => array( 'type' => 'object' ),
+				'outputSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'result' => array( 'type' => 'string' ),
+					),
+					'required'   => array( 'missing_field' ), // Required prop not in properties
+				),
+			)
 		);
 
-		$result = McpToolValidator::validate_tool_data( $valid_tool_data );
-		$this->assertTrue( $result );
-	}
-
-	public function test_validate_tool_data_with_unknown_annotation_field_name(): void {
-		// Unknown fields should be ignored (filtered out by mapper before validation)
-		$valid_tool_data = array(
-			'name'        => 'test-tool',
-			'description' => 'A test tool',
-			'inputSchema' => array( 'type' => 'object' ),
-			'annotations' => array(
-				'readonly' => true, // Unknown field, should be ignored
-			),
-		);
-
-		$result = McpToolValidator::validate_tool_data( $valid_tool_data );
-
-		$this->assertTrue( $result, 'Unknown annotation fields should be ignored' );
-	}
-
-	public function test_validate_tool_data_with_invalid_annotation_boolean_type(): void {
-		$invalid_tool_data = array(
-			'name'        => 'test-tool',
-			'description' => 'A test tool',
-			'inputSchema' => array( 'type' => 'object' ),
-			'annotations' => array(
-				'readOnlyHint' => 'yes', // Should be boolean, not string
-			),
-		);
-
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
+		$result = McpToolValidator::validate_tool_dto( $tool );
 		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Tool annotation field readOnlyHint must be a boolean', $result->get_error_message() );
+		$this->assertStringContainsString( 'outputSchema', $result->get_error_message() );
+		$this->assertStringContainsString( 'does not exist in properties', $result->get_error_message() );
 	}
 
-	public function test_validate_tool_data_with_invalid_annotation_string_type(): void {
-		$invalid_tool_data = array(
+	// =========================================================================
+	// get_validation_errors Tests
+	// =========================================================================
+
+	public function test_get_validation_errors_with_valid_tool_data(): void {
+		$tool_data = array(
 			'name'        => 'test-tool',
 			'description' => 'A test tool',
 			'inputSchema' => array( 'type' => 'object' ),
-			'annotations' => array(
-				'title' => 123, // Should be string, not number
-			),
 		);
 
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Tool annotation field title must be a string', $result->get_error_message() );
+		$errors = McpToolValidator::get_validation_errors( $tool_data );
+		$this->assertEmpty( $errors );
 	}
 
-	public function test_validate_tool_data_with_empty_annotation_title(): void {
-		$invalid_tool_data = array(
-			'name'        => 'test-tool',
-			'description' => 'A test tool',
+	public function test_get_validation_errors_with_missing_name(): void {
+		$tool_data = array(
 			'inputSchema' => array( 'type' => 'object' ),
-			'annotations' => array(
-				'title' => '   ', // Empty/whitespace-only string
-			),
 		);
 
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Tool annotation field title must be a non-empty string', $result->get_error_message() );
+		$errors = McpToolValidator::get_validation_errors( $tool_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'name is required', $errors[0] );
 	}
 
-	public function test_validate_tool_data_with_multiple_annotation_errors(): void {
-		$invalid_tool_data = array(
+	public function test_get_validation_errors_accepts_optional_description(): void {
+		$tool_data = array(
 			'name'        => 'test-tool',
-			'description' => 'A test tool',
 			'inputSchema' => array( 'type' => 'object' ),
-			'annotations' => array(
-				'readonly'      => true,    // Invalid field name
-				'readOnlyHint'  => 'yes',   // Invalid type
-				'invalidField'  => true,    // Unknown field
-			),
+			// No description - should be valid per MCP 2025-11-25 spec
 		);
 
-		$result = McpToolValidator::validate_tool_data( $invalid_tool_data );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'tool_validation_failed', $result->get_error_code() );
-
-		$error_message = $result->get_error_message();
-		// Unknown fields are ignored, only type errors are reported
-		$this->assertStringContainsString( 'Tool annotation field readOnlyHint must be a boolean', $error_message );
+		$errors = McpToolValidator::get_validation_errors( $tool_data );
+		$this->assertEmpty( $errors );
 	}
 
-	public function test_validate_tool_data_with_partial_mcp_annotations(): void {
-		// Should be valid - not all annotation fields are required
-		$valid_tool_data = array(
+	public function test_get_validation_errors_rejects_invalid_description_type(): void {
+		$tool_data = array(
 			'name'        => 'test-tool',
-			'description' => 'A test tool',
+			'description' => 123, // Invalid: should be string
 			'inputSchema' => array( 'type' => 'object' ),
-			'annotations' => array(
-				'readOnlyHint' => true,
+		);
+
+		$errors = McpToolValidator::get_validation_errors( $tool_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'description must be a string', $errors[0] );
+	}
+
+	public function test_get_validation_errors_with_missing_input_schema(): void {
+		$tool_data = array(
+			'name' => 'test-tool',
+		);
+
+		$errors = McpToolValidator::get_validation_errors( $tool_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'inputSchema', $errors[0] );
+	}
+
+	// =========================================================================
+	// get_tool_annotation_validation_errors Tests
+	// =========================================================================
+
+	public function test_get_tool_annotation_validation_errors_with_valid_annotations(): void {
+		$annotations = array(
+			'title'           => 'My Tool',
+			'readOnlyHint'    => true,
+			'destructiveHint' => false,
+			'idempotentHint'  => true,
+			'openWorldHint'   => false,
+		);
+
+		$errors = McpToolValidator::get_tool_annotation_validation_errors( $annotations );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_get_tool_annotation_validation_errors_rejects_non_boolean_hints(): void {
+		$annotations = array(
+			'readOnlyHint' => 'true', // Invalid: should be boolean
+		);
+
+		$errors = McpToolValidator::get_tool_annotation_validation_errors( $annotations );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'readOnlyHint must be a boolean', $errors[0] );
+	}
+
+	public function test_get_tool_annotation_validation_errors_rejects_empty_title(): void {
+		$annotations = array(
+			'title' => '   ', // Invalid: empty after trim
+		);
+
+		$errors = McpToolValidator::get_tool_annotation_validation_errors( $annotations );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'title must be a non-empty string', $errors[0] );
+	}
+
+	public function test_get_tool_annotation_validation_errors_ignores_unknown_fields(): void {
+		$annotations = array(
+			'title'        => 'My Tool',
+			'unknownField' => 'some value', // Should be ignored
+		);
+
+		$errors = McpToolValidator::get_tool_annotation_validation_errors( $annotations );
+		$this->assertEmpty( $errors );
+	}
+
+	// =========================================================================
+	// get_execution_validation_errors Tests
+	// =========================================================================
+
+	public function test_get_execution_validation_errors_with_valid_execution(): void {
+		$execution = array(
+			'taskSupport' => 'optional',
+		);
+
+		$errors = McpToolValidator::get_execution_validation_errors( $execution );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_get_execution_validation_errors_accepts_all_valid_task_support_values(): void {
+		$valid_values = array( 'forbidden', 'optional', 'required' );
+
+		foreach ( $valid_values as $value ) {
+			$errors = McpToolValidator::get_execution_validation_errors( array( 'taskSupport' => $value ) );
+			$this->assertEmpty( $errors, "Value '$value' should be valid" );
+		}
+	}
+
+	public function test_get_execution_validation_errors_rejects_invalid_task_support(): void {
+		$execution = array(
+			'taskSupport' => 'invalid-value',
+		);
+
+		$errors = McpToolValidator::get_execution_validation_errors( $execution );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'taskSupport must be one of', $errors[0] );
+	}
+
+	public function test_get_execution_validation_errors_rejects_non_string_task_support(): void {
+		$execution = array(
+			'taskSupport' => true, // Invalid: should be string
+		);
+
+		$errors = McpToolValidator::get_execution_validation_errors( $execution );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'taskSupport must be a string', $errors[0] );
+	}
+
+	public function test_get_execution_validation_errors_rejects_non_array(): void {
+		$errors = McpToolValidator::get_execution_validation_errors( 'not-an-array' );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'execution must be an object/array', $errors[0] );
+	}
+
+	// =========================================================================
+	// Icons Validation Tests
+	// =========================================================================
+
+	public function test_get_validation_errors_with_valid_icons(): void {
+		$tool_data = array(
+			'name'        => 'test-tool',
+			'inputSchema' => array( 'type' => 'object' ),
+			'icons'       => array(
+				array(
+					'src'      => 'https://example.com/icon.png',
+					'mimeType' => 'image/png',
+					'sizes'    => array( '48x48' ),
+				),
 			),
 		);
 
-		$result = McpToolValidator::validate_tool_data( $valid_tool_data );
-		$this->assertTrue( $result );
+		$errors = McpToolValidator::get_validation_errors( $tool_data );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_get_validation_errors_rejects_invalid_icons(): void {
+		$tool_data = array(
+			'name'        => 'test-tool',
+			'inputSchema' => array( 'type' => 'object' ),
+			'icons'       => 'not-an-array', // Invalid
+		);
+
+		$errors = McpToolValidator::get_validation_errors( $tool_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'icons must be an array', $errors[0] );
+	}
+
+	// =========================================================================
+	// _meta Validation Tests
+	// =========================================================================
+
+	public function test_get_validation_errors_with_valid_meta(): void {
+		$tool_data = array(
+			'name'        => 'test-tool',
+			'inputSchema' => array( 'type' => 'object' ),
+			'_meta'       => array( 'key' => 'value' ),
+		);
+
+		$errors = McpToolValidator::get_validation_errors( $tool_data );
+		$this->assertEmpty( $errors );
+	}
+
+	public function test_get_validation_errors_rejects_invalid_meta(): void {
+		$tool_data = array(
+			'name'        => 'test-tool',
+			'inputSchema' => array( 'type' => 'object' ),
+			'_meta'       => 'not-an-array', // Invalid
+		);
+
+		$errors = McpToolValidator::get_validation_errors( $tool_data );
+		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( '_meta must be an object/array', $errors[0] );
 	}
 }

--- a/tests/Unit/Domain/Tools/McpToolValidatorTest.php
+++ b/tests/Unit/Domain/Tools/McpToolValidatorTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Domain\Tools;
 
 use WP\MCP\Domain\Tools\McpToolValidator;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Tools\DTO\Tool;
+use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 /**
  * Tests for McpToolValidator class.
@@ -20,7 +20,7 @@ final class McpToolValidatorTest extends TestCase {
 	// =========================================================================
 
 	public function test_validate_tool_dto_with_valid_tool(): void {
-		$tool = Tool::fromArray(
+		$tool = ToolDto::fromArray(
 			array(
 				'name'        => 'test-tool',
 				'inputSchema' => array( 'type' => 'object' ),
@@ -32,7 +32,7 @@ final class McpToolValidatorTest extends TestCase {
 	}
 
 	public function test_validate_tool_dto_rejects_invalid_name(): void {
-		$tool = Tool::fromArray(
+		$tool = ToolDto::fromArray(
 			array(
 				'name'        => 'invalid/name',
 				'inputSchema' => array( 'type' => 'object' ),
@@ -46,7 +46,7 @@ final class McpToolValidatorTest extends TestCase {
 	}
 
 	public function test_validate_tool_dto_rejects_invalid_icons(): void {
-		$tool = Tool::fromArray(
+		$tool = ToolDto::fromArray(
 			array(
 				'name'        => 'test-tool',
 				'inputSchema' => array( 'type' => 'object' ),
@@ -66,7 +66,7 @@ final class McpToolValidatorTest extends TestCase {
 	}
 
 	public function test_validate_tool_dto_validates_input_schema(): void {
-		$tool = Tool::fromArray(
+		$tool = ToolDto::fromArray(
 			array(
 				'name'        => 'test-tool',
 				'inputSchema' => array(
@@ -86,7 +86,7 @@ final class McpToolValidatorTest extends TestCase {
 	}
 
 	public function test_validate_tool_dto_validates_output_schema(): void {
-		$tool = Tool::fromArray(
+		$tool = ToolDto::fromArray(
 			array(
 				'name'         => 'test-tool',
 				'inputSchema'  => array( 'type' => 'object' ),

--- a/tests/Unit/Prompts/McpPromptBuilderTest.php
+++ b/tests/Unit/Prompts/McpPromptBuilderTest.php
@@ -6,6 +6,7 @@ namespace WP\MCP\Tests\Unit\Prompts;
 
 use WP\MCP\Domain\Prompts\McpPromptBuilder;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
 
 // Test prompt class
 class TestPrompt extends McpPromptBuilder {
@@ -34,22 +35,155 @@ class TestPrompt extends McpPromptBuilder {
 	}
 }
 
+// Test prompt with icons
+class TestPromptWithIcons extends McpPromptBuilder {
+
+	protected function configure(): void {
+		$this->name        = 'test-prompt-with-icons';
+		$this->title       = 'Test Prompt With Icons';
+		$this->description = 'A test prompt with MCP icons';
+		$this->set_icons(
+			array(
+				array(
+					'src'      => 'https://example.com/icon.png',
+					'mimeType' => 'image/png',
+					'sizes'    => array( '32x32' ),
+					'theme'    => 'light',
+				),
+				array(
+					'src'      => 'https://example.com/icon-dark.svg',
+					'mimeType' => 'image/svg+xml',
+					'theme'    => 'dark',
+				),
+			)
+		);
+	}
+
+	public function handle( array $arguments ): array {
+		return array( 'result' => 'success' );
+	}
+}
+
+// Test prompt with user _meta
+class TestPromptWithMeta extends McpPromptBuilder {
+
+	protected function configure(): void {
+		$this->name        = 'test-prompt-with-meta';
+		$this->title       = 'Test Prompt With Meta';
+		$this->description = 'A test prompt with custom _meta';
+		$this->set_meta(
+			array(
+				'custom_vendor' => array(
+					'feature_flag' => true,
+					'version'      => '2.0',
+				),
+				'another_key'   => 'some-value',
+			)
+		);
+	}
+
+	public function handle( array $arguments ): array {
+		return array( 'result' => 'success' );
+	}
+}
+
+// Test prompt with both icons and _meta
+class TestPromptWithIconsAndMeta extends McpPromptBuilder {
+
+	protected function configure(): void {
+		$this->name        = 'test-prompt-icons-meta';
+		$this->title       = 'Test Prompt Icons and Meta';
+		$this->description = 'A test prompt with both icons and custom _meta';
+		$this->set_icons(
+			array(
+				array(
+					'src'      => 'https://example.com/combined-icon.png',
+					'mimeType' => 'image/png',
+					'sizes'    => array( '48x48' ),
+				),
+			)
+		);
+		$this->set_meta(
+			array(
+				'vendor_data' => array( 'key' => 'value' ),
+			)
+		);
+	}
+
+	public function handle( array $arguments ): array {
+		return array( 'result' => 'success' );
+	}
+}
+
+// Test prompt with invalid icons (missing src)
+class TestPromptWithMixedIcons extends McpPromptBuilder {
+
+	protected function configure(): void {
+		$this->name        = 'test-prompt-mixed-icons';
+		$this->title       = 'Test Prompt Mixed Icons';
+		$this->description = 'A test prompt with some valid and invalid icons';
+		$this->set_icons(
+			array(
+				array(
+					'src'      => 'https://example.com/valid.png',
+					'mimeType' => 'image/png',
+				),
+				array(
+					// Missing src - invalid.
+					'mimeType' => 'image/png',
+				),
+				array(
+					'src'      => 'https://example.com/also-valid.svg',
+					'mimeType' => 'image/svg+xml',
+				),
+			)
+		);
+	}
+
+	public function handle( array $arguments ): array {
+		return array( 'result' => 'success' );
+	}
+}
+
+// Test prompt using add_argument() in configure() - simulates real-world usage
+// like CodeReviewPrompt. This is the pattern that was vulnerable to argument
+// accumulation when configure() was called multiple times.
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
+class TestPromptWithAddArgument extends McpPromptBuilder {
+
+	protected function configure(): void {
+		$this->name        = 'add-argument-test';
+		$this->title       = 'Add Argument Test';
+		$this->description = 'Tests add_argument() idempotence';
+
+		// Using add_argument() - this pattern was the original source of the bug.
+		$this->add_argument( 'code', 'The code to review', true );
+		$this->add_argument( 'language', 'Programming language', false );
+		$this->add_argument( 'focus', 'Review focus area', false );
+	}
+
+	public function handle( array $arguments ): array {
+		return array( 'result' => 'success' );
+	}
+}
+
 final class McpPromptBuilderTest extends TestCase {
 
 	public function test_builder_creates_prompt(): void {
 		$builder = new TestPrompt();
 		$prompt  = $builder->build();
 
-		$this->assertSame( 'test-prompt', $prompt->get_name() );
-		$this->assertSame( 'Test Prompt', $prompt->get_title() );
-		$this->assertSame( 'A test prompt for unit testing', $prompt->get_description() );
+		$this->assertInstanceOf( Prompt::class, $prompt );
+		$this->assertSame( 'test-prompt', $prompt->getName() );
+		$this->assertSame( 'Test Prompt', $prompt->getTitle() );
+		$this->assertSame( 'A test prompt for unit testing', $prompt->getDescription() );
 
-		$arguments = $prompt->get_arguments();
+		$arguments = $prompt->getArguments();
 		$this->assertCount( 2, $arguments );
-		$this->assertSame( 'input', $arguments[0]['name'] );
-		$this->assertTrue( $arguments[0]['required'] );
-		$this->assertSame( 'optional', $arguments[1]['name'] );
-		$this->assertArrayNotHasKey( 'required', $arguments[1] );
+		$this->assertSame( 'input', $arguments[0]->getName() );
+		$this->assertTrue( $arguments[0]->getRequired() );
+		$this->assertSame( 'optional', $arguments[1]->getName() );
+		$this->assertNull( $arguments[1]->getRequired() );
 	}
 
 	public function test_prompt_can_be_registered_with_server(): void {
@@ -61,27 +195,20 @@ final class McpPromptBuilderTest extends TestCase {
 
 		$prompt = $server->get_prompt( 'test-prompt' );
 		$this->assertNotNull( $prompt );
-		$this->assertSame( 'test-prompt', $prompt->get_name() );
+		$this->assertSame( 'test-prompt', $prompt->getName() );
 	}
 
 	public function test_prompt_execution_bypasses_abilities(): void {
 		$server = $this->makeServer( array(), array(), array( TestPrompt::class ) );
 
 		$prompt = $server->get_prompt( 'test-prompt' );
+		$this->assertNotNull( $prompt );
 
-		// Verify this is a builder-based prompt
-		$this->assertTrue( $prompt->is_builder_based() );
+		$builder = $server->get_prompt_builder( 'test-prompt' );
+		$this->assertNotNull( $builder );
+		$this->assertTrue( $builder->has_permission( array() ) );
 
-		// Verify abilities are bypassed (get_ability returns WP_Error)
-		$ability = $prompt->get_ability();
-		$this->assertWPError( $ability );
-		$this->assertEquals( 'builder_has_no_ability', $ability->get_error_code() );
-
-		// Test direct permission checking
-		$this->assertTrue( $prompt->check_permission_direct( array() ) );
-
-		// Test direct execution
-		$result = $prompt->execute_direct(
+		$result = $builder->handle(
 			array(
 				'input'    => 'test value',
 				'optional' => 'custom',
@@ -106,5 +233,249 @@ final class McpPromptBuilderTest extends TestCase {
 		$prompts = $server->get_prompts();
 		// Should have at least the builder prompt even if ability fails
 		$this->assertArrayHasKey( 'test-prompt', $prompts );
+	}
+
+	// =========================================================================
+	// Icons Tests (MCP 2025-11-25)
+	// =========================================================================
+
+	public function test_builder_with_icons_includes_icons_in_prompt(): void {
+		$builder = new TestPromptWithIcons();
+		$prompt  = $builder->build();
+
+		$this->assertInstanceOf( Prompt::class, $prompt );
+
+		$arr = $prompt->toArray();
+
+		// Verify icons array is present.
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertIsArray( $arr['icons'] );
+		$this->assertCount( 2, $arr['icons'] );
+
+		// Verify first icon.
+		$this->assertSame( 'https://example.com/icon.png', $arr['icons'][0]['src'] );
+		$this->assertSame( 'image/png', $arr['icons'][0]['mimeType'] );
+		$this->assertSame( array( '32x32' ), $arr['icons'][0]['sizes'] );
+		$this->assertSame( 'light', $arr['icons'][0]['theme'] );
+
+		// Verify second icon.
+		$this->assertSame( 'https://example.com/icon-dark.svg', $arr['icons'][1]['src'] );
+		$this->assertSame( 'image/svg+xml', $arr['icons'][1]['mimeType'] );
+		$this->assertSame( 'dark', $arr['icons'][1]['theme'] );
+	}
+
+	public function test_builder_invalid_icons_are_filtered_out(): void {
+		$builder = new TestPromptWithMixedIcons();
+		$prompt  = $builder->build();
+
+		$arr = $prompt->toArray();
+
+		// Should have only 2 valid icons (one without src was filtered out).
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 2, $arr['icons'] );
+
+		// Verify valid icons are present.
+		$this->assertSame( 'https://example.com/valid.png', $arr['icons'][0]['src'] );
+		$this->assertSame( 'https://example.com/also-valid.svg', $arr['icons'][1]['src'] );
+	}
+
+	public function test_builder_without_icons_has_no_icons_key(): void {
+		$builder = new TestPrompt();
+		$prompt  = $builder->build();
+
+		$arr = $prompt->toArray();
+
+		// Verify icons key is not present when builder has no icons.
+		$this->assertArrayNotHasKey( 'icons', $arr );
+	}
+
+	public function test_get_icons_returns_configured_icons(): void {
+		$builder = new TestPromptWithIcons();
+
+		$icons = $builder->get_icons();
+
+		$this->assertIsArray( $icons );
+		$this->assertCount( 2, $icons );
+		$this->assertSame( 'https://example.com/icon.png', $icons[0]['src'] );
+	}
+
+	public function test_get_icons_returns_empty_array_when_not_set(): void {
+		$builder = new TestPrompt();
+
+		$icons = $builder->get_icons();
+
+		$this->assertIsArray( $icons );
+		$this->assertEmpty( $icons );
+	}
+
+	// =========================================================================
+	// User _meta Tests (MCP 2025-11-25)
+	// =========================================================================
+
+		public function test_builder_with_meta_includes_meta_in_prompt(): void {
+			$builder = new TestPromptWithMeta();
+			$prompt  = $builder->build();
+
+		$arr = $prompt->toArray();
+
+		// Verify _meta is present.
+		$this->assertArrayHasKey( '_meta', $arr );
+
+		// Verify custom_vendor key is preserved.
+		$this->assertArrayHasKey( 'custom_vendor', $arr['_meta'] );
+		$this->assertIsArray( $arr['_meta']['custom_vendor'] );
+		$this->assertTrue( $arr['_meta']['custom_vendor']['feature_flag'] );
+		$this->assertSame( '2.0', $arr['_meta']['custom_vendor']['version'] );
+
+			// Verify another_key is preserved.
+			$this->assertArrayHasKey( 'another_key', $arr['_meta'] );
+			$this->assertSame( 'some-value', $arr['_meta']['another_key'] );
+		}
+
+		public function test_builder_without_user_meta_has_no_meta_field(): void {
+			$builder = new TestPrompt();
+			$prompt  = $builder->build();
+
+			$arr = $prompt->toArray();
+
+			$this->assertArrayNotHasKey( '_meta', $arr );
+		}
+
+	public function test_get_meta_returns_configured_meta(): void {
+		$builder = new TestPromptWithMeta();
+
+		$meta = $builder->get_meta();
+
+		$this->assertIsArray( $meta );
+		$this->assertArrayHasKey( 'custom_vendor', $meta );
+		$this->assertArrayHasKey( 'another_key', $meta );
+	}
+
+	public function test_get_meta_returns_empty_array_when_not_set(): void {
+		$builder = new TestPrompt();
+
+		$meta = $builder->get_meta();
+
+		$this->assertIsArray( $meta );
+		$this->assertEmpty( $meta );
+	}
+
+	// =========================================================================
+	// Combined Icons and _meta Tests
+	// =========================================================================
+
+	public function test_builder_with_both_icons_and_meta(): void {
+		$builder = new TestPromptWithIconsAndMeta();
+		$prompt  = $builder->build();
+
+		$arr = $prompt->toArray();
+
+		// Verify icons are present.
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 1, $arr['icons'] );
+		$this->assertSame( 'https://example.com/combined-icon.png', $arr['icons'][0]['src'] );
+		$this->assertSame( 'image/png', $arr['icons'][0]['mimeType'] );
+		$this->assertSame( array( '48x48' ), $arr['icons'][0]['sizes'] );
+
+			// Verify user _meta is present.
+			$this->assertArrayHasKey( '_meta', $arr );
+			$this->assertArrayHasKey( 'vendor_data', $arr['_meta'] );
+			$this->assertSame( 'value', $arr['_meta']['vendor_data']['key'] );
+		}
+
+	public function test_builder_with_icons_can_be_registered_with_server(): void {
+		$server = $this->makeServer( array(), array(), array( TestPromptWithIcons::class ) );
+
+		$prompts = $server->get_prompts();
+		$this->assertCount( 1, $prompts );
+		$this->assertArrayHasKey( 'test-prompt-with-icons', $prompts );
+
+		$prompt = $server->get_prompt( 'test-prompt-with-icons' );
+		$this->assertNotNull( $prompt );
+
+		$arr = $prompt->toArray();
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 2, $arr['icons'] );
+	}
+
+	public function test_builder_with_meta_can_be_registered_with_server(): void {
+		$server = $this->makeServer( array(), array(), array( TestPromptWithMeta::class ) );
+
+		$prompts = $server->get_prompts();
+		$this->assertCount( 1, $prompts );
+		$this->assertArrayHasKey( 'test-prompt-with-meta', $prompts );
+
+		$prompt = $server->get_prompt( 'test-prompt-with-meta' );
+		$this->assertNotNull( $prompt );
+
+		$arr = $prompt->toArray();
+		$this->assertArrayHasKey( '_meta', $arr );
+		$this->assertArrayHasKey( 'custom_vendor', $arr['_meta'] );
+	}
+
+	// =========================================================================
+	// Configuration Idempotence Tests
+	// =========================================================================
+
+	public function test_multiple_build_calls_do_not_accumulate_arguments(): void {
+		$builder = new TestPromptWithAddArgument();
+
+		// Call build() multiple times.
+		$prompt1 = $builder->build();
+		$prompt2 = $builder->build();
+		$prompt3 = $builder->build();
+
+		// All should have exactly 3 arguments (not accumulating).
+		$this->assertCount( 3, $prompt1->getArguments() );
+		$this->assertCount( 3, $prompt2->getArguments() );
+		$this->assertCount( 3, $prompt3->getArguments() );
+	}
+
+	public function test_getters_do_not_accumulate_arguments(): void {
+		$builder = new TestPromptWithAddArgument();
+
+		// Call various getters multiple times.
+		$builder->get_name();
+		$builder->get_title();
+		$builder->get_description();
+		$builder->get_arguments();
+		$builder->get_name();
+		$builder->get_arguments();
+
+		// Build should still have exactly 3 arguments.
+		$prompt = $builder->build();
+		$this->assertCount( 3, $prompt->getArguments() );
+	}
+
+	public function test_mixed_getter_and_build_calls_do_not_accumulate(): void {
+		$builder = new TestPromptWithAddArgument();
+
+		// Mix of getter and build calls (this was the original bug scenario).
+		$builder->get_name();
+		$builder->build();
+		$builder->get_arguments();
+		$builder->build();
+		$builder->get_title();
+
+		// Final build should still have exactly 3 arguments.
+		$prompt = $builder->build();
+		$this->assertCount( 3, $prompt->getArguments() );
+
+		// Verify argument names are correct (no duplicates).
+		$args      = $prompt->getArguments();
+		$arg_names = array_map( fn( $arg ) => $arg->getName(), $args );
+		$this->assertSame( array( 'code', 'language', 'focus' ), $arg_names );
+	}
+
+	public function test_constructor_calls_configure_exactly_once(): void {
+		// This test verifies the structural guarantee: configure() is called
+		// during construction, not lazily.
+		$builder = new TestPromptWithAddArgument();
+
+		// Immediately after construction, arguments should be populated.
+		$this->assertCount( 3, $builder->get_arguments() );
+
+		// Name should be set without triggering any additional configure() call.
+		$this->assertSame( 'add-argument-test', $builder->get_name() );
 	}
 }

--- a/tests/Unit/Prompts/McpPromptBuilderTest.php
+++ b/tests/Unit/Prompts/McpPromptBuilderTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Prompts;
 
 use WP\MCP\Domain\Prompts\McpPromptBuilder;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 
 // Test prompt class
 class TestPrompt extends McpPromptBuilder {
@@ -173,7 +173,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPrompt();
 		$prompt  = $builder->build();
 
-		$this->assertInstanceOf( Prompt::class, $prompt );
+		$this->assertInstanceOf( PromptDto::class, $prompt );
 		$this->assertSame( 'test-prompt', $prompt->getName() );
 		$this->assertSame( 'Test Prompt', $prompt->getTitle() );
 		$this->assertSame( 'A test prompt for unit testing', $prompt->getDescription() );
@@ -243,7 +243,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPromptWithIcons();
 		$prompt  = $builder->build();
 
-		$this->assertInstanceOf( Prompt::class, $prompt );
+		$this->assertInstanceOf( PromptDto::class, $prompt );
 
 		$arr = $prompt->toArray();
 

--- a/tests/Unit/Prompts/McpPromptTest.php
+++ b/tests/Unit/Prompts/McpPromptTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Prompts;
 
 use WP\MCP\Domain\Prompts\McpPrompt;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 
 /**
  * Tests for McpPrompt array configuration.
@@ -44,9 +44,9 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_component();
+		$dto = $prompt->get_protocol_dto();
 
-		$this->assertInstanceOf( Prompt::class, $dto );
+		$this->assertInstanceOf( PromptDto::class, $dto );
 		$this->assertSame( 'test-array', $dto->getName() );
 		$this->assertSame( 'Test Array Prompt', $dto->getTitle() );
 		$this->assertSame( 'A prompt created from array config', $dto->getDescription() );
@@ -135,7 +135,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_component();
+		$dto = $prompt->get_protocol_dto();
 		$arr = $dto->toArray();
 
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -156,7 +156,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_component();
+		$dto = $prompt->get_protocol_dto();
 		$arr = $dto->toArray();
 
 		$this->assertArrayHasKey( '_meta', $arr );
@@ -204,7 +204,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_component();
+		$dto = $prompt->get_protocol_dto();
 		$arr = $dto->toArray();
 
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -265,7 +265,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_component();
+		$dto = $prompt->get_protocol_dto();
 		$this->assertSame( 'getter-test', $dto->getName() );
 		$this->assertSame( 'Getter Title', $dto->getTitle() );
 		$this->assertSame( 'Getter Description', $dto->getDescription() );
@@ -287,7 +287,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_component();
+		$dto = $prompt->get_protocol_dto();
 		$this->assertSame( 'minimal-test', $dto->getName() );
 		$this->assertNull( $dto->getTitle() );
 		$this->assertNull( $dto->getDescription() );

--- a/tests/Unit/Prompts/McpPromptTest.php
+++ b/tests/Unit/Prompts/McpPromptTest.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\MCP\Tests\Unit\Prompts;
+
+use WP\MCP\Domain\Prompts\McpPrompt;
+use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
+
+/**
+ * Tests for McpPrompt array configuration.
+ */
+final class McpPromptTest extends TestCase {
+
+
+	// =========================================================================
+	// fromArray Tests
+	// =========================================================================
+
+	public function test_fromArray_creates_prompt(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'        => 'test-array',
+				'title'       => 'Test Array Prompt',
+				'description' => 'A prompt created from array config',
+				'arguments'   => array(
+					array(
+						'name'        => 'code',
+						'description' => 'The code to review',
+						'required'    => true,
+					),
+					array(
+						'name'        => 'language',
+						'description' => 'Programming language',
+					),
+				),
+				'handler'     => static function ( array $args ): array {
+					return array(
+						'result' => 'success',
+						'args'   => $args,
+					);
+				},
+			)
+		);
+
+		$dto = $prompt->get_component();
+
+		$this->assertInstanceOf( Prompt::class, $dto );
+		$this->assertSame( 'test-array', $dto->getName() );
+		$this->assertSame( 'Test Array Prompt', $dto->getTitle() );
+		$this->assertSame( 'A prompt created from array config', $dto->getDescription() );
+
+		$arguments = $dto->getArguments();
+		$this->assertCount( 2, $arguments );
+		$this->assertSame( 'code', $arguments[0]->getName() );
+		$this->assertTrue( $arguments[0]->getRequired() );
+		$this->assertSame( 'language', $arguments[1]->getName() );
+		$this->assertNull( $arguments[1]->getRequired() );
+	}
+
+	public function test_fromArray_handler_is_executed(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'handler-test',
+				'handler' => static function ( array $args ): array {
+					return array(
+						'received' => $args,
+						'computed' => $args['value'] * 2,
+					);
+				},
+			)
+		);
+
+		$result = $prompt->execute( array( 'value' => 21 ) );
+
+		$this->assertSame( 21, $result['received']['value'] );
+		$this->assertSame( 42, $result['computed'] );
+	}
+
+	public function test_fromArray_permission_callback(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'       => 'permission-test',
+				'handler'    => static fn( $args ) => array(),
+				'permission' => static function ( array $args ): bool {
+					return $args['allowed'] ?? false;
+				},
+			)
+		);
+
+		$this->assertTrue( $prompt->check_permission( array( 'allowed' => true ) ) );
+		$this->assertFalse( $prompt->check_permission( array( 'allowed' => false ) ) );
+		$this->assertFalse( $prompt->check_permission( array() ) );
+	}
+
+	public function test_fromArray_no_permission_denies_access(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'no-permission-test',
+				'handler' => static fn( $args ) => array(),
+			)
+		);
+
+		// Without explicit permission callback, access should be denied.
+		$result = $prompt->check_permission( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
+	}
+
+	public function test_fromArray_explicit_permission_allows_access(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'       => 'explicit-permission-test',
+				'handler'    => static fn( $args ) => array(),
+				'permission' => static fn() => true,
+			)
+		);
+
+		$this->assertTrue( $prompt->check_permission( array() ) );
+		$this->assertTrue( $prompt->check_permission( array( 'any' => 'value' ) ) );
+	}
+
+	public function test_fromArray_with_icons(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'icons-test',
+				'handler' => static fn( $args ) => array(),
+				'icons'   => array(
+					array(
+						'src'      => 'https://example.com/icon.png',
+						'mimeType' => 'image/png',
+					),
+				),
+			)
+		);
+
+		$dto = $prompt->get_component();
+		$arr = $dto->toArray();
+
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 1, $arr['icons'] );
+		$this->assertSame( 'https://example.com/icon.png', $arr['icons'][0]['src'] );
+	}
+
+	public function test_fromArray_with_meta(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'meta-test',
+				'handler' => static fn( $args ) => array(),
+				'meta'    => array(
+					'custom_key'  => 'custom_value',
+					'mcp_adapter' => array( 'allowed' => true ),
+					'nested'      => array( 'a' => 1 ),
+				),
+			)
+		);
+
+		$dto = $prompt->get_component();
+		$arr = $dto->toArray();
+
+		$this->assertArrayHasKey( '_meta', $arr );
+		$this->assertSame( 'custom_value', $arr['_meta']['custom_key'] );
+		$this->assertSame( array( 'a' => 1 ), $arr['_meta']['nested'] );
+		$this->assertSame( array( 'allowed' => true ), $arr['_meta']['mcp_adapter'] );
+	}
+
+	public function test_fromArray_returns_WP_Error_without_name(): void {
+		$result = McpPrompt::fromArray(
+			array(
+				'handler' => static fn( $args ) => array(),
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_prompt_missing_name', $result->get_error_code() );
+	}
+
+	public function test_fromArray_returns_WP_Error_without_handler(): void {
+		$result = McpPrompt::fromArray(
+			array(
+				'name' => 'no-handler',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_prompt_missing_handler', $result->get_error_code() );
+	}
+
+	public function test_fromArray_with_icons_and_meta(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'full-config-test',
+				'handler' => static fn( $args ) => array(),
+				'icons'   => array(
+					array(
+						'src'      => 'https://example.com/icon.svg',
+						'mimeType' => 'image/svg+xml',
+					),
+				),
+				'meta'    => array(
+					'vendor' => 'test',
+				),
+			)
+		);
+
+		$dto = $prompt->get_component();
+		$arr = $dto->toArray();
+
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertArrayHasKey( '_meta', $arr );
+		$this->assertSame( 'test', $arr['_meta']['vendor'] );
+	}
+
+	// =========================================================================
+	// Server Registration Tests
+	// =========================================================================
+
+	public function test_fromArray_prompt_can_be_registered_with_server(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'array-server-test',
+				'title'   => 'Array Server Test',
+				'handler' => static fn( $args ) => array( 'source' => 'array' ),
+			)
+		);
+
+		$server = $this->makeServer( array(), array(), array( $prompt ) );
+
+		$prompts = $server->get_prompts();
+		$this->assertArrayHasKey( 'array-server-test', $prompts );
+
+		$mcp_prompt = $server->get_mcp_prompt( 'array-server-test' );
+		$this->assertNotNull( $mcp_prompt );
+
+		$result = $mcp_prompt->execute( array() );
+		$this->assertSame( 'array', $result['source'] );
+	}
+
+	// =========================================================================
+	// Interface Implementation Tests
+	// =========================================================================
+
+	public function test_getters_return_correct_values(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'        => 'getter-test',
+				'title'       => 'Getter Title',
+				'description' => 'Getter Description',
+				'arguments'   => array(
+					array(
+						'name'        => 'arg1',
+						'description' => 'First argument',
+						'required'    => true,
+					),
+				),
+				'icons'       => array(
+					array(
+						'src'      => 'https://example.com/icon.png',
+						'mimeType' => 'image/png',
+					),
+				),
+				'meta'        => array( 'key' => 'value' ),
+				'handler'     => static fn( $args ) => array(),
+			)
+		);
+
+		$dto = $prompt->get_component();
+		$this->assertSame( 'getter-test', $dto->getName() );
+		$this->assertSame( 'Getter Title', $dto->getTitle() );
+		$this->assertSame( 'Getter Description', $dto->getDescription() );
+		$this->assertCount( 1, $dto->getArguments() );
+		$this->assertSame( 'arg1', $dto->getArguments()[0]->getName() );
+
+		$arr = $dto->toArray();
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 1, $arr['icons'] );
+		$this->assertArrayHasKey( '_meta', $arr );
+		$this->assertSame( 'value', $arr['_meta']['key'] );
+	}
+
+	public function test_defaults_for_optional_fields(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'minimal-test',
+				'handler' => static fn( $args ) => array(),
+			)
+		);
+
+		$dto = $prompt->get_component();
+		$this->assertSame( 'minimal-test', $dto->getName() );
+		$this->assertNull( $dto->getTitle() );
+		$this->assertNull( $dto->getDescription() );
+		$this->assertNull( $dto->getArguments() );
+		$this->assertNull( $dto->getIcons() );
+		$this->assertNull( $dto->get_meta() );
+	}
+
+	// =========================================================================
+	// Secure-by-Default Behavior Tests
+	// =========================================================================
+
+	/**
+	 * Verify that no default permission callback is set.
+	 * Prompts must explicitly configure permissions for security.
+	 */
+	public function test_no_default_permission_returns_error(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'no-permission-prompt',
+				'handler' => static fn( $args ) => array(),
+			)
+		);
+
+		$result = $prompt->check_permission( array() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
+		$this->assertArrayHasKey( 'failure_reason', $result->get_error_data() );
+		$this->assertSame( 'no_permission_strategy', $result->get_error_data()['failure_reason'] );
+	}
+
+	// =========================================================================
+	// Error Handling Tests
+	// =========================================================================
+
+	public function test_execute_catches_handler_exceptions(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'throwing-prompt',
+				'handler' => static function ( $args ) {
+					throw new \RuntimeException( 'Handler exploded' );
+				},
+			)
+		);
+
+		$result = $prompt->execute( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_execution_failed', $result->get_error_code() );
+		$this->assertSame( 'Handler exploded', $result->get_error_message() );
+	}
+
+	public function test_check_permission_catches_exceptions(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'       => 'throwing-permission-prompt',
+				'handler'    => static fn( $args ) => array(),
+				'permission' => static function () {
+					throw new \RuntimeException( 'Permission check exploded' );
+				},
+			)
+		);
+
+		$result = $prompt->check_permission( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_permission_check_failed', $result->get_error_code() );
+		$this->assertSame( 'Permission check exploded', $result->get_error_message() );
+	}
+
+	public function test_fromArray_returns_wp_error_when_arguments_throw(): void {
+		// Pass invalid argument data that causes an exception during argument processing.
+		// The 'name' field is required for prompt arguments; accessing it without the key throws.
+		$result = McpPrompt::fromArray(
+			array(
+				'name'      => 'invalid-arguments-prompt',
+				'handler'   => static fn( $args ) => array(),
+				'arguments' => array(
+					array(
+						// Missing 'name' field - accessing $arg['name'] will throw an Undefined array key error.
+						'description' => 'An argument without a name',
+						'required'    => true,
+					),
+				),
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_prompt_dto_creation_failed', $result->get_error_code() );
+		// PHP 8 throws "Undefined array key 'name'", PHP 7.4 returns NULL triggering "Expected string, got NULL".
+		$message = $result->get_error_message();
+		$this->assertTrue(
+			false !== strpos( $message, 'name' ) || false !== strpos( $message, 'NULL' ),
+			"Expected error message to contain 'name' or 'NULL', got: {$message}"
+		);
+	}
+
+	public function test_fromArray_observability_context(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'    => 'observable-prompt',
+				'handler' => static fn( $args ) => array(),
+			)
+		);
+
+		$context = $prompt->get_observability_context();
+
+		$this->assertSame( 'prompt', $context['component_type'] );
+		$this->assertSame( 'observable-prompt', $context['prompt_name'] );
+		$this->assertSame( 'array', $context['source'] );
+	}
+}

--- a/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
+++ b/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Prompts;
 
 use WP\MCP\Domain\Prompts\RegisterAbilityAsMcpPrompt;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 
 	final class RegisterAbilityAsMcpPromptTest extends TestCase {
 
@@ -14,7 +14,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 			$ability = wp_get_ability( 'test/prompt' );
 			$this->assertNotNull( $ability, 'Ability test/prompt should be registered' );
 			$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
-			$this->assertInstanceOf( Prompt::class, $prompt );
+			$this->assertInstanceOf( PromptDto::class, $prompt );
 			$arr = $prompt->toArray();
 			$this->assertSame( 'test-prompt', $arr['name'] );
 			$this->assertArrayHasKey( 'arguments', $arr );
@@ -71,7 +71,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 			$built = RegisterAbilityAsMcpPrompt::build( $ability );
 			$this->assertNotWPError( $built );
 			$this->assertIsArray( $built );
-			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
 			$prompt = $built['prompt'];
 
 			$arr = $prompt->toArray();
@@ -95,7 +95,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 			$built = RegisterAbilityAsMcpPrompt::build( $ability );
 			$this->assertNotWPError( $built );
 			$this->assertIsArray( $built );
-			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
 			$prompt = $built['prompt'];
 
 			$arr = $prompt->toArray();
@@ -211,7 +211,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
 		$prompt = $built['prompt'];
 
 		$arr = $prompt->toArray();
@@ -243,7 +243,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
 		$prompt = $built['prompt'];
 
 		$arr = $prompt->toArray();
@@ -295,7 +295,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
 		$prompt = $built['prompt'];
 
 		$arr = $prompt->toArray();
@@ -329,7 +329,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 			$built = RegisterAbilityAsMcpPrompt::build( $ability );
 			$this->assertNotWPError( $built );
 			$this->assertIsArray( $built );
-			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
 			$prompt = $built['prompt'];
 
 			$arr = $prompt->toArray();
@@ -364,7 +364,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 			$built = RegisterAbilityAsMcpPrompt::build( $ability );
 			$this->assertNotWPError( $built );
 			$this->assertIsArray( $built );
-			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
 			$prompt = $built['prompt'];
 
 			$arr = $prompt->toArray();
@@ -412,7 +412,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 			$built = RegisterAbilityAsMcpPrompt::build( $ability );
 			$this->assertNotWPError( $built );
 			$this->assertIsArray( $built );
-			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
 			$prompt = $built['prompt'];
 
 			$arr = $prompt->toArray();
@@ -446,7 +446,7 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 			$built = RegisterAbilityAsMcpPrompt::build( $ability );
 			$this->assertNotWPError( $built );
 			$this->assertIsArray( $built );
-			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
 			$prompt = $built['prompt'];
 
 			$arr = $prompt->toArray();

--- a/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
+++ b/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
@@ -6,68 +6,589 @@ namespace WP\MCP\Tests\Unit\Prompts;
 
 use WP\MCP\Domain\Prompts\RegisterAbilityAsMcpPrompt;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
 
-final class RegisterAbilityAsMcpPromptTest extends TestCase {
+	final class RegisterAbilityAsMcpPromptTest extends TestCase {
 
-	public function test_make_builds_prompt_from_ability(): void {
-		$ability = wp_get_ability( 'test/prompt' );
-		$this->assertNotNull( $ability, 'Ability test/prompt should be registered' );
-		$prompt  = RegisterAbilityAsMcpPrompt::make( $ability, $this->makeServer() );
-		$arr     = $prompt->to_array();
-		$this->assertSame( 'test-prompt', $arr['name'] );
-		$this->assertArrayHasKey( 'arguments', $arr );
-		$this->assertSame( $ability, $prompt->get_ability() );
-	}
+		public function test_make_builds_prompt_from_ability(): void {
+			$ability = wp_get_ability( 'test/prompt' );
+			$this->assertNotNull( $ability, 'Ability test/prompt should be registered' );
+			$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+			$this->assertInstanceOf( Prompt::class, $prompt );
+			$arr = $prompt->toArray();
+			$this->assertSame( 'test-prompt', $arr['name'] );
+			$this->assertArrayHasKey( 'arguments', $arr );
+			$this->assertNull( $prompt->get_meta() );
+		}
 
 	public function test_annotations_are_mapped_to_mcp_format(): void {
 		$ability = wp_get_ability( 'test/prompt-with-annotations' );
 		$this->assertNotNull( $ability, 'Ability test/prompt-with-annotations should be registered' );
 
-		$prompt = RegisterAbilityAsMcpPrompt::make( $ability, $this->makeServer() );
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->to_array();
+		$arr = $prompt->toArray();
 
-		// Verify MCP-format annotations.
-		$this->assertArrayHasKey( 'annotations', $arr );
-		$this->assertArrayHasKey( 'audience', $arr['annotations'] );
-		$this->assertArrayHasKey( 'lastModified', $arr['annotations'] );
-		$this->assertArrayHasKey( 'priority', $arr['annotations'] );
-
-		// Verify values.
-		$this->assertIsArray( $arr['annotations']['audience'] );
-		$this->assertContains( 'user', $arr['annotations']['audience'] );
-		$this->assertSame( '2024-01-15T10:30:00Z', $arr['annotations']['lastModified'] );
-		$this->assertSame( 0.9, $arr['annotations']['priority'] );
+		// Note: Schema Prompt DTO does not support annotations; these are intentionally not exposed.
+		$this->assertArrayNotHasKey( 'annotations', $arr );
 	}
 
 	public function test_partial_annotations_are_included(): void {
 		$ability = wp_get_ability( 'test/prompt-partial-annotations' );
 		$this->assertNotNull( $ability, 'Ability test/prompt-partial-annotations should be registered' );
 
-		$prompt = RegisterAbilityAsMcpPrompt::make( $ability, $this->makeServer() );
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->to_array();
+		$arr = $prompt->toArray();
 
-		// Verify only provided annotations are present.
-		$this->assertArrayHasKey( 'annotations', $arr );
-		$this->assertArrayHasKey( 'audience', $arr['annotations'] );
-		$this->assertContains( 'assistant', $arr['annotations']['audience'] );
-		$this->assertArrayNotHasKey( 'lastModified', $arr['annotations'] );
-		$this->assertArrayNotHasKey( 'priority', $arr['annotations'] );
+		// Note: Schema Prompt DTO does not support annotations; these are intentionally not exposed.
+		$this->assertArrayNotHasKey( 'annotations', $arr );
 	}
 
 	public function test_empty_annotations_are_not_included(): void {
 		$ability = wp_get_ability( 'test/prompt' );
 		$this->assertNotNull( $ability, 'Ability test/prompt should be registered' );
 
-		$prompt = RegisterAbilityAsMcpPrompt::make( $ability, $this->makeServer() );
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->to_array();
+		$arr = $prompt->toArray();
 
 		// Verify annotations field is not present when empty.
 		$this->assertArrayNotHasKey( 'annotations', $arr );
 	}
-}
+
+	// =========================================================================
+	// Flattened Schema Tests
+	// =========================================================================
+
+		public function test_flattened_string_schema_creates_single_input_argument(): void {
+			$ability = wp_get_ability( 'test/prompt-flattened-string' );
+			$this->assertNotNull( $ability, 'Ability test/prompt-flattened-string should be registered' );
+
+			$built = RegisterAbilityAsMcpPrompt::build( $ability );
+			$this->assertNotWPError( $built );
+			$this->assertIsArray( $built );
+			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$prompt = $built['prompt'];
+
+			$arr = $prompt->toArray();
+
+		// Should have exactly one argument named 'input'.
+		$this->assertArrayHasKey( 'arguments', $arr );
+		$this->assertCount( 1, $arr['arguments'] );
+		$this->assertSame( 'input', $arr['arguments'][0]['name'] );
+			$this->assertSame( 'The code to review', $arr['arguments'][0]['description'] );
+			$this->assertTrue( $arr['arguments'][0]['required'] );
+
+			$adapter_meta = $built['adapter_meta'];
+			$this->assertTrue( $adapter_meta['input_schema_transformed'] );
+			$this->assertSame( 'input', $adapter_meta['input_schema_wrapper'] );
+		}
+
+		public function test_flattened_array_schema_creates_single_input_argument(): void {
+			$ability = wp_get_ability( 'test/prompt-flattened-array' );
+			$this->assertNotNull( $ability, 'Ability test/prompt-flattened-array should be registered' );
+
+			$built = RegisterAbilityAsMcpPrompt::build( $ability );
+			$this->assertNotWPError( $built );
+			$this->assertIsArray( $built );
+			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$prompt = $built['prompt'];
+
+			$arr = $prompt->toArray();
+
+		// Should have exactly one argument named 'input'.
+		$this->assertArrayHasKey( 'arguments', $arr );
+		$this->assertCount( 1, $arr['arguments'] );
+		$this->assertSame( 'input', $arr['arguments'][0]['name'] );
+			$this->assertSame( 'List of items to process', $arr['arguments'][0]['description'] );
+			$this->assertTrue( $arr['arguments'][0]['required'] );
+
+			$this->assertTrue( $built['adapter_meta']['input_schema_transformed'] );
+		}
+
+	// =========================================================================
+	// Property Title Mapping Tests
+	// =========================================================================
+
+	public function test_property_title_is_mapped_to_argument_title(): void {
+		$ability = wp_get_ability( 'test/prompt-with-titles' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-with-titles should be registered' );
+
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+		$this->assertNotWPError( $prompt );
+
+		$arr = $prompt->toArray();
+
+		$this->assertArrayHasKey( 'arguments', $arr );
+		$this->assertCount( 2, $arr['arguments'] );
+
+		// Find arguments by name.
+		$code_arg     = null;
+		$language_arg = null;
+		foreach ( $arr['arguments'] as $arg ) {
+			if ( 'code' === $arg['name'] ) {
+				$code_arg = $arg;
+			}
+			if ( 'language' !== $arg['name'] ) {
+				continue;
+			}
+
+			$language_arg = $arg;
+		}
+
+		// Verify titles are mapped.
+		$this->assertNotNull( $code_arg );
+		$this->assertSame( 'Source Code', $code_arg['title'] );
+		$this->assertSame( 'The code to review', $code_arg['description'] );
+		$this->assertTrue( $code_arg['required'] );
+
+		$this->assertNotNull( $language_arg );
+		$this->assertSame( 'Programming Language', $language_arg['title'] );
+		$this->assertSame( 'The programming language', $language_arg['description'] );
+		// Optional argument should not have 'required' key.
+		$this->assertArrayNotHasKey( 'required', $language_arg );
+	}
+
+	// =========================================================================
+	// Required Field Handling Tests
+	// =========================================================================
+
+	public function test_required_only_emitted_when_true(): void {
+		$ability = wp_get_ability( 'test/prompt-mixed-required' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-mixed-required should be registered' );
+
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+		$this->assertNotWPError( $prompt );
+
+		$arr = $prompt->toArray();
+
+		$this->assertArrayHasKey( 'arguments', $arr );
+		$this->assertCount( 3, $arr['arguments'] );
+
+		// Find arguments by name.
+		$topic_arg  = null;
+		$tone_arg   = null;
+		$length_arg = null;
+		foreach ( $arr['arguments'] as $arg ) {
+			if ( 'topic' === $arg['name'] ) {
+				$topic_arg = $arg;
+			}
+			if ( 'tone' === $arg['name'] ) {
+				$tone_arg = $arg;
+			}
+			if ( 'length' !== $arg['name'] ) {
+				continue;
+			}
+
+			$length_arg = $arg;
+		}
+
+		// Required argument should have required: true.
+		$this->assertNotNull( $topic_arg );
+		$this->assertArrayHasKey( 'required', $topic_arg );
+		$this->assertTrue( $topic_arg['required'] );
+
+		// Optional arguments should NOT have the 'required' key at all.
+		$this->assertNotNull( $tone_arg );
+		$this->assertArrayNotHasKey( 'required', $tone_arg );
+
+		$this->assertNotNull( $length_arg );
+		$this->assertArrayNotHasKey( 'required', $length_arg );
+	}
+
+	// =========================================================================
+	// Edge Case Tests
+	// =========================================================================
+
+	public function test_empty_object_schema_has_no_arguments(): void {
+		$ability = wp_get_ability( 'test/prompt-empty-object' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-empty-object should be registered' );
+
+		$built = RegisterAbilityAsMcpPrompt::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertIsArray( $built );
+		$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+		$prompt = $built['prompt'];
+
+		$arr = $prompt->toArray();
+
+		// Empty object schema should result in no arguments key.
+		$this->assertArrayNotHasKey( 'arguments', $arr );
+
+		// Should NOT track transformation (no wrapping occurred).
+		$this->assertArrayNotHasKey( 'input_schema_transformed', $built['adapter_meta'] );
+	}
+
+	public function test_no_schema_has_no_arguments(): void {
+		$ability = wp_get_ability( 'test/prompt-no-schema' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-no-schema should be registered' );
+
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+		$this->assertNotWPError( $prompt );
+
+		$arr = $prompt->toArray();
+
+		// No schema should result in no arguments key.
+		$this->assertArrayNotHasKey( 'arguments', $arr );
+	}
+
+	public function test_object_schema_with_properties_no_transformation(): void {
+		$ability = wp_get_ability( 'test/prompt' );
+		$this->assertNotNull( $ability, 'Ability test/prompt should be registered' );
+
+		$built = RegisterAbilityAsMcpPrompt::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertIsArray( $built );
+		$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+		$prompt = $built['prompt'];
+
+		$arr = $prompt->toArray();
+
+		// Object schema should have arguments.
+		$this->assertArrayHasKey( 'arguments', $arr );
+		$this->assertNotEmpty( $arr['arguments'] );
+
+		// Should NOT track transformation (already an object schema).
+		$this->assertArrayNotHasKey( 'input_schema_transformed', $built['adapter_meta'] );
+	}
+
+	// =========================================================================
+	// Meta Tracking Tests
+	// =========================================================================
+
+	public function test_meta_tracks_ability_name(): void {
+		$ability = wp_get_ability( 'test/prompt' );
+		$this->assertNotNull( $ability );
+
+		$built = RegisterAbilityAsMcpPrompt::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertIsArray( $built );
+		$this->assertSame( 'test/prompt', $built['adapter_meta']['ability'] );
+	}
+
+	public function test_meta_tracks_transformation_for_flattened_schema(): void {
+		$ability = wp_get_ability( 'test/prompt-flattened-string' );
+		$this->assertNotNull( $ability );
+
+		$built = RegisterAbilityAsMcpPrompt::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertIsArray( $built );
+
+		$adapter_meta = $built['adapter_meta'];
+		$this->assertSame( 'test/prompt-flattened-string', $adapter_meta['ability'] );
+		$this->assertTrue( $adapter_meta['input_schema_transformed'] );
+		$this->assertSame( 'input', $adapter_meta['input_schema_wrapper'] );
+	}
+
+	// =========================================================================
+	// Explicit mcp.arguments Tests
+	// =========================================================================
+
+	public function test_explicit_arguments_are_used_when_defined(): void {
+		$ability = wp_get_ability( 'test/prompt-explicit-args' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-explicit-args should be registered' );
+
+		$built = RegisterAbilityAsMcpPrompt::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertIsArray( $built );
+		$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+		$prompt = $built['prompt'];
+
+		$arr = $prompt->toArray();
+
+		// Should have 2 arguments from explicit definition.
+		$this->assertArrayHasKey( 'arguments', $arr );
+		$this->assertCount( 2, $arr['arguments'] );
+
+		// Verify first argument (code).
+		$code_arg = $arr['arguments'][0];
+		$this->assertSame( 'code', $code_arg['name'] );
+		$this->assertSame( 'Source Code', $code_arg['title'] );
+		$this->assertSame( 'The code to review', $code_arg['description'] );
+		$this->assertTrue( $code_arg['required'] );
+
+		// Verify second argument (language).
+		$language_arg = $arr['arguments'][1];
+		$this->assertSame( 'language', $language_arg['name'] );
+		$this->assertSame( 'Programming language (optional)', $language_arg['description'] );
+		$this->assertArrayNotHasKey( 'required', $language_arg ); // Optional - no required field.
+		$this->assertArrayNotHasKey( 'title', $language_arg );    // No title defined.
+
+			// Verify arguments_source is 'explicit'.
+			$this->assertSame( 'explicit', $built['adapter_meta']['arguments_source'] );
+		}
+
+		public function test_explicit_arguments_override_input_schema(): void {
+			$ability = wp_get_ability( 'test/prompt-explicit-args-override' );
+			$this->assertNotNull( $ability, 'Ability test/prompt-explicit-args-override should be registered' );
+
+			$built = RegisterAbilityAsMcpPrompt::build( $ability );
+			$this->assertNotWPError( $built );
+			$this->assertIsArray( $built );
+			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$prompt = $built['prompt'];
+
+			$arr = $prompt->toArray();
+
+		// Should have exactly 1 argument from explicit override, NOT from input_schema.
+		$this->assertArrayHasKey( 'arguments', $arr );
+		$this->assertCount( 1, $arr['arguments'] );
+
+		// Verify the argument is from explicit, not schema.
+		$arg = $arr['arguments'][0];
+		$this->assertSame( 'explicit_field', $arg['name'] );
+		$this->assertSame( 'Explicit Field', $arg['title'] );
+		$this->assertSame( 'This should appear instead of schema_field', $arg['description'] );
+		$this->assertTrue( $arg['required'] );
+
+		// Verify NO schema_field (from input_schema).
+			foreach ( $arr['arguments'] as $argument ) {
+				$this->assertNotSame( 'schema_field', $argument['name'] );
+			}
+
+			// Verify arguments_source is 'explicit'.
+			$this->assertSame( 'explicit', $built['adapter_meta']['arguments_source'] );
+
+			// Verify NO transformation metadata (explicit args bypass schema transform).
+			$this->assertArrayNotHasKey( 'input_schema_transformed', $built['adapter_meta'] );
+		}
+
+		public function test_empty_explicit_arguments_falls_back_to_schema(): void {
+			$ability = wp_get_ability( 'test/prompt-empty-explicit-args' );
+			$this->assertNotNull( $ability, 'Ability test/prompt-empty-explicit-args should be registered' );
+
+			$built = RegisterAbilityAsMcpPrompt::build( $ability );
+			$this->assertNotWPError( $built );
+			$this->assertIsArray( $built );
+			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$prompt = $built['prompt'];
+
+			$arr = $prompt->toArray();
+
+		// Should fall back to input_schema since mcp.arguments is empty.
+		$this->assertArrayHasKey( 'arguments', $arr );
+		$this->assertCount( 1, $arr['arguments'] );
+
+		// Verify the argument is from input_schema.
+		$arg = $arr['arguments'][0];
+		$this->assertSame( 'fallback_field', $arg['name'] );
+		$this->assertSame( 'This should appear because mcp.arguments is empty', $arg['description'] );
+			$this->assertTrue( $arg['required'] );
+
+			// Verify arguments_source is 'schema' (fell back).
+			$this->assertSame( 'schema', $built['adapter_meta']['arguments_source'] );
+		}
+
+	public function test_invalid_explicit_arguments_missing_name_returns_wp_error(): void {
+		$ability = wp_get_ability( 'test/prompt-invalid-explicit-args-no-name' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-invalid-explicit-args-no-name should be registered' );
+
+		$result = RegisterAbilityAsMcpPrompt::make( $ability );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_prompt_argument_missing_name', $result->get_error_code() );
+		$this->assertStringContainsString( 'missing required "name" field', $result->get_error_message() );
+	}
+
+	public function test_invalid_explicit_arguments_not_array_returns_wp_error(): void {
+		$ability = wp_get_ability( 'test/prompt-invalid-explicit-args-not-array' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-invalid-explicit-args-not-array should be registered' );
+
+		$result = RegisterAbilityAsMcpPrompt::make( $ability );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_prompt_invalid_argument', $result->get_error_code() );
+		$this->assertStringContainsString( 'must be an array', $result->get_error_message() );
+	}
+
+		public function test_explicit_arguments_with_all_fields(): void {
+			$ability = wp_get_ability( 'test/prompt-explicit-args-all-fields' );
+			$this->assertNotNull( $ability, 'Ability test/prompt-explicit-args-all-fields should be registered' );
+
+			$built = RegisterAbilityAsMcpPrompt::build( $ability );
+			$this->assertNotWPError( $built );
+			$this->assertIsArray( $built );
+			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$prompt = $built['prompt'];
+
+			$arr = $prompt->toArray();
+
+		// Should have 2 arguments.
+		$this->assertArrayHasKey( 'arguments', $arr );
+		$this->assertCount( 2, $arr['arguments'] );
+
+		// Verify full_arg has all fields.
+		$full_arg = $arr['arguments'][0];
+		$this->assertSame( 'full_arg', $full_arg['name'] );
+		$this->assertSame( 'Full Argument', $full_arg['title'] );
+		$this->assertSame( 'An argument with all fields populated', $full_arg['description'] );
+		$this->assertTrue( $full_arg['required'] );
+
+		// Verify minimal_arg has only name (no optional fields).
+		$minimal_arg = $arr['arguments'][1];
+		$this->assertSame( 'minimal_arg', $minimal_arg['name'] );
+		$this->assertArrayNotHasKey( 'title', $minimal_arg );
+		$this->assertArrayNotHasKey( 'description', $minimal_arg );
+		$this->assertArrayNotHasKey( 'required', $minimal_arg );
+
+			// Verify arguments_source.
+			$this->assertSame( 'explicit', $built['adapter_meta']['arguments_source'] );
+		}
+
+		public function test_arguments_source_tracks_schema_source(): void {
+			$ability = wp_get_ability( 'test/prompt' );
+			$this->assertNotNull( $ability );
+
+			$built = RegisterAbilityAsMcpPrompt::build( $ability );
+			$this->assertNotWPError( $built );
+			$this->assertIsArray( $built );
+			$this->assertInstanceOf( Prompt::class, $built['prompt'] );
+			$prompt = $built['prompt'];
+
+			$arr = $prompt->toArray();
+
+			// Verify arguments_source is 'schema' for auto-converted arguments.
+			$this->assertSame( 'schema', $built['adapter_meta']['arguments_source'] );
+		}
+
+		public function test_no_arguments_has_no_arguments_source(): void {
+			$ability = wp_get_ability( 'test/prompt-no-schema' );
+			$this->assertNotNull( $ability );
+
+			// Verify arguments_source is NOT present when there are no arguments.
+			$built = RegisterAbilityAsMcpPrompt::build( $ability );
+			$this->assertNotWPError( $built );
+			$this->assertIsArray( $built );
+			$this->assertArrayNotHasKey( 'arguments_source', $built['adapter_meta'] );
+		}
+
+	// =========================================================================
+	// Icons Tests (MCP 2025-11-25)
+	// =========================================================================
+
+	public function test_icons_are_mapped_from_mcp_meta(): void {
+		$ability = wp_get_ability( 'test/prompt-with-icons' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-with-icons should be registered' );
+
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+		$this->assertNotWPError( $prompt );
+
+		$arr = $prompt->toArray();
+
+		// Verify icons array is present.
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertIsArray( $arr['icons'] );
+		$this->assertCount( 2, $arr['icons'] );
+
+		// Verify first icon (PNG with all fields).
+		$this->assertSame( 'https://example.com/prompt-icon.png', $arr['icons'][0]['src'] );
+		$this->assertSame( 'image/png', $arr['icons'][0]['mimeType'] );
+		$this->assertSame( array( '32x32' ), $arr['icons'][0]['sizes'] );
+		$this->assertSame( 'light', $arr['icons'][0]['theme'] );
+
+		// Verify second icon (SVG).
+		$this->assertSame( 'https://example.com/prompt-icon-dark.svg', $arr['icons'][1]['src'] );
+		$this->assertSame( 'image/svg+xml', $arr['icons'][1]['mimeType'] );
+		$this->assertSame( 'dark', $arr['icons'][1]['theme'] );
+	}
+
+	public function test_invalid_icons_are_filtered_out(): void {
+		$ability = wp_get_ability( 'test/prompt-with-mixed-icons' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-with-mixed-icons should be registered' );
+
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+		$this->assertNotWPError( $prompt );
+
+		$arr = $prompt->toArray();
+
+		// Should have only 2 valid icons (the one missing src was filtered out).
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 2, $arr['icons'] );
+
+		// Verify valid icons are present.
+		$this->assertSame( 'https://example.com/valid-prompt-icon.png', $arr['icons'][0]['src'] );
+		$this->assertSame( 'https://example.com/another-valid-prompt.svg', $arr['icons'][1]['src'] );
+	}
+
+	public function test_prompt_without_icons_has_no_icons_key(): void {
+		$ability = wp_get_ability( 'test/prompt' );
+		$this->assertNotNull( $ability );
+
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+		$this->assertNotWPError( $prompt );
+
+		$arr = $prompt->toArray();
+
+		// Verify icons key is not present when ability has no icons.
+		$this->assertArrayNotHasKey( 'icons', $arr );
+	}
+
+	// =========================================================================
+	// User _meta Passthrough Tests (MCP 2025-11-25)
+	// =========================================================================
+
+		public function test_user_meta_is_passed_through(): void {
+			$ability = wp_get_ability( 'test/prompt-with-custom-meta' );
+			$this->assertNotNull( $ability, 'Ability test/prompt-with-custom-meta should be registered' );
+
+			$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+			$this->assertNotWPError( $prompt );
+
+			$arr = $prompt->toArray();
+
+			// Verify _meta is present with user-defined keys.
+			$this->assertArrayHasKey( '_meta', $arr );
+
+		// Verify custom_vendor key is preserved.
+		$this->assertArrayHasKey( 'custom_vendor', $arr['_meta'] );
+		$this->assertIsArray( $arr['_meta']['custom_vendor'] );
+		$this->assertTrue( $arr['_meta']['custom_vendor']['feature_flag'] );
+		$this->assertSame( '1.0', $arr['_meta']['custom_vendor']['version'] );
+
+			// Verify another_vendor key is preserved.
+			$this->assertArrayHasKey( 'another_vendor', $arr['_meta'] );
+			$this->assertSame( 'some-value', $arr['_meta']['another_vendor'] );
+		}
+
+		public function test_prompt_without_user_meta_has_no_meta_field(): void {
+			$ability = wp_get_ability( 'test/prompt' );
+			$this->assertNotNull( $ability );
+
+			$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+			$this->assertNotWPError( $prompt );
+
+			$arr = $prompt->toArray();
+
+			$this->assertArrayNotHasKey( '_meta', $arr );
+		}
+
+	// =========================================================================
+	// Combined Icons and _meta Tests
+	// =========================================================================
+
+	public function test_prompt_with_both_icons_and_meta(): void {
+		$ability = wp_get_ability( 'test/prompt-with-icons-and-meta' );
+		$this->assertNotNull( $ability, 'Ability test/prompt-with-icons-and-meta should be registered' );
+
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+		$this->assertNotWPError( $prompt );
+
+		$arr = $prompt->toArray();
+
+		// Verify icons are present.
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 1, $arr['icons'] );
+		$this->assertSame( 'https://example.com/combined-prompt-icon.png', $arr['icons'][0]['src'] );
+		$this->assertSame( 'image/png', $arr['icons'][0]['mimeType'] );
+		$this->assertSame( array( '48x48' ), $arr['icons'][0]['sizes'] );
+
+			// Verify user _meta is present.
+			$this->assertArrayHasKey( '_meta', $arr );
+			$this->assertArrayHasKey( 'vendor_info', $arr['_meta'] );
+			$this->assertSame( 'test-value', $arr['_meta']['vendor_info']['custom_data'] );
+		}
+	}

--- a/tests/Unit/Resources/McpResourceTest.php
+++ b/tests/Unit/Resources/McpResourceTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\MCP\Tests\Unit\Resources;
+
+use WP\MCP\Domain\Resources\McpResource;
+use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Resources\DTO\Resource;
+
+final class McpResourceTest extends TestCase {
+
+
+	public function test_from_ability_builds_clean_resource_dto_and_adapter_meta(): void {
+		$ability = wp_get_ability( 'test/resource-new-meta' );
+		$this->assertNotNull( $ability, 'Ability test/resource-new-meta should be registered' );
+
+		$mcp_resource = McpResource::fromAbility( $ability );
+		$this->assertNotWPError( $mcp_resource );
+		$this->assertInstanceOf( McpResource::class, $mcp_resource );
+
+		$dto = $mcp_resource->get_component();
+		$this->assertInstanceOf( Resource::class, $dto );
+
+		$arr = $dto->toArray();
+		$this->assertArrayHasKey( '_meta', $arr );
+		$this->assertArrayHasKey( 'custom_field', $arr['_meta'] );
+		$this->assertSame( 'custom_value', $arr['_meta']['custom_field'] );
+
+		$adapter_meta = $mcp_resource->get_adapter_meta();
+		$this->assertArrayHasKey( 'ability', $adapter_meta );
+		$this->assertSame( $ability->get_name(), $adapter_meta['ability'] );
+	}
+
+	public function test_ability_backed_execute_and_permission_match_legacy_no_args_behavior(): void {
+		$ability = wp_get_ability( 'test/resource-plain-string' );
+		$this->assertNotNull( $ability, 'Ability test/resource-plain-string should be registered' );
+
+		$mcp_resource = McpResource::fromAbility( $ability );
+		$this->assertNotWPError( $mcp_resource );
+
+		$permission = $mcp_resource->check_permission( array( 'uri' => 'WordPress://local/resource-plain-string' ) );
+		$this->assertTrue( $permission );
+
+		$result = $mcp_resource->execute( array( 'uri' => 'WordPress://local/resource-plain-string' ) );
+		$this->assertSame( 'plain string content', $result );
+	}
+
+	public function test_permission_callback_supports_zero_arg_callable(): void {
+		$mcp_resource = McpResource::fromArray(
+			array(
+				'uri'        => 'WordPress://local/custom',
+				'title'      => 'Custom',
+				'handler'    => static function ( $args ) {
+					return $args;
+				},
+				'permission' => static function (): bool {
+					return true;
+				},
+			)
+		);
+
+		$this->assertTrue( $mcp_resource->check_permission( array( 'anything' => true ) ) );
+	}
+
+	public function test_fromArray_meta_preserves_all_keys(): void {
+		$mcp_resource = McpResource::fromArray(
+			array(
+				'uri'     => 'WordPress://local/meta-test',
+				'meta'    => array(
+					'mcp_adapter' => array( 'should_not' => 'leak' ),
+					'foo'         => 'bar',
+				),
+				'handler' => static function ( $args ) {
+					return $args;
+				},
+			)
+		);
+
+		$dto = $mcp_resource->get_component();
+		$arr = $dto->toArray();
+
+		$this->assertArrayHasKey( '_meta', $arr );
+		$this->assertArrayHasKey( 'foo', $arr['_meta'] );
+		$this->assertSame( 'bar', $arr['_meta']['foo'] );
+		$this->assertSame( array( 'should_not' => 'leak' ), $arr['_meta']['mcp_adapter'] );
+	}
+
+	// =========================================================================
+	// fromArray Tests
+	// =========================================================================
+
+	public function test_fromArray_builds_minimal_resource(): void {
+		$resource = McpResource::fromArray(
+			array(
+				'uri'     => 'WordPress://local/minimal',
+				'handler' => static fn() => 'content',
+			)
+		);
+
+		$dto = $resource->get_component();
+
+		$this->assertInstanceOf( Resource::class, $dto );
+		$this->assertSame( 'WordPress://local/minimal', $dto->getUri() );
+		// Name defaults to URI when not provided
+		$this->assertSame( 'WordPress://local/minimal', $dto->getName() );
+	}
+
+	public function test_fromArray_with_all_options(): void {
+		$resource = McpResource::fromArray(
+			array(
+				'uri'         => 'WordPress://local/full',
+				'name'        => 'full-resource',
+				'title'       => 'Full Resource',
+				'description' => 'A comprehensive test resource',
+				'mimeType'    => 'text/plain',
+				'size'        => 1024,
+				'annotations' => array(
+					'audience' => array( 'user' ),
+					'priority' => 0.8,
+				),
+				'meta'        => array( 'version' => '1.0' ),
+				'handler'     => static fn() => 'full content',
+				'permission'  => static fn() => true,
+			)
+		);
+
+		$dto  = $resource->get_component();
+		$data = $dto->toArray();
+
+		$this->assertSame( 'WordPress://local/full', $dto->getUri() );
+		$this->assertSame( 'full-resource', $dto->getName() );
+		$this->assertSame( 'Full Resource', $dto->getTitle() );
+		$this->assertSame( 'A comprehensive test resource', $dto->getDescription() );
+		$this->assertSame( 'text/plain', $dto->getMimeType() );
+		$this->assertSame( 1024, $dto->getSize() );
+		$this->assertArrayHasKey( 'annotations', $data );
+		$this->assertArrayHasKey( '_meta', $data );
+		$this->assertSame( '1.0', $data['_meta']['version'] );
+	}
+
+	public function test_fromArray_requires_uri(): void {
+		$result = McpResource::fromArray(
+			array(
+				'handler' => static fn() => 'content',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_resource_missing_uri', $result->get_error_code() );
+	}
+
+	public function test_fromArray_requires_handler(): void {
+		$result = McpResource::fromArray(
+			array(
+				'uri' => 'WordPress://local/no-handler',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_resource_missing_handler', $result->get_error_code() );
+	}
+
+	public function test_fromArray_validates_uri(): void {
+		$result = McpResource::fromArray(
+			array(
+				'uri'     => 'invalid-no-scheme',
+				'handler' => static fn() => 'content',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_resource_invalid_uri', $result->get_error_code() );
+	}
+
+	public function test_fromArray_executes_handler(): void {
+		$resource = McpResource::fromArray(
+			array(
+				'uri'     => 'WordPress://local/executable',
+				'handler' => static fn( $args ) => 'Hello, ' . ( $args['name'] ?? 'World' ),
+			)
+		);
+
+		$result = $resource->execute( array( 'name' => 'Claude' ) );
+
+		$this->assertSame( 'Hello, Claude', $result );
+	}
+
+	public function test_fromArray_checks_permission(): void {
+		$resource = McpResource::fromArray(
+			array(
+				'uri'        => 'WordPress://local/permission-test',
+				'handler'    => static fn() => 'content',
+				'permission' => static fn( $args ) => ( $args['token'] ?? '' ) === 'secret',
+			)
+		);
+
+		$this->assertTrue( $resource->check_permission( array( 'token' => 'secret' ) ) );
+		$this->assertFalse( $resource->check_permission( array( 'token' => 'wrong' ) ) );
+		$this->assertFalse( $resource->check_permission( array() ) );
+	}
+
+	public function test_fromArray_observability_context(): void {
+		$resource = McpResource::fromArray(
+			array(
+				'uri'     => 'WordPress://local/observable',
+				'handler' => static fn() => 'content',
+			)
+		);
+
+		$context = $resource->get_observability_context();
+
+		$this->assertSame( 'resource', $context['component_type'] );
+		$this->assertSame( 'WordPress://local/observable', $context['resource_uri'] );
+		$this->assertSame( 'array', $context['source'] );
+	}
+
+	// =========================================================================
+	// Error Handling Tests
+	// =========================================================================
+
+	public function test_execute_catches_handler_exceptions(): void {
+		$resource = McpResource::fromArray(
+			array(
+				'uri'     => 'WordPress://local/throwing',
+				'handler' => static function () {
+					throw new \RuntimeException( 'Handler exploded' );
+				},
+			)
+		);
+
+		$result = $resource->execute( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_execution_failed', $result->get_error_code() );
+		$this->assertSame( 'Handler exploded', $result->get_error_message() );
+	}
+
+	public function test_check_permission_catches_exceptions(): void {
+		$resource = McpResource::fromArray(
+			array(
+				'uri'        => 'WordPress://local/throwing-permission',
+				'handler'    => static fn() => 'content',
+				'permission' => static function () {
+					throw new \RuntimeException( 'Permission check exploded' );
+				},
+			)
+		);
+
+		$result = $resource->check_permission( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_permission_check_failed', $result->get_error_code() );
+		$this->assertSame( 'Permission check exploded', $result->get_error_message() );
+	}
+
+	public function test_fromArray_returns_wp_error_when_annotations_throw(): void {
+		// Pass invalid annotations data that causes Annotations::fromArray() to throw.
+		// The 'priority' field expects a float, not a string.
+		$result = McpResource::fromArray(
+			array(
+				'uri'         => 'WordPress://local/invalid-annotations',
+				'handler'     => static fn() => 'content',
+				'annotations' => array(
+					'priority' => 'not-a-float', // This will cause Annotations::fromArray() to throw.
+				),
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_resource_dto_creation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'Expected float', $result->get_error_message() );
+	}
+
+	// =========================================================================
+	// Secure-by-Default Behavior Tests
+	// =========================================================================
+
+	/**
+	 * Verify that no default permission callback is set.
+	 * Resources must explicitly configure permissions for security.
+	 */
+	public function test_no_default_permission_returns_error(): void {
+		$resource = McpResource::fromArray(
+			array(
+				'uri'     => 'WordPress://local/no-permission',
+				'handler' => static fn( $args ) => 'content',
+			)
+		);
+
+		$result = $resource->check_permission( array() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
+		$this->assertArrayHasKey( 'failure_reason', $result->get_error_data() );
+		$this->assertSame( 'no_permission_strategy', $result->get_error_data()['failure_reason'] );
+	}
+}

--- a/tests/Unit/Resources/McpResourceTest.php
+++ b/tests/Unit/Resources/McpResourceTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Resources;
 
 use WP\MCP\Domain\Resources\McpResource;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Resources\DTO\Resource;
+use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
 final class McpResourceTest extends TestCase {
 
@@ -19,8 +19,8 @@ final class McpResourceTest extends TestCase {
 		$this->assertNotWPError( $mcp_resource );
 		$this->assertInstanceOf( McpResource::class, $mcp_resource );
 
-		$dto = $mcp_resource->get_component();
-		$this->assertInstanceOf( Resource::class, $dto );
+		$dto = $mcp_resource->get_protocol_dto();
+		$this->assertInstanceOf( ResourceDto::class, $dto );
 
 		$arr = $dto->toArray();
 		$this->assertArrayHasKey( '_meta', $arr );
@@ -77,7 +77,7 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$dto = $mcp_resource->get_component();
+		$dto = $mcp_resource->get_protocol_dto();
 		$arr = $dto->toArray();
 
 		$this->assertArrayHasKey( '_meta', $arr );
@@ -98,9 +98,9 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$dto = $resource->get_component();
+		$dto = $resource->get_protocol_dto();
 
-		$this->assertInstanceOf( Resource::class, $dto );
+		$this->assertInstanceOf( ResourceDto::class, $dto );
 		$this->assertSame( 'WordPress://local/minimal', $dto->getUri() );
 		// Name defaults to URI when not provided
 		$this->assertSame( 'WordPress://local/minimal', $dto->getName() );
@@ -125,7 +125,7 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$dto  = $resource->get_component();
+		$dto  = $resource->get_protocol_dto();
 		$data = $dto->toArray();
 
 		$this->assertSame( 'WordPress://local/full', $dto->getUri() );

--- a/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
+++ b/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
@@ -6,26 +6,28 @@ namespace WP\MCP\Tests\Unit\Resources;
 
 use WP\MCP\Domain\Resources\RegisterAbilityAsMcpResource;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Resources\DTO\Resource;
 
 final class RegisterAbilityAsMcpResourceTest extends TestCase {
 
-	public function test_make_builds_resource_from_ability(): void {
-		$ability  = wp_get_ability( 'test/resource' );
-		$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
-		$resource = RegisterAbilityAsMcpResource::make( $ability, $this->makeServer() );
-		$arr      = $resource->to_array();
-		$this->assertSame( 'WordPress://local/resource-1', $arr['uri'] );
-		$this->assertSame( $ability, $resource->get_ability() );
-	}
+		public function test_make_builds_resource_from_ability(): void {
+			$ability  = wp_get_ability( 'test/resource' );
+			$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
+			$resource = RegisterAbilityAsMcpResource::make( $ability );
+			$this->assertInstanceOf( Resource::class, $resource );
+			$arr = $resource->toArray();
+			$this->assertSame( 'WordPress://local/resource-1', $arr['uri'] );
+			$this->assertNull( $resource->get_meta() );
+		}
 
 	public function test_annotations_are_mapped_to_mcp_format(): void {
 		$ability = wp_get_ability( 'test/resource-with-annotations' );
 		$this->assertNotNull( $ability, 'Ability test/resource-with-annotations should be registered' );
 
-		$resource = RegisterAbilityAsMcpResource::make( $ability, $this->makeServer() );
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->to_array();
+		$arr = $resource->toArray();
 
 		// Verify MCP-format annotations.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -45,10 +47,10 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$ability = wp_get_ability( 'test/resource-partial-annotations' );
 		$this->assertNotNull( $ability, 'Ability test/resource-partial-annotations should be registered' );
 
-		$resource = RegisterAbilityAsMcpResource::make( $ability, $this->makeServer() );
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->to_array();
+		$arr = $resource->toArray();
 
 		// Verify only provided annotations are present.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -58,27 +60,256 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$this->assertArrayNotHasKey( 'lastModified', $arr['annotations'] );
 	}
 
-		public function test_empty_annotations_are_not_included(): void {
-			$ability = wp_get_ability( 'test/resource' );
-			$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
+	public function test_empty_annotations_are_not_included(): void {
+		$ability = wp_get_ability( 'test/resource' );
+		$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
 
-			$resource = RegisterAbilityAsMcpResource::make( $ability, $this->makeServer() );
-			$this->assertNotWPError( $resource );
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
 
-			$arr = $resource->to_array();
+		$arr = $resource->toArray();
 
-			// Verify annotations field is not present when empty.
-			$this->assertArrayNotHasKey( 'annotations', $arr );
-		}
+		// Verify annotations field is not present when empty.
+		$this->assertArrayNotHasKey( 'annotations', $arr );
+	}
 
-		public function test_get_uri_trims_whitespace_from_meta(): void {
-			$ability = wp_get_ability( 'test/resource-whitespace-uri' );
-			$this->assertNotNull( $ability, 'Ability test/resource-whitespace-uri should be registered' );
+	public function test_get_uri_trims_whitespace_from_meta(): void {
+		$ability = wp_get_ability( 'test/resource-whitespace-uri' );
+		$this->assertNotNull( $ability, 'Ability test/resource-whitespace-uri should be registered' );
 
-			$resource = RegisterAbilityAsMcpResource::make( $ability, $this->makeServer() );
-			$this->assertNotWPError( $resource );
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
 
-			$arr = $resource->to_array();
-			$this->assertSame( 'WordPress://local/resource-whitespace', $arr['uri'] );
-		}
+		$arr = $resource->toArray();
+		$this->assertSame( 'WordPress://local/resource-whitespace', $arr['uri'] );
+	}
+
+	public function test_new_meta_structure_maps_all_fields(): void {
+		$ability = wp_get_ability( 'test/resource-new-meta' );
+		$this->assertNotNull( $ability, 'Ability test/resource-new-meta should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+
+		// Verify core fields.
+		$this->assertSame( 'test/resource-new-meta', $arr['name'] );
+		$this->assertSame( 'WordPress://local/resource-new-meta', $arr['uri'] );
+		$this->assertSame( 'Resource New Meta', $arr['title'] );
+		$this->assertSame( 'A resource using standardized mcp.* meta structure', $arr['description'] );
+
+		// Verify mimeType.
+		$this->assertArrayHasKey( 'mimeType', $arr );
+		$this->assertSame( 'text/plain', $arr['mimeType'] );
+
+		// Verify size.
+		$this->assertArrayHasKey( 'size', $arr );
+		$this->assertSame( 1024, $arr['size'] );
+
+		// Verify annotations.
+		$this->assertArrayHasKey( 'annotations', $arr );
+		$this->assertContains( 'user', $arr['annotations']['audience'] );
+		$this->assertSame( 0.7, $arr['annotations']['priority'] );
+
+		// Verify icons.
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 1, $arr['icons'] );
+		$this->assertSame( 'https://example.com/resource-icon.png', $arr['icons'][0]['src'] );
+
+		// Verify _meta passthrough.
+		$this->assertArrayHasKey( '_meta', $arr );
+		$this->assertArrayHasKey( 'custom_field', $arr['_meta'] );
+		$this->assertSame( 'custom_value', $arr['_meta']['custom_field'] );
+	}
+
+	public function test_invalid_uri_returns_wp_error(): void {
+		$ability = wp_get_ability( 'test/resource-invalid-uri' );
+		$this->assertNotNull( $ability, 'Ability test/resource-invalid-uri should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+
+		$this->assertWPError( $resource );
+		$this->assertSame( 'resource_uri_invalid', $resource->get_error_code() );
+	}
+
+	public function test_invalid_mimetype_is_silently_skipped(): void {
+		$ability = wp_get_ability( 'test/resource-invalid-mimetype' );
+		$this->assertNotNull( $ability, 'Ability test/resource-invalid-mimetype should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+
+		// mimeType should NOT be present (invalid format was skipped).
+		$this->assertArrayNotHasKey( 'mimeType', $arr );
+	}
+
+	public function test_size_field_is_included(): void {
+		$ability = wp_get_ability( 'test/resource-with-size' );
+		$this->assertNotNull( $ability, 'Ability test/resource-with-size should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+
+		$this->assertArrayHasKey( 'size', $arr );
+		$this->assertSame( 2048, $arr['size'] );
+	}
+
+	public function test_icons_are_included_from_new_meta_structure(): void {
+		$ability = wp_get_ability( 'test/resource-with-icons' );
+		$this->assertNotNull( $ability, 'Ability test/resource-with-icons should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 1, $arr['icons'] );
+		$this->assertSame( 'https://example.com/resource-icon.svg', $arr['icons'][0]['src'] );
+		$this->assertSame( 'image/svg+xml', $arr['icons'][0]['mimeType'] );
+		$this->assertSame( 'light', $arr['icons'][0]['theme'] );
+	}
+
+	public function test_resource_name_filter_is_applied(): void {
+		$ability = wp_get_ability( 'test/resource' );
+		$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
+
+		$filter_callback = static function ( string $name, \WP_Ability $ability ): string {
+			return 'filtered-' . $name;
+		};
+
+		add_filter( 'mcp_adapter_resource_name', $filter_callback, 10, 2 );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+		$this->assertSame( 'filtered-test/resource', $arr['name'] );
+
+		remove_filter( 'mcp_adapter_resource_name', $filter_callback, 10 );
+	}
+
+	public function test_resource_uri_filter_is_applied(): void {
+		$ability = wp_get_ability( 'test/resource' );
+		$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
+
+		$filter_callback = static function ( string $uri, \WP_Ability $ability ): string {
+			return str_replace( 'local', 'filtered', $uri );
+		};
+
+		add_filter( 'mcp_adapter_resource_uri', $filter_callback, 10, 2 );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+		$this->assertSame( 'WordPress://filtered/resource-1', $arr['uri'] );
+
+		remove_filter( 'mcp_adapter_resource_uri', $filter_callback, 10 );
+	}
+
+	public function test_invalid_uri_filter_result_returns_wp_error(): void {
+		$ability = wp_get_ability( 'test/resource' );
+		$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
+
+		$filter_callback = static function ( string $uri, \WP_Ability $ability ): string {
+			return 'invalid-no-scheme';
+		};
+
+		add_filter( 'mcp_adapter_resource_uri', $filter_callback, 10, 2 );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+
+		$this->assertWPError( $resource );
+		$this->assertSame( 'mcp_resource_uri_filter_invalid', $resource->get_error_code() );
+
+		remove_filter( 'mcp_adapter_resource_uri', $filter_callback, 10 );
+	}
+
+	public function test_invalid_annotations_are_dropped_with_doing_it_wrong(): void {
+		$ability = wp_get_ability( 'test/resource-invalid-annotations-new-meta' );
+		$this->assertNotNull( $ability, 'Ability test/resource-invalid-annotations-new-meta should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+
+		// Resource should still be created successfully (graceful degradation).
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+
+		// Annotations should NOT be present (all dropped due to validation errors).
+		$this->assertArrayNotHasKey( 'annotations', $arr );
+
+		// Verify _doing_it_wrong was triggered.
+		$this->assertDoingItWrongTriggered( 'WP\MCP\Domain\Resources\RegisterAbilityAsMcpResource::get_data' );
+	}
+
+	public function test_mixed_valid_invalid_annotations_drops_all(): void {
+		$ability = wp_get_ability( 'test/resource-mixed-annotations' );
+		$this->assertNotNull( $ability, 'Ability test/resource-mixed-annotations should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+
+		// Resource should still be created successfully.
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+
+		// ALL annotations should be dropped even though priority was valid.
+		// This is because we drop all if ANY are invalid.
+		$this->assertArrayNotHasKey( 'annotations', $arr );
+
+		// Verify _doing_it_wrong was triggered.
+		$this->assertDoingItWrongTriggered( 'WP\MCP\Domain\Resources\RegisterAbilityAsMcpResource::get_data' );
+	}
+
+	public function test_valid_annotations_are_preserved(): void {
+		$ability = wp_get_ability( 'test/resource-new-meta' );
+		$this->assertNotNull( $ability, 'Ability test/resource-new-meta should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+
+		// Valid annotations should be preserved.
+		$this->assertArrayHasKey( 'annotations', $arr );
+		$this->assertArrayHasKey( 'audience', $arr['annotations'] );
+		$this->assertArrayHasKey( 'priority', $arr['annotations'] );
+		$this->assertArrayHasKey( 'lastModified', $arr['annotations'] );
+
+		// Verify values are correct.
+		$this->assertContains( 'user', $arr['annotations']['audience'] );
+		$this->assertSame( 0.7, $arr['annotations']['priority'] );
+		$this->assertSame( '2025-01-15T10:30:00Z', $arr['annotations']['lastModified'] );
+	}
+
+	public function test_missing_uri_returns_wp_error(): void {
+		$ability = wp_get_ability( 'test/resource-missing-uri' );
+		$this->assertNotNull( $ability, 'Ability test/resource-missing-uri should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+
+		$this->assertWPError( $resource );
+		$this->assertSame( 'resource_uri_not_found', $resource->get_error_code() );
+	}
+
+	public function test_valid_mimetype_is_accepted(): void {
+		$ability = wp_get_ability( 'test/resource-valid-mimetype' );
+		$this->assertNotNull( $ability, 'Ability test/resource-valid-mimetype should be registered' );
+
+		$resource = RegisterAbilityAsMcpResource::make( $ability );
+		$this->assertNotWPError( $resource );
+
+		$arr = $resource->toArray();
+
+		// mimeType should be present with valid format.
+		$this->assertArrayHasKey( 'mimeType', $arr );
+		$this->assertSame( 'application/json', $arr['mimeType'] );
+	}
 }

--- a/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
+++ b/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Resources;
 
 use WP\MCP\Domain\Resources\RegisterAbilityAsMcpResource;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Resources\DTO\Resource;
+use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
 final class RegisterAbilityAsMcpResourceTest extends TestCase {
 
@@ -14,7 +14,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 			$ability  = wp_get_ability( 'test/resource' );
 			$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
 			$resource = RegisterAbilityAsMcpResource::make( $ability );
-			$this->assertInstanceOf( Resource::class, $resource );
+			$this->assertInstanceOf( ResourceDto::class, $resource );
 			$arr = $resource->toArray();
 			$this->assertSame( 'WordPress://local/resource-1', $arr['uri'] );
 			$this->assertNull( $resource->get_meta() );

--- a/tests/Unit/Tools/McpToolTest.php
+++ b/tests/Unit/Tools/McpToolTest.php
@@ -1,0 +1,571 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\MCP\Tests\Unit\Tools;
+
+use WP\MCP\Domain\Tools\McpTool;
+use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Tools\DTO\Tool;
+
+final class McpToolTest extends TestCase {
+
+
+	// =========================================================================
+	// fromAbility Tests
+	// =========================================================================
+
+	public function test_fromAbility_builds_mcp_tool_and_preserves_user_meta(): void {
+		$this->register_ability_in_hook(
+			'test/mcptool-from-ability',
+			array(
+				'label'               => 'McpTool From Ability',
+				'description'         => 'Test MCP tool',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array( 'ok' => true );
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'_meta' => array(
+							'public_meta_key' => 'public_meta_value',
+						),
+					),
+				),
+			)
+		);
+
+		$ability = wp_get_ability( 'test/mcptool-from-ability' );
+		$this->assertNotNull( $ability );
+
+		$mcp_tool = McpTool::fromAbility( $ability );
+		$this->assertNotWPError( $mcp_tool );
+
+		$dto = $mcp_tool->get_component();
+		$this->assertInstanceOf( Tool::class, $dto );
+
+		$data = $dto->toArray();
+
+		// User-provided _meta is preserved.
+		$this->assertArrayHasKey( '_meta', $data );
+		$this->assertSame( 'public_meta_value', $data['_meta']['public_meta_key'] );
+
+		// McpTool keeps adapter meta internally.
+		$adapter_meta = $mcp_tool->get_adapter_meta();
+		$this->assertSame( 'test/mcptool-from-ability', $adapter_meta['ability'] );
+
+		wp_unregister_ability( 'test/mcptool-from-ability' );
+	}
+
+	public function test_execute_unwraps_input_and_wraps_output_when_transformed(): void {
+		$this->register_ability_in_hook(
+			'test/mcptool-flat-schemas',
+			array(
+				'label'               => 'McpTool Flat Schemas',
+				'description'         => 'Flat input/output schemas',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'string' ),
+				'output_schema'       => array( 'type' => 'string' ),
+				'execute_callback'    => static function ( $input ) {
+					return $input;
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+			)
+		);
+
+		$ability = wp_get_ability( 'test/mcptool-flat-schemas' );
+		$this->assertNotNull( $ability );
+
+		$mcp_tool = McpTool::fromAbility( $ability );
+		$this->assertNotWPError( $mcp_tool );
+
+		$result = $mcp_tool->execute( array( 'input' => 'hello' ) );
+		$this->assertNotWPError( $result );
+		$this->assertSame( array( 'result' => 'hello' ), $result );
+
+		wp_unregister_ability( 'test/mcptool-flat-schemas' );
+	}
+
+	public function test_check_permission_unwraps_input_when_transformed(): void {
+		$this->register_ability_in_hook(
+			'test/mcptool-flat-permission',
+			array(
+				'label'               => 'McpTool Flat Permission',
+				'description'         => 'Flat input schema permission test',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'string' ),
+				'execute_callback'    => static function ( $input ) {
+					return $input;
+				},
+				'permission_callback' => static function ( $input ) {
+					return 'allowed' === $input;
+				},
+			)
+		);
+
+		$ability = wp_get_ability( 'test/mcptool-flat-permission' );
+		$this->assertNotNull( $ability );
+
+		$mcp_tool = McpTool::fromAbility( $ability );
+		$this->assertNotWPError( $mcp_tool );
+
+		$this->assertTrue( $mcp_tool->check_permission( array( 'input' => 'allowed' ) ) );
+		$this->assertFalse( $mcp_tool->check_permission( array( 'input' => 'denied' ) ) );
+
+		wp_unregister_ability( 'test/mcptool-flat-permission' );
+	}
+
+	public function test_fromArray_executes_handler_and_checks_permission(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'        => 'mcptool-direct',
+				'description' => 'Direct callable tool',
+				'inputSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'value' => array( 'type' => 'string' ),
+					),
+				),
+				'handler'     => static function ( $args ) {
+					return array( 'uppercased' => strtoupper( $args['value'] ?? '' ) );
+				},
+				'permission'  => static fn() => true,
+			)
+		);
+
+		$this->assertTrue( $tool->check_permission( array( 'value' => 'hello' ) ) );
+
+		$result = $tool->execute( array( 'value' => 'hello' ) );
+		$this->assertNotWPError( $result );
+		$this->assertSame( array( 'uppercased' => 'HELLO' ), $result );
+	}
+
+	public function test_fromArray_uses_permission_callback(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'        => 'mcptool-direct-permission',
+				'description' => 'Direct callable tool with permission callback',
+				'handler'     => static function () {
+					return array( 'ok' => true );
+				},
+				'permission'  => static function ( $args ) {
+					return isset( $args['allowed'] ) && true === $args['allowed'];
+				},
+			)
+		);
+
+		$this->assertTrue( $tool->check_permission( array( 'allowed' => true ) ) );
+		$this->assertFalse( $tool->check_permission( array( 'allowed' => false ) ) );
+		$this->assertFalse( $tool->check_permission( array() ) );
+	}
+
+	// =========================================================================
+	// fromArray Tests
+	// =========================================================================
+
+	public function test_fromArray_builds_minimal_tool(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'    => 'minimal-tool',
+				'handler' => static fn( $args ) => array( 'ok' => true ),
+			)
+		);
+
+		$dto = $tool->get_component();
+
+		$this->assertInstanceOf( Tool::class, $dto );
+		$this->assertSame( 'minimal-tool', $dto->getName() );
+		$this->assertNull( $dto->getTitle() );
+		$this->assertNull( $dto->getDescription() );
+
+		// Input schema defaults to object type
+		$input_schema = $dto->getInputSchema()->toArray();
+		$this->assertSame( 'object', $input_schema['type'] );
+	}
+
+	public function test_fromArray_with_all_options(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'         => 'full-featured-tool',
+				'title'        => 'Full Featured Tool',
+				'description'  => 'A comprehensive test tool',
+				'inputSchema'  => array(
+					'type'       => 'object',
+					'properties' => array(
+						'text' => array( 'type' => 'string' ),
+					),
+					'required'   => array( 'text' ),
+				),
+				'outputSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'result' => array( 'type' => 'string' ),
+					),
+				),
+				'meta'         => array( 'custom_key' => 'custom_value' ),
+				'handler'      => static fn( $args ) => array( 'result' => strtoupper( $args['text'] ) ),
+				'permission'   => static fn( $args ) => true,
+			)
+		);
+
+		$dto  = $tool->get_component();
+		$data = $dto->toArray();
+
+		$this->assertSame( 'full-featured-tool', $dto->getName() );
+		$this->assertSame( 'Full Featured Tool', $dto->getTitle() );
+		$this->assertSame( 'A comprehensive test tool', $dto->getDescription() );
+
+		// Check input schema
+		$input_schema = $dto->getInputSchema()->toArray();
+		$this->assertSame( 'object', $input_schema['type'] );
+		$this->assertArrayHasKey( 'text', $input_schema['properties'] );
+		$this->assertContains( 'text', $input_schema['required'] );
+
+		// Check output schema
+		$this->assertArrayHasKey( 'outputSchema', $data );
+
+		// Check custom meta preserved
+		$this->assertArrayHasKey( '_meta', $data );
+		$this->assertSame( 'custom_value', $data['_meta']['custom_key'] );
+	}
+
+	public function test_fromArray_with_annotations(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'        => 'annotated-tool',
+				'description' => 'A tool with annotations',
+				'annotations' => array(
+					'readOnlyHint'   => true,
+					'idempotentHint' => true,
+				),
+				'handler'     => static fn( $args ) => array( 'ok' => true ),
+			)
+		);
+
+		$dto  = $tool->get_component();
+		$data = $dto->toArray();
+
+		$this->assertArrayHasKey( 'annotations', $data );
+		$this->assertTrue( $data['annotations']['readOnlyHint'] );
+		$this->assertTrue( $data['annotations']['idempotentHint'] );
+	}
+
+	public function test_fromArray_with_destructive_annotations(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'        => 'destructive-tool',
+				'description' => 'Deletes data',
+				'annotations' => array(
+					'destructiveHint' => true,
+					'openWorldHint'   => true,
+				),
+				'handler'     => static fn( $args ) => array( 'deleted' => true ),
+			)
+		);
+
+		$dto  = $tool->get_component();
+		$data = $dto->toArray();
+
+		$this->assertArrayHasKey( 'annotations', $data );
+		$this->assertTrue( $data['annotations']['destructiveHint'] );
+		$this->assertTrue( $data['annotations']['openWorldHint'] );
+	}
+
+	public function test_fromArray_with_all_annotations(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'        => 'all-annotations-tool',
+				'annotations' => array(
+					'title'           => 'Custom Annotation Title',
+					'readOnlyHint'    => false,
+					'destructiveHint' => true,
+					'idempotentHint'  => true,
+					'openWorldHint'   => false,
+				),
+				'handler'     => static fn( $args ) => array( 'ok' => true ),
+			)
+		);
+
+		$dto  = $tool->get_component();
+		$data = $dto->toArray();
+
+		$this->assertSame( 'Custom Annotation Title', $data['annotations']['title'] );
+		$this->assertFalse( $data['annotations']['readOnlyHint'] );
+		$this->assertTrue( $data['annotations']['destructiveHint'] );
+		$this->assertTrue( $data['annotations']['idempotentHint'] );
+		$this->assertFalse( $data['annotations']['openWorldHint'] );
+	}
+
+	public function test_fromArray_executes_handler(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'        => 'executable-tool',
+				'inputSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'name' => array( 'type' => 'string' ),
+					),
+				),
+				'handler'     => static fn( $args ) => array( 'greeting' => 'Hello, ' . ( $args['name'] ?? 'World' ) ),
+			)
+		);
+
+		$result = $tool->execute( array( 'name' => 'Claude' ) );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( array( 'greeting' => 'Hello, Claude' ), $result );
+	}
+
+	public function test_fromArray_checks_permission(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'       => 'permission-tool',
+				'handler'    => static fn( $args ) => array( 'ok' => true ),
+				'permission' => static fn( $args ) => ( $args['secret'] ?? '' ) === 'password123',
+			)
+		);
+
+		$this->assertTrue( $tool->check_permission( array( 'secret' => 'password123' ) ) );
+		$this->assertFalse( $tool->check_permission( array( 'secret' => 'wrong' ) ) );
+		$this->assertFalse( $tool->check_permission( array() ) );
+	}
+
+	public function test_no_permission_callback_denies_access(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'    => 'no-permission-tool',
+				'handler' => static fn( $args ) => array( 'ok' => true ),
+			)
+		);
+
+		// Without explicit permission callback, access should be denied.
+		$result = $tool->check_permission( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
+	}
+
+	public function test_explicit_permission_allows_access(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'       => 'public-tool',
+				'handler'    => static fn( $args ) => array( 'ok' => true ),
+				'permission' => static fn() => true,
+			)
+		);
+
+		// Explicit permission callback allowing access.
+		$this->assertTrue( $tool->check_permission( array() ) );
+		$this->assertTrue( $tool->check_permission( array( 'any' => 'value' ) ) );
+	}
+
+	public function test_fromArray_observability_context(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'    => 'observable-tool',
+				'handler' => static fn( $args ) => array( 'ok' => true ),
+			)
+		);
+
+		$context = $tool->get_observability_context();
+
+		$this->assertSame( 'tool', $context['component_type'] );
+		$this->assertSame( 'observable-tool', $context['tool_name'] );
+		$this->assertSame( 'array', $context['source'] );
+	}
+
+	public function test_fromArray_creates_tool(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'        => 'array-tool',
+				'title'       => 'Array Tool',
+				'description' => 'Created from array',
+				'inputSchema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'value' => array( 'type' => 'string' ),
+					),
+				),
+				'handler'     => static fn( $args ) => array( 'uppercased' => strtoupper( $args['value'] ?? '' ) ),
+				'permission'  => static fn( $args ) => true,
+				'annotations' => array( 'readOnlyHint' => true ),
+			)
+		);
+
+		$dto  = $tool->get_component();
+		$data = $dto->toArray();
+
+		$this->assertSame( 'array-tool', $dto->getName() );
+		$this->assertSame( 'Array Tool', $dto->getTitle() );
+		$this->assertSame( 'Created from array', $dto->getDescription() );
+		$this->assertTrue( $data['annotations']['readOnlyHint'] );
+
+		// Execute
+		$result = $tool->execute( array( 'value' => 'hello' ) );
+		$this->assertSame( array( 'uppercased' => 'HELLO' ), $result );
+	}
+
+	public function test_fromArray_requires_name(): void {
+		$result = McpTool::fromArray(
+			array(
+				'handler' => static fn( $args ) => array( 'ok' => true ),
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_tool_missing_name', $result->get_error_code() );
+	}
+
+	public function test_fromArray_requires_handler(): void {
+		$result = McpTool::fromArray(
+			array(
+				'name' => 'missing-handler-tool',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_tool_missing_handler', $result->get_error_code() );
+	}
+
+	public function test_fromArray_with_meta(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'    => 'meta-tool',
+				'meta'    => array( 'version' => '1.0.0' ),
+				'handler' => static fn( $args ) => array( 'ok' => true ),
+			)
+		);
+
+		$dto  = $tool->get_component();
+		$data = $dto->toArray();
+
+		$this->assertArrayHasKey( '_meta', $data );
+		$this->assertSame( '1.0.0', $data['_meta']['version'] );
+	}
+
+	// =========================================================================
+	// Error Handling Tests
+	// =========================================================================
+
+	public function test_execute_catches_handler_exceptions(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'    => 'throwing-tool',
+				'handler' => static function ( $args ) {
+					throw new \RuntimeException( 'Handler exploded' );
+				},
+			)
+		);
+
+		$result = $tool->execute( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_execution_failed', $result->get_error_code() );
+		$this->assertSame( 'Handler exploded', $result->get_error_message() );
+	}
+
+	public function test_check_permission_catches_exceptions(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'       => 'throwing-permission-tool',
+				'handler'    => static fn( $args ) => array( 'ok' => true ),
+				'permission' => static function ( $args ) {
+					throw new \RuntimeException( 'Permission check exploded' );
+				},
+			)
+		);
+
+		$result = $tool->check_permission( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_permission_check_failed', $result->get_error_code() );
+		$this->assertSame( 'Permission check exploded', $result->get_error_message() );
+	}
+
+	public function test_fromArray_returns_wp_error_when_annotations_throw(): void {
+		// Pass invalid annotations data that causes ToolAnnotations::fromArray() to throw.
+		// The 'readOnlyHint' field expects a bool, not a string.
+		$result = McpTool::fromArray(
+			array(
+				'name'        => 'invalid-annotations-tool',
+				'handler'     => static fn( $args ) => array( 'ok' => true ),
+				'annotations' => array(
+					'readOnlyHint' => 'not-a-boolean', // This will cause ToolAnnotations::fromArray() to throw.
+				),
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_tool_dto_creation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'Expected bool', $result->get_error_message() );
+	}
+
+	// =========================================================================
+	// Result Normalization Tests
+	// =========================================================================
+
+	public function test_execute_wraps_scalar_results(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'    => 'scalar-result-tool',
+				'handler' => static fn( $args ) => 'just a string',
+			)
+		);
+
+		$result = $tool->execute( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array( 'result' => 'just a string' ), $result );
+	}
+
+	public function test_execute_preserves_array_results(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'    => 'array-result-tool',
+				'handler' => static fn( $args ) => array(
+					'custom' => 'response',
+					'items'  => array( 1, 2, 3 ),
+				),
+			)
+		);
+
+		$result = $tool->execute( array() );
+
+		$this->assertSame(
+			array(
+				'custom' => 'response',
+				'items'  => array( 1, 2, 3 ),
+			),
+			$result
+		);
+	}
+
+	// =========================================================================
+	// Secure-by-Default Behavior Tests
+	// =========================================================================
+
+	/**
+	 * Verify that no default permission callback is set.
+	 * Tools must explicitly configure permissions for security.
+	 */
+	public function test_no_default_permission_returns_error(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'    => 'no-permission-tool',
+				'handler' => static fn( $args ) => array( 'ok' => true ),
+			)
+		);
+
+		$result = $tool->check_permission( array() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
+		$this->assertArrayHasKey( 'failure_reason', $result->get_error_data() );
+		$this->assertSame( 'no_permission_strategy', $result->get_error_data()['failure_reason'] );
+	}
+}

--- a/tests/Unit/Tools/McpToolTest.php
+++ b/tests/Unit/Tools/McpToolTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Tools;
 
 use WP\MCP\Domain\Tools\McpTool;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Tools\DTO\Tool;
+use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 final class McpToolTest extends TestCase {
 
@@ -45,8 +45,8 @@ final class McpToolTest extends TestCase {
 		$mcp_tool = McpTool::fromAbility( $ability );
 		$this->assertNotWPError( $mcp_tool );
 
-		$dto = $mcp_tool->get_component();
-		$this->assertInstanceOf( Tool::class, $dto );
+		$dto = $mcp_tool->get_protocol_dto();
+		$this->assertInstanceOf( ToolDto::class, $dto );
 
 		$data = $dto->toArray();
 
@@ -177,9 +177,9 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto = $tool->get_component();
+		$dto = $tool->get_protocol_dto();
 
-		$this->assertInstanceOf( Tool::class, $dto );
+		$this->assertInstanceOf( ToolDto::class, $dto );
 		$this->assertSame( 'minimal-tool', $dto->getName() );
 		$this->assertNull( $dto->getTitle() );
 		$this->assertNull( $dto->getDescription() );
@@ -214,7 +214,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_component();
+		$dto  = $tool->get_protocol_dto();
 		$data = $dto->toArray();
 
 		$this->assertSame( 'full-featured-tool', $dto->getName() );
@@ -248,7 +248,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_component();
+		$dto  = $tool->get_protocol_dto();
 		$data = $dto->toArray();
 
 		$this->assertArrayHasKey( 'annotations', $data );
@@ -269,7 +269,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_component();
+		$dto  = $tool->get_protocol_dto();
 		$data = $dto->toArray();
 
 		$this->assertArrayHasKey( 'annotations', $data );
@@ -292,7 +292,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_component();
+		$dto  = $tool->get_protocol_dto();
 		$data = $dto->toArray();
 
 		$this->assertSame( 'Custom Annotation Title', $data['annotations']['title'] );
@@ -397,7 +397,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_component();
+		$dto  = $tool->get_protocol_dto();
 		$data = $dto->toArray();
 
 		$this->assertSame( 'array-tool', $dto->getName() );
@@ -441,7 +441,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_component();
+		$dto  = $tool->get_protocol_dto();
 		$data = $dto->toArray();
 
 		$this->assertArrayHasKey( '_meta', $data );

--- a/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
+++ b/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
@@ -6,19 +6,19 @@ namespace WP\MCP\Tests\Unit\Tools;
 
 use WP\MCP\Domain\Tools\RegisterAbilityAsMcpTool;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Tools\DTO\Tool;
+use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 	/**
 	 * @param \WP_Ability $ability The ability to build into a Tool DTO.
 	 */
-	private function build_tool_from_ability( \WP_Ability $ability ): Tool {
+	private function build_tool_from_ability( \WP_Ability $ability ): ToolDto {
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
 		$this->assertArrayHasKey( 'tool', $built );
-		$this->assertInstanceOf( Tool::class, $built['tool'] );
+		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
 
 		return $built['tool'];
 	}
@@ -224,7 +224,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotNull( $ability, 'Ability test/flat-transformed-tool should be registered' );
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
-		$this->assertInstanceOf( Tool::class, $built['tool'] );
+		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
 
 		$adapter_meta = $built['adapter_meta'];
 		$this->assertSame( 'test/flat-transformed-tool', $adapter_meta['ability'] );
@@ -269,7 +269,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( Tool::class, $tool );
+		$this->assertInstanceOf( ToolDto::class, $tool );
 
 			$data = $tool->toArray();
 			$this->assertArrayHasKey( '_meta', $data );
@@ -411,7 +411,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
-		$this->assertInstanceOf( Tool::class, $built['tool'] );
+		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
 
 		// Verify input transformation metadata is present.
 		$adapter_meta = $built['adapter_meta'];
@@ -452,7 +452,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
-		$this->assertInstanceOf( Tool::class, $built['tool'] );
+		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
 
 		$adapter_meta = $built['adapter_meta'];
 		$this->assertSame( 'test/output-only-transformed', $adapter_meta['ability'] );
@@ -506,7 +506,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
-		$this->assertInstanceOf( Tool::class, $built['tool'] );
+		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
 
 		$adapter_meta = $built['adapter_meta'];
 
@@ -580,7 +580,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( Tool::class, $tool );
+		$this->assertInstanceOf( ToolDto::class, $tool );
 
 		$meta = $tool->get_meta();
 		$this->assertIsArray( $meta );
@@ -604,7 +604,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( Tool::class, $tool );
+		$this->assertInstanceOf( ToolDto::class, $tool );
 
 		$arr = $tool->toArray();
 
@@ -643,7 +643,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( Tool::class, $tool );
+		$this->assertInstanceOf( ToolDto::class, $tool );
 
 		$data = $tool->toArray();
 		$this->assertArrayNotHasKey( '_meta', $data );
@@ -686,7 +686,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( Tool::class, $tool );
+		$this->assertInstanceOf( ToolDto::class, $tool );
 
 		$data = $tool->toArray();
 		$this->assertArrayHasKey( '_meta', $data );
@@ -736,7 +736,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( Tool::class, $tool );
+		$this->assertInstanceOf( ToolDto::class, $tool );
 
 		$data = $tool->toArray();
 		$this->assertArrayNotHasKey( '_meta', $data );

--- a/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
+++ b/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
@@ -6,14 +6,28 @@ namespace WP\MCP\Tests\Unit\Tools;
 
 use WP\MCP\Domain\Tools\RegisterAbilityAsMcpTool;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Tools\DTO\Tool;
 
 final class RegisterAbilityAsMcpToolTest extends TestCase {
 
-	public function test_make_builds_tool_from_ability(): void {
+	/**
+	 * @param \WP_Ability $ability The ability to build into a Tool DTO.
+	 */
+	private function build_tool_from_ability( \WP_Ability $ability ): Tool {
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertIsArray( $built );
+		$this->assertArrayHasKey( 'tool', $built );
+		$this->assertInstanceOf( Tool::class, $built['tool'] );
+
+		return $built['tool'];
+	}
+
+	public function test_build_builds_tool_from_ability(): void {
 		$ability = wp_get_ability( 'test/always-allowed' );
 		$this->assertNotNull( $ability, 'Ability test/always-allowed should be registered' );
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$arr  = $tool->to_array();
+		$tool = $this->build_tool_from_ability( $ability );
+		$arr  = $tool->toArray();
 		$this->assertSame( 'test-always-allowed', $arr['name'] );
 		$this->assertArrayHasKey( 'inputSchema', $arr );
 	}
@@ -22,10 +36,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$ability = wp_get_ability( 'test/annotated-ability' );
 		$this->assertNotNull( $ability, 'Ability test/annotated-ability should be registered' );
 
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$this->assertNotWPError( $tool );
+		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->to_array();
+		$arr = $tool->toArray();
 
 		// Verify MCP-format annotations.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -48,10 +61,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$ability = wp_get_ability( 'test/null-annotations' );
 		$this->assertNotNull( $ability, 'Ability test/null-annotations should be registered' );
 
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$this->assertNotWPError( $tool );
+		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->to_array();
+		$arr = $tool->toArray();
 
 		// Verify only non-null annotations are present.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -65,10 +77,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$ability = wp_get_ability( 'test/with-instructions' );
 		$this->assertNotNull( $ability, 'Ability test/with-instructions should be registered' );
 
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$this->assertNotWPError( $tool );
+		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->to_array();
+		$arr = $tool->toArray();
 
 		// Verify instructions field is not in the output.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -83,10 +94,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$ability = wp_get_ability( 'test/mcp-native' );
 		$this->assertNotNull( $ability, 'Ability test/mcp-native should be registered' );
 
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$this->assertNotWPError( $tool );
+		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->to_array();
+		$arr = $tool->toArray();
 
 		// Verify MCP-native fields are preserved.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -104,10 +114,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$ability = wp_get_ability( 'test/no-annotations' );
 		$this->assertNotNull( $ability, 'Ability test/no-annotations should be registered' );
 
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$this->assertNotWPError( $tool );
+		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->to_array();
+		$arr = $tool->toArray();
 
 		// Verify annotations field is not present.
 		$this->assertArrayNotHasKey( 'annotations', $arr );
@@ -117,10 +126,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$ability = wp_get_ability( 'test/all-null-annotations' );
 		$this->assertNotNull( $ability, 'Ability test/all-null-annotations should be registered' );
 
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$this->assertNotWPError( $tool );
+		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->to_array();
+		$arr = $tool->toArray();
 
 		// Verify annotations field is not present when all values are null.
 		$this->assertArrayNotHasKey( 'annotations', $arr );
@@ -130,10 +138,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$ability = wp_get_ability( 'test/annotated-ability' );
 		$this->assertNotNull( $ability, 'Ability test/annotated-ability should be registered' );
 
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$this->assertNotWPError( $tool );
+		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->to_array();
+		$arr = $tool->toArray();
 
 		// Verify annotations exist.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -158,36 +165,38 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 			$this->markTestSkipped( 'Built-in ability mcp-adapter/get-ability-info not found' );
 		}
 
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
-		$this->assertNotWPError( $tool );
+			$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->to_array();
+			$arr = $tool->toArray();
 
 		if ( ! isset( $arr['annotations'] ) ) {
 			// If no annotations, test passes.
 			return;
 		}
 
-		// Verify ONLY MCP-spec fields are present.
-		// Includes tool-specific hints and shared annotations (audience, lastModified, priority).
-		$valid_mcp_fields = array(
+		// Verify ONLY MCP ToolAnnotations fields are present.
+		// Per MCP 2025-11-25 spec, ToolAnnotations contains only these fields.
+		// Shared Annotations (audience, lastModified, priority) are for Resources/Prompts, NOT Tools.
+		$valid_tool_annotation_fields = array(
 			'readOnlyHint',
 			'destructiveHint',
 			'idempotentHint',
 			'openWorldHint',
 			'title',
-			'audience',
-			'lastModified',
-			'priority',
 		);
 		foreach ( array_keys( $arr['annotations'] ) as $field ) {
-			$this->assertContains( $field, $valid_mcp_fields, "Non-MCP field '{$field}' should be filtered out" );
+			$this->assertContains( $field, $valid_tool_annotation_fields, "Field '{$field}' is not a valid ToolAnnotations field per MCP spec" );
 		}
 
 		// Verify no WordPress-format fields.
 		$this->assertArrayNotHasKey( 'readonly', $arr['annotations'] );
 		$this->assertArrayNotHasKey( 'destructive', $arr['annotations'] );
 		$this->assertArrayNotHasKey( 'idempotent', $arr['annotations'] );
+
+		// Verify shared Annotations fields are NOT present (they're for Resources, not Tools).
+		$this->assertArrayNotHasKey( 'audience', $arr['annotations'], 'Shared annotation audience should not be mapped for tools' );
+		$this->assertArrayNotHasKey( 'lastModified', $arr['annotations'], 'Shared annotation lastModified should not be mapped for tools' );
+		$this->assertArrayNotHasKey( 'priority', $arr['annotations'], 'Shared annotation priority should not be mapped for tools' );
 	}
 
 	public function test_transformation_flags_are_stored_in_metadata(): void {
@@ -213,16 +222,526 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$ability = wp_get_ability( 'test/flat-transformed-tool' );
 		$this->assertNotNull( $ability, 'Ability test/flat-transformed-tool should be registered' );
-		$tool = RegisterAbilityAsMcpTool::make( $ability, $this->makeServer() );
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertInstanceOf( Tool::class, $built['tool'] );
 
-		$this->assertInstanceOf( \WP\MCP\Domain\Tools\McpTool::class, $tool );
-
-		$metadata = $tool->get_metadata();
-		$this->assertTrue( $metadata['_input_schema_transformed'] ?? false );
-		$this->assertTrue( $metadata['_output_schema_transformed'] ?? false );
-		$this->assertSame( 'input', $metadata['_input_schema_wrapper'] ?? '' );
-		$this->assertSame( 'result', $metadata['_output_schema_wrapper'] ?? '' );
+		$adapter_meta = $built['adapter_meta'];
+		$this->assertSame( 'test/flat-transformed-tool', $adapter_meta['ability'] );
+		$this->assertTrue( $adapter_meta['input_schema_transformed'] );
+		$this->assertTrue( $adapter_meta['output_schema_transformed'] );
+		$this->assertSame( 'input', $adapter_meta['input_schema_wrapper'] );
+		$this->assertSame( 'result', $adapter_meta['output_schema_wrapper'] );
 
 		wp_unregister_ability( 'test/flat-transformed-tool' );
+	}
+
+	public function test_build_preserves_user_mcp_adapter_meta_key(): void {
+		$this->register_ability_in_hook(
+			'test/tool-user-meta-mcp-adapter',
+			array(
+				'label'               => 'Tool User Meta MCP Adapter',
+				'description'         => 'Test reserved _meta key stripping',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array( 'ok' => true );
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'_meta' => array(
+							'mcp_adapter'       => array( 'spoofed' => true ),
+							'public_meta_key'   => 'public_meta_value',
+							'public_meta_other' => 'public_meta_other_value',
+						),
+					),
+				),
+			)
+		);
+
+		$ability = wp_get_ability( 'test/tool-user-meta-mcp-adapter' );
+		$this->assertNotNull( $ability );
+
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+
+		$tool = $built['tool'];
+		$this->assertInstanceOf( Tool::class, $tool );
+
+			$data = $tool->toArray();
+			$this->assertArrayHasKey( '_meta', $data );
+			$this->assertSame( 'public_meta_value', $data['_meta']['public_meta_key'] );
+			$this->assertSame( 'public_meta_other_value', $data['_meta']['public_meta_other'] );
+			$this->assertSame( array( 'spoofed' => true ), $data['_meta']['mcp_adapter'] );
+
+		wp_unregister_ability( 'test/tool-user-meta-mcp-adapter' );
+	}
+
+	// Tool Name Filter and Validation Tests
+
+	public function test_tool_name_filter_applied(): void {
+		$this->register_ability_in_hook(
+			'test/filter-name-ability',
+			array(
+				'label'               => 'Filter Test',
+				'description'         => 'Tests filter hook',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'ok';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array( 'mcp' => array( 'public' => true ) ),
+			)
+		);
+
+		// Add filter to modify tool name.
+		$filter_callback = static function ( string $name ) {
+			return 'custom-filtered-name';
+		};
+		add_filter( 'mcp_adapter_tool_name', $filter_callback );
+
+			$ability = wp_get_ability( 'test/filter-name-ability' );
+			$this->assertNotNull( $ability );
+
+			$tool = $this->build_tool_from_ability( $ability );
+
+			$arr = $tool->toArray();
+			$this->assertSame( 'custom-filtered-name', $arr['name'] );
+
+		remove_filter( 'mcp_adapter_tool_name', $filter_callback );
+		wp_unregister_ability( 'test/filter-name-ability' );
+	}
+
+	public function test_tool_name_filter_validation_rejects_invalid(): void {
+		$this->register_ability_in_hook(
+			'test/filter-invalid-ability',
+			array(
+				'label'               => 'Filter Invalid Test',
+				'description'         => 'Tests filter validation',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'ok';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array( 'mcp' => array( 'public' => true ) ),
+			)
+		);
+
+		// Add filter that returns invalid name (with spaces).
+		$filter_callback = static function () {
+			return 'invalid name with spaces';
+		};
+		add_filter( 'mcp_adapter_tool_name', $filter_callback );
+
+			$ability = wp_get_ability( 'test/filter-invalid-ability' );
+			$this->assertNotNull( $ability );
+
+			$built = RegisterAbilityAsMcpTool::build( $ability );
+			$this->assertWPError( $built );
+			$this->assertSame( 'mcp_tool_name_filter_invalid', $built->get_error_code() );
+
+			remove_filter( 'mcp_adapter_tool_name', $filter_callback );
+			wp_unregister_ability( 'test/filter-invalid-ability' );
+	}
+
+	public function test_tool_name_sanitizes_slash_to_hyphen(): void {
+		// Verify basic slash-to-hyphen sanitization works.
+		$this->register_ability_in_hook(
+			'test/slash-ability',
+			array(
+				'label'               => 'Slash Test',
+				'description'         => 'Tests slash to hyphen conversion',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'ok';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array( 'mcp' => array( 'public' => true ) ),
+			)
+		);
+
+			$ability = wp_get_ability( 'test/slash-ability' );
+			$this->assertNotNull( $ability );
+
+			$tool = $this->build_tool_from_ability( $ability );
+
+			$arr = $tool->toArray();
+			$this->assertSame( 'test-slash-ability', $arr['name'] );
+
+		wp_unregister_ability( 'test/slash-ability' );
+	}
+
+		// Adapter metadata correctness tests (semantic accuracy of adapter_meta).
+
+	public function test_metadata_omits_output_keys_when_output_schema_absent(): void {
+		// Scenario: input transformed (flat string), NO output schema.
+		// Expected: input_schema_* keys present, NO output_schema_* keys.
+		$this->register_ability_in_hook(
+			'test/input-only-transformed',
+			array(
+				'label'               => 'Input Only Transformed',
+				'description'         => 'Has flat input schema, no output schema',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'string' ), // Will be transformed.
+				// No output_schema.
+				'execute_callback'    => static function ( $input ) {
+					return $input;
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array( 'mcp' => array( 'public' => true ) ),
+			)
+		);
+
+		$ability = wp_get_ability( 'test/input-only-transformed' );
+		$this->assertNotNull( $ability, 'Ability test/input-only-transformed should be registered' );
+
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertInstanceOf( Tool::class, $built['tool'] );
+
+		// Verify input transformation metadata is present.
+		$adapter_meta = $built['adapter_meta'];
+		$this->assertSame( 'test/input-only-transformed', $adapter_meta['ability'] );
+		$this->assertTrue( $adapter_meta['input_schema_transformed'] );
+		$this->assertSame( 'input', $adapter_meta['input_schema_wrapper'] );
+
+		// Verify output transformation metadata is NOT present (no outputSchema).
+		$this->assertArrayNotHasKey( 'output_schema_transformed', $adapter_meta, 'output_schema_transformed should be omitted when no output schema exists' );
+		$this->assertArrayNotHasKey( 'output_schema_wrapper', $adapter_meta, 'output_schema_wrapper should be omitted when no output schema exists' );
+
+		wp_unregister_ability( 'test/input-only-transformed' );
+	}
+
+	public function test_metadata_omits_input_wrapper_when_not_transformed(): void {
+		// Scenario: input NOT transformed (object), output transformed (flat string).
+		// Expected: NO input_schema_* keys, output_schema_* keys present.
+		$this->register_ability_in_hook(
+			'test/output-only-transformed',
+			array(
+				'label'               => 'Output Only Transformed',
+				'description'         => 'Has object input schema, flat output schema',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ), // Will NOT be transformed.
+				'output_schema'       => array( 'type' => 'string' ), // Will be transformed.
+				'execute_callback'    => static function () {
+					return 'result';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array( 'mcp' => array( 'public' => true ) ),
+			)
+		);
+
+		$ability = wp_get_ability( 'test/output-only-transformed' );
+		$this->assertNotNull( $ability, 'Ability test/output-only-transformed should be registered' );
+
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertInstanceOf( Tool::class, $built['tool'] );
+
+		$adapter_meta = $built['adapter_meta'];
+		$this->assertSame( 'test/output-only-transformed', $adapter_meta['ability'] );
+
+		// Verify input transformation metadata is NOT present (not transformed).
+		$this->assertArrayNotHasKey( 'input_schema_transformed', $adapter_meta, 'input_schema_transformed should be omitted when input was not transformed' );
+		$this->assertArrayNotHasKey( 'input_schema_wrapper', $adapter_meta, 'input_schema_wrapper should be omitted when input was not transformed' );
+
+		// Verify output transformation metadata IS present.
+		$this->assertArrayHasKey( 'output_schema_transformed', $adapter_meta, 'output_schema_transformed should be present when output was transformed' );
+		$this->assertTrue( $adapter_meta['output_schema_transformed'] );
+		$this->assertArrayHasKey( 'output_schema_wrapper', $adapter_meta, 'output_schema_wrapper should be present when output was transformed' );
+		$this->assertSame( 'result', $adapter_meta['output_schema_wrapper'] );
+
+		wp_unregister_ability( 'test/output-only-transformed' );
+	}
+
+	public function test_metadata_only_has_ability_when_no_transformations(): void {
+		// Scenario: neither input nor output transformed (both are objects).
+		// Expected: only 'ability' key, no transformation keys.
+		$this->register_ability_in_hook(
+			'test/no-transformations',
+			array(
+				'label'               => 'No Transformations',
+				'description'         => 'Both schemas are already objects',
+				'category'            => 'test',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'name' => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => static function ( $input ) {
+					return array( 'message' => 'Hello ' . ( $input['name'] ?? 'world' ) );
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array( 'mcp' => array( 'public' => true ) ),
+			)
+		);
+
+		$ability = wp_get_ability( 'test/no-transformations' );
+		$this->assertNotNull( $ability, 'Ability test/no-transformations should be registered' );
+
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+		$this->assertInstanceOf( Tool::class, $built['tool'] );
+
+		$adapter_meta = $built['adapter_meta'];
+
+		// Verify only 'ability' key is present.
+		$this->assertArrayHasKey( 'ability', $adapter_meta );
+		$this->assertSame( 'test/no-transformations', $adapter_meta['ability'] );
+
+		// Verify no transformation keys.
+		$this->assertArrayNotHasKey( 'input_schema_transformed', $adapter_meta );
+		$this->assertArrayNotHasKey( 'input_schema_wrapper', $adapter_meta );
+		$this->assertArrayNotHasKey( 'output_schema_transformed', $adapter_meta );
+		$this->assertArrayNotHasKey( 'output_schema_wrapper', $adapter_meta );
+
+		wp_unregister_ability( 'test/no-transformations' );
+	}
+
+	// Icons and _meta Mapping Tests (MCP 2025-11-25).
+
+	public function test_icons_are_mapped_from_ability_meta(): void {
+		$ability = wp_get_ability( 'test/with-icons' );
+		$this->assertNotNull( $ability, 'Ability test/with-icons should be registered' );
+
+		$tool = $this->build_tool_from_ability( $ability );
+
+		$arr = $tool->toArray();
+
+		// Verify icons field exists and has correct structure.
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertIsArray( $arr['icons'] );
+		$this->assertCount( 2, $arr['icons'] );
+
+		// Verify first icon (all fields).
+		$this->assertSame( 'https://example.com/icon.png', $arr['icons'][0]['src'] );
+		$this->assertSame( 'image/png', $arr['icons'][0]['mimeType'] );
+		$this->assertIsArray( $arr['icons'][0]['sizes'] );
+		$this->assertSame( array( '32x32' ), $arr['icons'][0]['sizes'] );
+		$this->assertSame( 'light', $arr['icons'][0]['theme'] );
+
+		// Verify second icon (no sizes).
+		$this->assertSame( 'https://example.com/icon-dark.svg', $arr['icons'][1]['src'] );
+		$this->assertSame( 'image/svg+xml', $arr['icons'][1]['mimeType'] );
+		$this->assertSame( 'dark', $arr['icons'][1]['theme'] );
+	}
+
+	public function test_invalid_icons_are_filtered_out(): void {
+		$ability = wp_get_ability( 'test/with-mixed-icons' );
+		$this->assertNotNull( $ability, 'Ability test/with-mixed-icons should be registered' );
+
+		$tool = $this->build_tool_from_ability( $ability );
+
+		$arr = $tool->toArray();
+
+		// Verify icons field exists with only valid icons.
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertIsArray( $arr['icons'] );
+
+		// Should only have 2 valid icons (the one without src was filtered out).
+		$this->assertCount( 2, $arr['icons'] );
+
+		// Verify the valid icons are present.
+		$srcs = array_column( $arr['icons'], 'src' );
+		$this->assertContains( 'https://example.com/valid-icon.png', $srcs );
+		$this->assertContains( 'https://example.com/another-valid.svg', $srcs );
+	}
+
+		public function test_custom_meta_is_passed_through(): void {
+		$ability = wp_get_ability( 'test/with-custom-meta' );
+		$this->assertNotNull( $ability, 'Ability test/with-custom-meta should be registered' );
+
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+
+		$tool = $built['tool'];
+		$this->assertInstanceOf( Tool::class, $tool );
+
+		$meta = $tool->get_meta();
+		$this->assertIsArray( $meta );
+
+		// Verify custom vendor keys are present.
+		$this->assertArrayHasKey( 'custom_vendor', $meta );
+		$this->assertSame( true, $meta['custom_vendor']['feature_flag'] );
+		$this->assertSame( '1.0', $meta['custom_vendor']['version'] );
+
+		$this->assertArrayHasKey( 'another_vendor', $meta );
+		$this->assertSame( 'some-value', $meta['another_vendor'] );
+
+			$this->assertSame( 'test/with-custom-meta', $built['adapter_meta']['ability'] );
+		}
+
+		public function test_icons_and_meta_can_coexist(): void {
+		$ability = wp_get_ability( 'test/with-icons-and-meta' );
+		$this->assertNotNull( $ability, 'Ability test/with-icons-and-meta should be registered' );
+
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+
+		$tool = $built['tool'];
+		$this->assertInstanceOf( Tool::class, $tool );
+
+		$arr = $tool->toArray();
+
+		// Verify icons field exists.
+		$this->assertArrayHasKey( 'icons', $arr );
+		$this->assertCount( 1, $arr['icons'] );
+		$this->assertSame( 'https://example.com/combined-icon.png', $arr['icons'][0]['src'] );
+		$this->assertSame( array( '48x48' ), $arr['icons'][0]['sizes'] );
+
+			// Verify custom _meta exists (internal adapter metadata is not exposed here).
+			$meta = $tool->get_meta();
+			$this->assertArrayHasKey( 'vendor_info', $meta );
+			$this->assertSame( 'test-value', $meta['vendor_info']['custom_data'] );
+			$this->assertSame( 'test/with-icons-and-meta', $built['adapter_meta']['ability'] );
+		}
+
+	public function test_tool_without_icons_has_no_icons_field(): void {
+		// Use an existing ability that doesn't have icons defined.
+		$ability = wp_get_ability( 'test/always-allowed' );
+		$this->assertNotNull( $ability, 'Ability test/always-allowed should be registered' );
+
+		$tool = $this->build_tool_from_ability( $ability );
+
+		$arr = $tool->toArray();
+
+		// Verify icons field is not present.
+		$this->assertArrayNotHasKey( 'icons', $arr );
+	}
+
+	public function test_tool_without_custom_meta_has_no_meta_field(): void {
+		// Use an existing ability that doesn't have custom _meta defined.
+		$ability = wp_get_ability( 'test/always-allowed' );
+		$this->assertNotNull( $ability, 'Ability test/always-allowed should be registered' );
+
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+
+		$tool = $built['tool'];
+		$this->assertInstanceOf( Tool::class, $tool );
+
+		$data = $tool->toArray();
+		$this->assertArrayNotHasKey( '_meta', $data );
+		$this->assertSame( 'test/always-allowed', $built['adapter_meta']['ability'] );
+	}
+
+	public function test_user_meta_mcp_adapter_collision_is_preserved(): void {
+		$this->register_ability_in_hook(
+			'test/meta-collision',
+			array(
+				'label'               => 'Meta Collision Test',
+				'description'         => 'Tests _meta collision',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'success';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'_meta'  => array(
+							'mcp_adapter'       => array(
+								'spoofed' => 'should-be-overwritten',
+								'fake'    => 'data',
+							),
+							'legitimate_vendor' => 'preserved',
+						),
+					),
+				),
+			)
+		);
+
+		$ability = wp_get_ability( 'test/meta-collision' );
+		$this->assertNotNull( $ability );
+
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+
+		$tool = $built['tool'];
+		$this->assertInstanceOf( Tool::class, $tool );
+
+		$data = $tool->toArray();
+		$this->assertArrayHasKey( '_meta', $data );
+		$this->assertArrayHasKey( 'mcp_adapter', $data['_meta'] );
+		$this->assertSame(
+			array(
+				'spoofed' => 'should-be-overwritten',
+				'fake'    => 'data',
+			),
+			$data['_meta']['mcp_adapter']
+		);
+		$this->assertArrayHasKey( 'legitimate_vendor', $data['_meta'] );
+		$this->assertSame( 'preserved', $data['_meta']['legitimate_vendor'] );
+		$this->assertSame( 'test/meta-collision', $built['adapter_meta']['ability'] );
+
+		wp_unregister_ability( 'test/meta-collision' );
+	}
+
+	public function test_empty_user_meta_does_not_add_empty_keys(): void {
+		// If user provides empty _meta array, it should not affect the output.
+		$this->register_ability_in_hook(
+			'test/empty-meta',
+			array(
+				'label'               => 'Empty Meta Test',
+				'description'         => 'Tests empty _meta handling',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'success';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'_meta'  => array(), // Empty _meta array.
+					),
+				),
+			)
+		);
+
+			$ability = wp_get_ability( 'test/empty-meta' );
+			$this->assertNotNull( $ability );
+
+		$built = RegisterAbilityAsMcpTool::build( $ability );
+		$this->assertNotWPError( $built );
+
+		$tool = $built['tool'];
+		$this->assertInstanceOf( Tool::class, $tool );
+
+		$data = $tool->toArray();
+		$this->assertArrayNotHasKey( '_meta', $data );
+		$this->assertSame( 'test/empty-meta', $built['adapter_meta']['ability'] );
+
+		wp_unregister_ability( 'test/empty-meta' );
 	}
 }


### PR DESCRIPTION
## Summary

Updates the three core domain models (McpTool, McpResource, McpPrompt) and their validators to use php-mcp-schema DTOs instead of manual array structures.

## Changes

### Tools
- `McpTool` — Now wraps `WP\McpSchema\Server\Tools\Tool` DTO
- `McpToolValidator` — Updated validation logic
- `RegisterAbilityAsMcpTool` — Uses schema DTOs for conversion

### Resources
- `McpResource` — Now wraps `WP\McpSchema\Server\Resources\Resource` DTO
- `McpResourceValidator` — Updated validation logic
- `RegisterAbilityAsMcpResource` — Uses schema DTOs for conversion

### Prompts
- `McpPrompt` — Now wraps `WP\McpSchema\Server\Prompts\Prompt` DTO
- `McpPromptBuilder` — Updated to produce DTOs
- `McpPromptValidator` — Updated validation logic
- `RegisterAbilityAsMcpPrompt` — Uses schema DTOs for conversion

### Tests
- Updated all domain model tests
- Updated validator tests
- Updated ability conversion tests

## Why

- Type-safe domain models with IDE support
- Guaranteed MCP protocol compliance
- Cleaner serialization (DTOs handle JSON conversion)
- PHPStan Level 8 compliance

## Stacked PR

⚠️ **This is PR 4 of 6** in the MCP Schema integration series.

| # | Branch | Description |
|---|--------|-------------|
| 1 | `01-composer-deps` | Composer dependency |
| 2 | `02-infrastructure` | Error handling + observability |
| 3 | `03-domain-utils` | Domain contracts + utilities |
| **4** | **`04-domain-components`** | **← You are here** |
| 5 | `05-core` | Core + abilities + plugin |
| 6 | `06-handlers-transport` | Handlers + Transport + CLI |

**Merge order**: 1 → 2 → 3 → 4 → 5 → 6

## Testing

- [ ] Tool, Resource, Prompt model tests pass
- [ ] Validator tests pass
- [ ] Ability conversion tests pass