### PR TITLE
[5/6] Update core layer and built-in abilities for MCP schema

### DIFF
--- a/includes/Abilities/DiscoverAbilitiesAbility.php
+++ b/includes/Abilities/DiscoverAbilitiesAbility.php
@@ -116,7 +116,6 @@ final class DiscoverAbilitiesAbility {
 	 * @param array $input Input parameters (unused for this ability).
 	 *
 	 * @return bool|\WP_Error True if the user has permission to discover abilities.
-	 * @phpstan-return bool|\WP_Error
 	 */
 	public static function check_permission( $input = array() ) {
 		// Validate user authentication and capabilities

--- a/includes/Abilities/DiscoverAbilitiesAbility.php
+++ b/includes/Abilities/DiscoverAbilitiesAbility.php
@@ -118,16 +118,6 @@ final class DiscoverAbilitiesAbility {
 	 * @return bool|\WP_Error True if the user has permission to discover abilities.
 	 */
 	public static function check_permission( $input = array() ) {
-		// Validate user authentication and capabilities
-		return self::validate_user_access();
-	}
-
-	/**
-	 * Validate user authentication and basic capabilities for discover abilities.
-	 *
-	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
-	 */
-	private static function validate_user_access() {
 		// Verify caller identity - ensure user is authenticated
 		if ( ! is_user_logged_in() ) {
 			return new \WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );

--- a/includes/Abilities/DiscoverAbilitiesAbility.php
+++ b/includes/Abilities/DiscoverAbilitiesAbility.php
@@ -67,62 +67,16 @@ final class DiscoverAbilitiesAbility {
 	}
 
 	/**
-	 * Check permissions for discovering abilities.
-	 *
-	 * Validates user capabilities and caller identity.
-	 *
-	 * @param array $input Input parameters (unused for this ability).
-	 *
-	 * @return bool|\WP_Error True if the user has permission to discover abilities.
-	 * @phpstan-return bool|\WP_Error
-	 */
-	public static function check_permission( $input = array() ) {
-		// Validate user authentication and capabilities
-		return self::validate_user_access();
-	}
-
-	/**
-	 * Validate user authentication and basic capabilities for discover abilities.
-	 *
-	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
-	 */
-	private static function validate_user_access() {
-		// Verify caller identity - ensure user is authenticated
-		if ( ! is_user_logged_in() ) {
-			return new \WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
-		}
-
-		// Check basic capability requirement - allow customization via filter
-		$required_capability = apply_filters( 'mcp_adapter_discover_abilities_capability', 'read' );
-		// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is determined dynamically via filter
-		if ( ! current_user_can( $required_capability ) ) {
-			return new \WP_Error(
-				'insufficient_capability',
-				sprintf( 'User lacks required capability: %s', $required_capability )
-			);
-		}
-
-		return true;
-	}
-
-	/**
 	 * Execute the discover abilities functionality.
 	 *
-	 * Enforces security checks and mcp.public filtering.
+	 * Note: Permission checks are handled by the WP_Ability::execute() framework method
+	 * before this callback is invoked (see WP_Ability::execute() line 605).
 	 *
 	 * @param array $input Input parameters (unused for this ability).
 	 *
 	 * @return array Array containing public MCP abilities.
 	 */
 	public static function execute( $input = array() ): array {
-		// Enforce security checks before execution
-		$permission_check = self::check_permission( $input );
-		if ( is_wp_error( $permission_check ) ) {
-			return array(
-				'error' => $permission_check->get_error_message(),
-			);
-		}
-
 		// Get all abilities and filter for publicly exposed ones
 		$abilities = wp_get_abilities();
 
@@ -150,5 +104,53 @@ final class DiscoverAbilitiesAbility {
 		return array(
 			'abilities' => $ability_list,
 		);
+	}
+
+	/**
+	 * Check permissions for discovering abilities.
+	 *
+	 * Validates user capabilities and caller identity.
+	 *
+	 * @param array $input Input parameters (unused for this ability).
+	 *
+	 * @return bool|\WP_Error True if the user has permission to discover abilities.
+	 * @phpstan-return bool|\WP_Error
+	 */
+	public static function check_permission( $input = array() ) {
+		// Validate user authentication and capabilities
+		return self::validate_user_access();
+	}
+
+	/**
+	 * Validate user authentication and basic capabilities for discover abilities.
+	 *
+	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
+	 */
+	private static function validate_user_access() {
+		// Verify caller identity - ensure user is authenticated
+		if ( ! is_user_logged_in() ) {
+			return new \WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
+		}
+
+		/**
+		 * Filters the capability required to discover available abilities.
+		 *
+		 * This capability is checked before listing all registered WordPress abilities
+		 * through the mcp-adapter-discover-abilities tool.
+		 *
+		 * @since 0.3.0
+		 *
+		 * @param string $capability The required capability. Default 'read'.
+		 */
+		$required_capability = apply_filters( 'mcp_adapter_discover_abilities_capability', 'read' );
+		// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is determined dynamically via filter
+		if ( ! current_user_can( $required_capability ) ) {
+			return new \WP_Error(
+				'insufficient_capability',
+				sprintf( 'User lacks required capability: %s', $required_capability )
+			);
+		}
+
+		return true;
 	}
 }

--- a/includes/Abilities/DiscoverAbilitiesAbility.php
+++ b/includes/Abilities/DiscoverAbilitiesAbility.php
@@ -70,7 +70,9 @@ final class DiscoverAbilitiesAbility {
 	 * Execute the discover abilities functionality.
 	 *
 	 * Note: Permission checks are handled by the WP_Ability::execute() framework method
-	 * before this callback is invoked (see WP_Ability::execute() line 605).
+	 * before this callback is invoked.
+	 *
+	 * @see \WP_Ability::execute()
 	 *
 	 * @param array $input Input parameters (unused for this ability).
 	 *

--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -158,7 +158,6 @@ final class ExecuteAbilityAbility {
 	 * @param array $input Input parameters containing ability_name and parameters.
 	 *
 	 * @return bool|\WP_Error True if the user has permission to execute the specified ability.
-	 * @phpstan-return bool|\WP_Error
 	 */
 	public static function check_permission( $input = array() ) {
 		$ability_name = $input['ability_name'] ?? '';

--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -92,8 +92,10 @@ final class ExecuteAbilityAbility {
 	 * Execute the ability execution functionality.
 	 *
 	 * Note: Permission checks are handled by the WP_Ability::execute() framework method
-	 * before this callback is invoked (see WP_Ability::execute() line 605). This ensures
-	 * all ability executions are properly authorized by the framework.
+	 * before this callback is invoked. This ensures all ability executions are properly
+	 * authorized by the framework.
+	 *
+	 * @see \WP_Ability::execute()
 	 *
 	 * @param array $input Input parameters containing ability_name and parameters.
 	 *

--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Abilities;
 
+use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
+
 /**
  * Execute Ability - Executes a WordPress ability with provided parameters.
  *
@@ -37,8 +39,8 @@ final class ExecuteAbilityAbility {
 				'description'         => 'Execute a WordPress ability with the provided parameters. This is the primary execution layer that can run any registered ability.',
 				'category'            => 'mcp-adapter',
 				'input_schema'        => array(
-					'type'                 => 'object',
-					'properties'           => array(
+					'type'       => 'object',
+					'properties' => array(
 						'ability_name' => array(
 							'type'        => 'string',
 							'description' => 'The full name of the ability to execute',
@@ -48,15 +50,22 @@ final class ExecuteAbilityAbility {
 							'description' => 'Parameters to pass to the ability',
 						),
 					),
-					'required'             => array( 'ability_name', 'parameters' ),
-					'additionalProperties' => false,
+					'required'   => array( 'ability_name', 'parameters' ),
 				),
 				'output_schema'       => array(
 					'type'       => 'object',
 					'properties' => array(
 						'success' => array( 'type' => 'boolean' ),
 						'data'    => array(
-							'type'        => array( 'object', 'array', 'string', 'number', 'integer', 'boolean', 'null' ),
+							'type'        => array(
+								'object',
+								'array',
+								'string',
+								'number',
+								'integer',
+								'boolean',
+								'null',
+							),
 							'description' => 'The result data from the ability execution',
 						),
 						'error'   => array(
@@ -77,6 +86,66 @@ final class ExecuteAbilityAbility {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Execute the ability execution functionality.
+	 *
+	 * Note: Permission checks are handled by the WP_Ability::execute() framework method
+	 * before this callback is invoked (see WP_Ability::execute() line 605). This ensures
+	 * all ability executions are properly authorized by the framework.
+	 *
+	 * @param array $input Input parameters containing ability_name and parameters.
+	 *
+	 * @return array Array containing execution results.
+	 */
+	public static function execute( $input = array() ): array {
+		$ability_name = $input['ability_name'] ?? '';
+		// Note: Use null coalescing instead of empty() to preserve empty arrays/objects ({} → [])
+		$parameters = $input['parameters'] ?? null;
+
+		if ( empty( $ability_name ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Ability name is required',
+			);
+		}
+
+		$ability = wp_get_ability( $ability_name );
+
+		if ( ! $ability ) {
+			return array(
+				'success' => false,
+				'error'   => "Ability '{$ability_name}' not found",
+			);
+		}
+
+		// Normalize parameters for ability's schema requirements
+		// Empty {} from MCP is treated as null for abilities without input schema
+		$parameters = AbilityArgumentNormalizer::normalize( $ability, $parameters );
+
+		try {
+			// Execute the ability
+			$result = $ability->execute( $parameters );
+
+			// Check if the result is a WP_Error
+			if ( is_wp_error( $result ) ) {
+				return array(
+					'success' => false,
+					'error'   => $result->get_error_message(),
+				);
+			}
+
+			return array(
+				'success' => true,
+				'data'    => $result,
+			);
+		} catch ( \Throwable $e ) {
+			return array(
+				'success' => false,
+				'error'   => $e->getMessage(),
+			);
+		}
 	}
 
 	/**
@@ -114,8 +183,10 @@ final class ExecuteAbilityAbility {
 			return new \WP_Error( 'ability_not_found', "Ability '{$ability_name}' not found" );
 		}
 
-		// Check if the user has permission to execute the target ability
-		$parameters        = empty( $input['parameters'] ) ? null : $input['parameters'];
+		// Normalize parameters for ability's schema requirements
+		// Empty {} from MCP is treated as null for abilities without input schema
+		$parameters        = $input['parameters'] ?? null;
+		$parameters        = AbilityArgumentNormalizer::normalize( $ability, $parameters );
 		$permission_result = $ability->check_permissions( $parameters );
 
 		// Return WP_Error as-is, or convert other values to boolean
@@ -132,12 +203,24 @@ final class ExecuteAbilityAbility {
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
 	private static function validate_user_access() {
-		// Verify caller identity - ensure user is authenticated
+		// Verify caller identity - ensure the user is authenticated
 		if ( ! is_user_logged_in() ) {
 			return new \WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
 		}
 
-		// Check basic capability requirement - allow customization via filter
+		/**
+		 * Filters the capability required to execute abilities.
+		 *
+		 * This is intentionally set to 'read' as the minimum baseline capability.
+		 * Each ability defines its own permission_callback that enforces the actual
+		 * capability requirements for that specific operation. This filter serves
+		 * only as a gate to prevent completely unauthenticated or capability-less
+		 * users from reaching the ability execution layer.
+		 *
+		 * @since 0.3.0
+		 *
+		 * @param string $capability The required capability. Default 'read'.
+		 */
 		$required_capability = apply_filters( 'mcp_adapter_execute_ability_capability', 'read' );
 		// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is determined dynamically via filter
 		if ( ! current_user_can( $required_capability ) ) {
@@ -148,76 +231,5 @@ final class ExecuteAbilityAbility {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Execute the ability execution functionality.
-	 *
-	 * Enforces security checks before executing any ability.
-	 *
-	 * @param array $input Input parameters containing ability_name and parameters.
-	 *
-	 * @return array Array containing execution results.
-	 */
-	public static function execute( $input = array() ): array {
-		$ability_name = $input['ability_name'] ?? '';
-		$parameters   = empty( $input['parameters'] ) ? null : $input['parameters'];
-
-		if ( empty( $ability_name ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Ability name is required',
-			);
-		}
-
-		// Enforce security checks before execution
-		// Note: WordPress will have already called check_permission, but we double-check
-		// as an additional security layer for direct method calls
-		$permission_check = self::check_permission( $input );
-		if ( is_wp_error( $permission_check ) ) {
-			return array(
-				'success' => false,
-				'error'   => $permission_check->get_error_message(),
-			);
-		}
-
-		if ( ! $permission_check ) {
-			return array(
-				'success' => false,
-				'error'   => 'Permission denied for ability execution',
-			);
-		}
-
-		$ability = wp_get_ability( $ability_name );
-
-		if ( ! $ability ) {
-			return array(
-				'success' => false,
-				'error'   => "Ability '{$ability_name}' not found",
-			);
-		}
-
-		try {
-			// Execute the ability
-			$result = $ability->execute( $parameters );
-
-			// Check if the result is a WP_Error
-			if ( is_wp_error( $result ) ) {
-				return array(
-					'success' => false,
-					'error'   => $result->get_error_message(),
-				);
-			}
-
-			return array(
-				'success' => true,
-				'data'    => $result,
-			);
-		} catch ( \Throwable $e ) {
-			return array(
-				'success' => false,
-				'error'   => $e->getMessage(),
-			);
-		}
 	}
 }

--- a/includes/Abilities/GetAbilityInfoAbility.php
+++ b/includes/Abilities/GetAbilityInfoAbility.php
@@ -136,7 +136,6 @@ final class GetAbilityInfoAbility {
 	 * @param array $input Input parameters containing ability_name.
 	 *
 	 * @return bool|\WP_Error True if the user has permission to get ability info.
-	 * @phpstan-return bool|\WP_Error
 	 */
 	public static function check_permission( $input = array() ) {
 		$ability_name = $input['ability_name'] ?? '';

--- a/includes/Abilities/GetAbilityInfoAbility.php
+++ b/includes/Abilities/GetAbilityInfoAbility.php
@@ -36,15 +36,14 @@ final class GetAbilityInfoAbility {
 				'description'         => 'Get detailed information about a specific WordPress ability including its input/output schema, description, and usage examples.',
 				'category'            => 'mcp-adapter',
 				'input_schema'        => array(
-					'type'                 => 'object',
-					'properties'           => array(
+					'type'       => 'object',
+					'properties' => array(
 						'ability_name' => array(
 							'type'        => 'string',
 							'description' => 'The full name of the ability to get information about',
 						),
 					),
-					'required'             => array( 'ability_name' ),
-					'additionalProperties' => false,
+					'required'   => array( 'ability_name' ),
 				),
 				'output_schema'       => array(
 					'type'       => 'object',
@@ -78,6 +77,55 @@ final class GetAbilityInfoAbility {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Execute the get ability info functionality.
+	 *
+	 * Note: Permission checks are handled by the WP_Ability::execute() framework method
+	 * before this callback is invoked (see WP_Ability::execute() line 605).
+	 *
+	 * @param array $input Input parameters containing ability_name.
+	 *
+	 * @return array Array containing detailed ability information.
+	 */
+	public static function execute( $input = array() ): array {
+		$ability_name = $input['ability_name'] ?? '';
+
+		if ( empty( $ability_name ) ) {
+			return array(
+				'error' => 'Ability name is required',
+			);
+		}
+
+		$ability = wp_get_ability( $ability_name );
+
+		if ( ! $ability ) {
+			return array(
+				'error' => "Ability '{$ability_name}' not found",
+			);
+		}
+
+		$ability_info = array(
+			'name'         => $ability->get_name(),
+			'label'        => $ability->get_label(),
+			'description'  => $ability->get_description(),
+			'input_schema' => $ability->get_input_schema(),
+		);
+
+		// Add output schema if available
+		$output_schema = $ability->get_output_schema();
+		if ( ! empty( $output_schema ) ) {
+			$ability_info['output_schema'] = $output_schema;
+		}
+
+		// Add meta information if available
+		$meta = $ability->get_meta();
+		if ( ! empty( $meta ) ) {
+			$ability_info['meta'] = $meta;
+		}
+
+		return $ability_info;
 	}
 
 	/**
@@ -118,7 +166,16 @@ final class GetAbilityInfoAbility {
 			return new \WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
 		}
 
-		// Check basic capability requirement - allow customization via filter
+		/**
+		 * Filters the capability required to get ability information.
+		 *
+		 * This capability is checked before returning detailed information about
+		 * a specific WordPress ability through the mcp-adapter-get-ability-info tool.
+		 *
+		 * @since 0.3.0
+		 *
+		 * @param string $capability The required capability. Default 'read'.
+		 */
 		$required_capability = apply_filters( 'mcp_adapter_get_ability_info_capability', 'read' );
 		// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is determined dynamically via filter
 		if ( ! current_user_can( $required_capability ) ) {
@@ -129,61 +186,5 @@ final class GetAbilityInfoAbility {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Execute the get ability info functionality.
-	 *
-	 * Enforces security checks before returning ability information.
-	 *
-	 * @param array $input Input parameters containing ability_name.
-	 *
-	 * @return array Array containing detailed ability information.
-	 */
-	public static function execute( $input = array() ): array {
-		$ability_name = $input['ability_name'] ?? '';
-
-		if ( empty( $ability_name ) ) {
-			return array(
-				'error' => 'Ability name is required',
-			);
-		}
-
-		// Enforce security checks before execution
-		$permission_check = self::check_permission( $input );
-		if ( is_wp_error( $permission_check ) ) {
-			return array(
-				'error' => $permission_check->get_error_message(),
-			);
-		}
-
-		$ability = wp_get_ability( $ability_name );
-
-		if ( ! $ability ) {
-			return array(
-				'error' => "Ability '{$ability_name}' not found",
-			);
-		}
-
-		$ability_info = array(
-			'name'         => $ability->get_name(),
-			'label'        => $ability->get_label(),
-			'description'  => $ability->get_description(),
-			'input_schema' => $ability->get_input_schema(),
-		);
-
-		// Add output schema if available
-		$output_schema = $ability->get_output_schema();
-		if ( ! empty( $output_schema ) ) {
-			$ability_info['output_schema'] = $output_schema;
-		}
-
-		// Add meta information if available
-		$meta = $ability->get_meta();
-		if ( ! empty( $meta ) ) {
-			$ability_info['meta'] = $meta;
-		}
-
-		return $ability_info;
 	}
 }

--- a/includes/Abilities/McpAbilityHelperTrait.php
+++ b/includes/Abilities/McpAbilityHelperTrait.php
@@ -58,6 +58,7 @@ trait McpAbilityHelperTrait {
 	 */
 	protected static function is_ability_mcp_public( \WP_Ability $ability ): bool {
 		$meta = $ability->get_meta();
+
 		return (bool) ( $meta['mcp']['public'] ?? false );
 	}
 

--- a/includes/Autoloader.php
+++ b/includes/Autoloader.php
@@ -9,7 +9,7 @@
  * @package WP\MCP
  */
 
-declare( strict_types = 1 );
+declare( strict_types=1 );
 
 namespace WP\MCP;
 
@@ -51,6 +51,7 @@ final class Autoloader {
 	private static function require_autoloader( string $autoloader_file ): bool {
 		if ( ! is_readable( $autoloader_file ) ) {
 			self::missing_autoloader_notice();
+
 			return false;
 		}
 

--- a/includes/Cli/McpCommand.php
+++ b/includes/Cli/McpCommand.php
@@ -108,6 +108,29 @@ class McpCommand extends \WP_CLI_Command { // phpcs:ignore
 	}
 
 	/**
+	 * Get a user by ID, login, or email.
+	 *
+	 * @param string $user User identifier (ID, login, or email).
+	 *
+	 * @return \WP_User|false User object or false if not found.
+	 */
+	private function get_user( string $user ) {
+		// Try as ID first
+		if ( is_numeric( $user ) ) {
+			return get_user_by( 'id', (int) $user );
+		}
+
+		// Try as login
+		$user_obj = get_user_by( 'login', $user );
+		if ( $user_obj ) {
+			return $user_obj;
+		}
+
+		// Try as email
+		return get_user_by( 'email', $user );
+	}
+
+	/**
 	 * List all registered MCP servers.
 	 *
 	 * ## OPTIONS
@@ -141,6 +164,7 @@ class McpCommand extends \WP_CLI_Command { // phpcs:ignore
 
 		if ( empty( $servers ) ) {
 			\WP_CLI::line( 'No MCP servers registered.' );
+
 			return;
 		}
 
@@ -159,27 +183,5 @@ class McpCommand extends \WP_CLI_Command { // phpcs:ignore
 
 		$format = $assoc_args['format'] ?? 'table';
 		format_items( $format, $items, array( 'ID', 'Name', 'Version', 'Tools', 'Resources', 'Prompts' ) );
-	}
-
-	/**
-	 * Get a user by ID, login, or email.
-	 *
-	 * @param string $user User identifier (ID, login, or email).
-	 * @return \WP_User|false User object or false if not found.
-	 */
-	private function get_user( string $user ) {
-		// Try as ID first
-		if ( is_numeric( $user ) ) {
-			return get_user_by( 'id', (int) $user );
-		}
-
-		// Try as login
-		$user_obj = get_user_by( 'login', $user );
-		if ( $user_obj ) {
-			return $user_obj;
-		}
-
-		// Try as email
-		return get_user_by( 'email', $user );
 	}
 }

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -32,20 +32,18 @@ final class McpAdapter {
 	 * @var \WP\MCP\Core\McpAdapter
 	 */
 	private static self $instance;
-
+	/**
+	 * Track if the adapter has been initialized to prevent duplicate initialization
+	 *
+	 * @var bool
+	 */
+	private static bool $initialized = false;
 	/**
 	 * Registered servers
 	 *
 	 * @var \WP\MCP\Core\McpServer[]
 	 */
 	private array $servers = array();
-
-	/**
-	 * Track if adapter has been initialized to prevent duplicate initialization
-	 *
-	 * @var bool
-	 */
-	private static bool $initialized = false;
 
 	/**
 	 * Get the registry instance
@@ -68,7 +66,7 @@ final class McpAdapter {
 		return self::$instance;
 	}
 
-		/**
+	/**
 	 * Initialize the registry
 	 *
 	 * @internal For use by instance initialization only.
@@ -80,9 +78,72 @@ final class McpAdapter {
 
 		$this->maybe_create_default_server();
 
+		/**
+		 * Fires after the MCP Adapter has been initialized.
+		 *
+		 * Use this action to register custom MCP servers. The adapter instance
+		 * provides methods to create and configure additional servers beyond
+		 * the default server.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param \WP\MCP\Core\McpAdapter $adapter The MCP Adapter singleton instance.
+		 */
 		do_action( 'mcp_adapter_init', $this );
 		$this->register_wp_cli_commands();
 		self::$initialized = true;
+	}
+
+	/**
+	 * Conditionally create the default server based on filter.
+	 *
+	 * @internal For use by adapter initialization only.
+	 */
+	private function maybe_create_default_server(): void {
+		/**
+		 * Filters whether the default MCP server should be created.
+		 *
+		 * Return false to prevent the default server from being created.
+		 * This is useful when you want to define custom servers only.
+		 *
+		 * @since 0.3.0
+		 *
+		 * @param bool $create_default Whether to create the default server. Default true.
+		 */
+		if ( ! apply_filters( 'mcp_adapter_create_default_server', true ) ) {
+			return;
+		}
+
+		// Register category before abilities
+		add_action( 'wp_abilities_api_categories_init', array( $this, 'register_default_category' ) );
+		add_action( 'wp_abilities_api_init', array( $this, 'register_default_abilities' ) );
+
+		add_action( 'mcp_adapter_init', array( DefaultServerFactory::class, 'create' ) );
+	}
+
+	/**
+	 * Register WP-CLI commands if WP-CLI is available
+	 *
+	 * @internal For use by adapter initialization only.
+	 */
+	private function register_wp_cli_commands(): void {
+		// Only register if WP-CLI is available
+		if ( ! defined( 'WP_CLI' ) || ! constant( 'WP_CLI' ) ) {
+			return;
+		}
+
+		if ( ! class_exists( '\WP_CLI' ) ) {
+			return;
+		}
+
+		\WP_CLI::add_command(
+			'mcp-adapter',
+			McpCommand::class,
+			array(
+				'shortdesc' => 'Manage MCP servers via WP-CLI.',
+				'longdesc'  => 'Commands for managing and serving MCP servers, including STDIO transport.',
+			)
+		);
 	}
 
 	/**
@@ -95,8 +156,8 @@ final class McpAdapter {
 	 * @param string $server_description Server description.
 	 * @param string $server_version Server version.
 	 * @param array $mcp_transports Array of classes that extend the BaseTransport.
-	 * @param class-string<\WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface> $error_handler The error handler class name. If null, NullMcpErrorHandler will be used.
-	 * @param class-string<\WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface> $observability_handler The observability handler class name. If null, NullMcpObservabilityHandler will be used.
+	 * @param class-string<\WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface>|null $error_handler The error handler class name. If null, NullMcpErrorHandler will be used.
+	 * @param class-string<\WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface>|null $observability_handler The observability handler class name. If null, NullMcpObservabilityHandler will be used.
 	 * @param array $tools Ability names to register as tools.
 	 * @param array $resources Resources to register.
 	 * @param array $prompts Prompts to register.
@@ -167,6 +228,7 @@ final class McpAdapter {
 				esc_html__( 'MCP Servers must be created during the "mcp_adapter_init" action. Hook into "mcp_adapter_init" to register your server.', 'mcp-adapter' ),
 				'0.1.0'
 			);
+
 			return new \WP_Error(
 				'invalid_timing',
 				esc_html__( 'MCP Server creation must be done during mcp_adapter_init action.', 'mcp-adapter' )
@@ -183,6 +245,7 @@ final class McpAdapter {
 				),
 				'0.1.0'
 			);
+
 			return new \WP_Error(
 				'duplicate_server_id',
 				// translators: %s: server ID.
@@ -191,21 +254,33 @@ final class McpAdapter {
 		}
 
 		// Create server with tools, resources, and prompts - let server handle all registration logic.
-		$server = new McpServer(
-			$server_id,
-			$server_route_namespace,
-			$server_route,
-			$server_name,
-			$server_description,
-			$server_version,
-			$mcp_transports,
-			$error_handler,
-			$observability_handler,
-			$tools,
-			$resources,
-			$prompts,
-			$transport_permission_callback
-		);
+		try {
+			$server = new McpServer(
+				$server_id,
+				$server_route_namespace,
+				$server_route,
+				$server_name,
+				$server_description,
+				$server_version,
+				$mcp_transports,
+				$error_handler,
+				$observability_handler,
+				$tools,
+				$resources,
+				$prompts,
+				$transport_permission_callback
+			);
+		} catch ( \Throwable $e ) {
+			return new \WP_Error(
+				'server_creation_failed',
+				sprintf(
+					/* translators: 1: server ID, 2: error message */
+					esc_html__( 'Failed to create server "%1$s": %2$s', 'mcp-adapter' ),
+					esc_html( $server_id ),
+					esc_html( $e->getMessage() )
+				)
+			);
+		}
 
 		// Track server creation.
 		$server->get_observability_handler()->record_event(
@@ -247,24 +322,6 @@ final class McpAdapter {
 	}
 
 	/**
-	 * Conditionally create the default server based on filter.
-	 *
-	 * @internal For use by adapter initialization only.
-	 */
-	private function maybe_create_default_server(): void {
-		// Allow disabling default server creation
-		if ( ! apply_filters( 'mcp_adapter_create_default_server', true ) ) {
-			return;
-		}
-
-		// Register category before abilities
-		add_action( 'wp_abilities_api_categories_init', array( $this, 'register_default_category' ) );
-		add_action( 'wp_abilities_api_init', array( $this, 'register_default_abilities' ) );
-
-		add_action( 'mcp_adapter_init', array( DefaultServerFactory::class, 'create' ) );
-	}
-
-	/**
 	 * Register the default MCP category.
 	 *
 	 * @return void
@@ -289,30 +346,5 @@ final class McpAdapter {
 		DiscoverAbilitiesAbility::register();
 		GetAbilityInfoAbility::register();
 		ExecuteAbilityAbility::register();
-	}
-
-	/**
-	 * Register WP-CLI commands if WP-CLI is available
-	 *
-	 * @internal For use by adapter initialization only.
-	 */
-	private function register_wp_cli_commands(): void {
-		// Only register if WP-CLI is available
-		if ( ! defined( 'WP_CLI' ) || ! constant( 'WP_CLI' ) ) {
-			return;
-		}
-
-		if ( ! class_exists( 'WP_CLI' ) ) {
-			return;
-		}
-
-		\WP_CLI::add_command(
-			'mcp-adapter',
-			McpCommand::class,
-			array(
-				'shortdesc' => 'Manage MCP servers via WP-CLI.',
-				'longdesc'  => 'Commands for managing and serving MCP servers, including STDIO transport.',
-			)
-		);
 	}
 }

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -155,12 +155,12 @@ final class McpAdapter {
 	 * @param string $server_name Server name.
 	 * @param string $server_description Server description.
 	 * @param string $server_version Server version.
-	 * @param array $mcp_transports Array of classes that extend the BaseTransport.
+	 * @param array<class-string<\WP\MCP\Transport\Contracts\McpTransportInterface>> $mcp_transports Array of MCP transport class names to initialize.
 	 * @param class-string<\WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface>|null $error_handler The error handler class name. If null, NullMcpErrorHandler will be used.
 	 * @param class-string<\WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface>|null $observability_handler The observability handler class name. If null, NullMcpObservabilityHandler will be used.
-	 * @param array $tools Ability names to register as tools.
-	 * @param array $resources Resources to register.
-	 * @param array $prompts Prompts to register.
+	 * @param array<string> $tools Ability names to register as tools.
+	 * @param array<string> $resources Resources to register.
+	 * @param array<string> $prompts Prompts to register.
 	 * @param callable|null $transport_permission_callback Optional custom permission callback for transport-level authentication. If null, defaults to is_user_logged_in().
 	 *
 	 * @return \WP\MCP\Core\McpAdapter|\WP_Error McpAdapter instance on success, WP_Error on failure.

--- a/includes/Core/McpComponentRegistry.php
+++ b/includes/Core/McpComponentRegistry.php
@@ -17,9 +17,9 @@ use WP\MCP\Domain\Tools\McpTool;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface;
 use WP\MCP\Infrastructure\Observability\FailureReason;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
-use WP\McpSchema\Server\Resources\DTO\Resource;
-use WP\McpSchema\Server\Tools\DTO\Tool;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
+use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
+use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 /**
  * Registry for managing MCP server components (tools, resources, prompts).
@@ -138,7 +138,7 @@ class McpComponentRegistry {
 			$this->add_mcp_tool( $tool_item );
 
 			/** @var \WP\McpSchema\Server\Tools\DTO\Tool $tool_dto */
-			$tool_dto = $tool_item->get_component();
+			$tool_dto = $tool_item->get_protocol_dto();
 			$this->track_registration( 'tool', $tool_dto->getName(), 'success' );
 
 			return;
@@ -172,7 +172,7 @@ class McpComponentRegistry {
 	 */
 	private function add_mcp_tool( McpTool $mcp_tool ): void {
 		/** @var \WP\McpSchema\Server\Tools\DTO\Tool $tool_dto */
-		$tool_dto  = $mcp_tool->get_component();
+		$tool_dto  = $mcp_tool->get_protocol_dto();
 		$tool_name = $tool_dto->getName();
 
 		if ( isset( $this->mcp_tools[ $tool_name ] ) ) {
@@ -277,7 +277,7 @@ class McpComponentRegistry {
 			$this->add_mcp_resource( $resource_item );
 
 			/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto */
-			$resource_dto = $resource_item->get_component();
+			$resource_dto = $resource_item->get_protocol_dto();
 			$this->track_registration( 'resource', $resource_dto->getUri(), 'success' );
 
 			return;
@@ -312,7 +312,7 @@ class McpComponentRegistry {
 	 */
 	private function add_mcp_resource( McpResource $mcp_resource ): bool {
 		/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto */
-		$resource_dto = $mcp_resource->get_component();
+		$resource_dto = $mcp_resource->get_protocol_dto();
 		$uri          = $resource_dto->getUri();
 
 		if ( isset( $this->mcp_resources[ $uri ] ) ) {
@@ -370,7 +370,7 @@ class McpComponentRegistry {
 			$this->track_registration( 'resource', $ability_name, 'success' );
 		} else {
 			/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto */
-			$resource_dto = $mcp_resource->get_component();
+			$resource_dto = $mcp_resource->get_protocol_dto();
 			$this->track_registration(
 				'resource',
 				$ability_name,
@@ -416,7 +416,7 @@ class McpComponentRegistry {
 			$this->add_mcp_prompt( $prompt_item );
 
 			/** @var \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt_dto */
-			$prompt_dto = $prompt_item->get_component();
+			$prompt_dto = $prompt_item->get_protocol_dto();
 			$this->track_registration( 'prompt', $prompt_dto->getName(), 'success' );
 
 			return;
@@ -466,7 +466,7 @@ class McpComponentRegistry {
 	 */
 	private function add_mcp_prompt( McpPrompt $mcp_prompt ): void {
 		/** @var \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt */
-		$prompt      = $mcp_prompt->get_component();
+		$prompt      = $mcp_prompt->get_protocol_dto();
 		$prompt_name = $prompt->getName();
 
 		if ( isset( $this->mcp_prompts[ $prompt_name ] ) ) {
@@ -575,7 +575,7 @@ class McpComponentRegistry {
 	 */
 	public function get_tools(): array {
 		return array_map(
-			static fn( McpTool $mcp_tool ): Tool => $mcp_tool->get_component(),
+			static fn( McpTool $mcp_tool ): ToolDto => $mcp_tool->get_protocol_dto(),
 			$this->mcp_tools
 		);
 	}
@@ -587,7 +587,7 @@ class McpComponentRegistry {
 	 */
 	public function get_resources(): array {
 		return array_map(
-			static fn( McpResource $mcp_resource ): Resource => $mcp_resource->get_component(),
+			static fn( McpResource $mcp_resource ): ResourceDto => $mcp_resource->get_protocol_dto(),
 			$this->mcp_resources
 		);
 	}
@@ -599,7 +599,7 @@ class McpComponentRegistry {
 	 */
 	public function get_prompts(): array {
 		return array_map(
-			static fn( McpPrompt $mcp_prompt ): Prompt => $mcp_prompt->get_component(),
+			static fn( McpPrompt $mcp_prompt ): PromptDto => $mcp_prompt->get_protocol_dto(),
 			$this->mcp_prompts
 		);
 	}

--- a/includes/Core/McpComponentRegistry.php
+++ b/includes/Core/McpComponentRegistry.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * MCP Component Registry for managing tools, resources, and prompts.
  *
@@ -11,38 +12,40 @@ namespace WP\MCP\Core;
 
 use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
 use WP\MCP\Domain\Prompts\McpPrompt;
-use WP\MCP\Domain\Prompts\RegisterAbilityAsMcpPrompt;
 use WP\MCP\Domain\Resources\McpResource;
-use WP\MCP\Domain\Resources\RegisterAbilityAsMcpResource;
 use WP\MCP\Domain\Tools\McpTool;
-use WP\MCP\Domain\Tools\RegisterAbilityAsMcpTool;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface;
+use WP\MCP\Infrastructure\Observability\FailureReason;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Resources\DTO\Resource;
+use WP\McpSchema\Server\Tools\DTO\Tool;
 
 /**
  * Registry for managing MCP server components (tools, resources, prompts).
  */
 class McpComponentRegistry {
-	/**
-	 * Tools registered to the server.
-	 *
-	 * @var array
-	 */
-	private array $tools = array();
 
 	/**
-	 * Resources registered to the server.
+	 * MCP tools keyed by tool name.
 	 *
-	 * @var array
+	 * @var array<string, \WP\MCP\Domain\Tools\McpTool>
 	 */
-	private array $resources = array();
+	private array $mcp_tools = array();
 
 	/**
-	 * Prompts registered to the server.
+	 * MCP resources keyed by resource URI.
 	 *
-	 * @var array
+	 * @var array<string, \WP\MCP\Domain\Resources\McpResource>
 	 */
-	private array $prompts = array();
+	private array $mcp_resources = array();
+
+	/**
+	 * MCP prompts keyed by prompt name.
+	 *
+	 * @var array<string, \WP\MCP\Domain\Prompts\McpPrompt>
+	 */
+	private array $mcp_prompts = array();
 
 	/**
 	 * MCP Server instance.
@@ -66,13 +69,6 @@ class McpComponentRegistry {
 	private McpObservabilityHandlerInterface $observability_handler;
 
 	/**
-	 * Whether MCP validation is enabled.
-	 *
-	 * @var bool
-	 */
-	private bool $mcp_validation_enabled;
-
-	/**
 	 * Whether to record component registration.
 	 *
 	 * @var bool
@@ -85,254 +81,303 @@ class McpComponentRegistry {
 	 * @param \WP\MCP\Core\McpServer $mcp_server MCP server instance.
 	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface $error_handler Error handler instance.
 	 * @param \WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface $observability_handler Observability handler instance.
-	 * @param bool                                                                       $mcp_validation_enabled Whether MCP validation is enabled.
 	 */
 	public function __construct(
 		McpServer $mcp_server,
 		McpErrorHandlerInterface $error_handler,
-		McpObservabilityHandlerInterface $observability_handler,
-		bool $mcp_validation_enabled
+		McpObservabilityHandlerInterface $observability_handler
 	) {
-		$this->mcp_server             = $mcp_server;
-		$this->error_handler          = $error_handler;
-		$this->observability_handler  = $observability_handler;
-		$this->mcp_validation_enabled = $mcp_validation_enabled;
+		$this->mcp_server            = $mcp_server;
+		$this->error_handler         = $error_handler;
+		$this->observability_handler = $observability_handler;
 
-		// Allow filtering whether component registration events should be recorded.
-		// Default is false to avoid polluting observability logs during startup.
-		$this->should_record_component_registration = apply_filters( 'mcp_adapter_observability_record_component_registration', false );
+		/**
+		 * Filters whether component registration events should be recorded for observability.
+		 *
+		 * Default is false to avoid polluting observability logs during startup.
+		 * Enable this filter to track tool, resource, and prompt registrations
+		 * for debugging or monitoring purposes.
+		 *
+		 * @since 0.3.0
+		 *
+		 * @param bool      $should_record Whether to record component registration events. Default false.
+		 * @param string    $server_id     The server ID for which components are being registered.
+		 * @param \WP\MCP\Core\McpServer $server        The McpServer instance owning the registry.
+		 */
+		$this->should_record_component_registration = apply_filters(
+			'mcp_adapter_observability_record_component_registration',
+			false,
+			$this->mcp_server->get_server_id(),
+			$this->mcp_server
+		);
 	}
 
 	/**
 	 * Register tools to the server.
 	 *
-	 * @param array $tools Array of ability names (strings) to convert to MCP tools.
+	 * @param array<int, string|\WP\MCP\Domain\Tools\McpTool> $tools Array of ability names (strings) or McpTool instances.
 	 *
 	 * @return void
 	 */
 	public function register_tools( array $tools ): void {
 		foreach ( $tools as $tool_item ) {
-			if ( ! is_string( $tool_item ) ) {
-				continue;
-			}
-
-			// Treat as ability name
-			$ability = wp_get_ability( $tool_item );
-
-			if ( ! $ability ) {
-				$this->error_handler->log( "WordPress ability '{$tool_item}' does not exist.", array( "RegisterAbilityAsMcpTool::{$tool_item}" ) );
-
-				// Track ability tool registration failure.
-				if ( $this->should_record_component_registration ) {
-					$this->observability_handler->record_event(
-						'mcp.component.registration',
-						array(
-							'status'         => 'failed',
-							'component_type' => 'ability_tool',
-							'component_name' => $tool_item,
-							'failure_reason' => 'ability_not_found',
-							'server_id'      => $this->mcp_server->get_server_id(),
-						)
-					);
-				}
-				continue;
-			}
-
-			$tool = RegisterAbilityAsMcpTool::make( $ability, $this->mcp_server );
-
-			// Check if tool creation returned an error
-			if ( is_wp_error( $tool ) ) {
-				$this->error_handler->log( $tool->get_error_message(), array( "RegisterAbilityAsMcpTool::{$tool_item}" ) );
-
-				// Track ability tool registration failure.
-				if ( $this->should_record_component_registration ) {
-					$this->observability_handler->record_event(
-						'mcp.component.registration',
-						array(
-							'status'         => 'failed',
-							'component_type' => 'ability_tool',
-							'component_name' => $tool_item,
-							'error_code'     => $tool->get_error_code(),
-							'server_id'      => $this->mcp_server->get_server_id(),
-						)
-					);
-				}
-				continue;
-			}
-
-			// If registry has validation enabled, validate the tool (bypassing server's validation flag)
-			if ( $this->mcp_validation_enabled ) {
-				$context_to_use    = "McpComponentRegistry::register_tools::{$tool_item}";
-				$validation_result = \WP\MCP\Domain\Tools\McpToolValidator::validate_tool_instance( $tool, $context_to_use );
-
-				// Check if validation returned an error
-				if ( is_wp_error( $validation_result ) ) {
-					$this->error_handler->log( $validation_result->get_error_message(), array( "RegisterAbilityAsMcpTool::{$tool_item}" ) );
-
-					// Track ability tool registration failure.
-					if ( $this->should_record_component_registration ) {
-						$this->observability_handler->record_event(
-							'mcp.component.registration',
-							array(
-								'status'         => 'failed',
-								'component_type' => 'ability_tool',
-								'component_name' => $tool_item,
-								'error_code'     => $validation_result->get_error_code(),
-								'server_id'      => $this->mcp_server->get_server_id(),
-							)
-						);
-					}
-					continue;
-				}
-			}
-
-			// Add the processed tools to this server.
-			$this->tools[ $tool->get_name() ] = $tool;
-
-			// Track successful ability tool registration.
-			if ( ! $this->should_record_component_registration ) {
-				continue;
-			}
-
-			$this->observability_handler->record_event(
-				'mcp.component.registration',
-				array(
-					'status'         => 'success',
-					'component_type' => 'ability_tool',
-					'component_name' => $tool_item,
-					'server_id'      => $this->mcp_server->get_server_id(),
-				)
-			);
+			$this->register_single_tool( $tool_item );
 		}
 	}
 
 	/**
-	 * Register a McpTool instance directly to the server.
+	 * Register a single tool to the server.
 	 *
-	 * @param \WP\MCP\Domain\Tools\McpTool $tool The tool instance to register.
+	 * @param string|\WP\MCP\Domain\Tools\McpTool $tool_item The tool to register.
 	 *
 	 * @return void
 	 */
-	public function add_tool( McpTool $tool ): void {
-		// Set the MCP server before validation (validation needs it to check if validation is enabled)
-		$tool->set_mcp_server( $this->mcp_server );
+	private function register_single_tool( $tool_item ): void {
+		// Case 0: McpTool instance.
+		if ( $tool_item instanceof McpTool ) {
+			$this->add_mcp_tool( $tool_item );
 
-		// Validate if validation is enabled (call validator directly to respect registry's validation flag)
-		if ( $this->mcp_validation_enabled ) {
-			$context_to_use    = "McpComponentRegistry::add_tool::{$tool->get_name()}";
-			$validation_result = \WP\MCP\Domain\Tools\McpToolValidator::validate_tool_instance( $tool, $context_to_use );
+			/** @var \WP\McpSchema\Server\Tools\DTO\Tool $tool_dto */
+			$tool_dto = $tool_item->get_component();
+			$this->track_registration( 'tool', $tool_dto->getName(), 'success' );
 
-			// Check if validation returned an error
-			if ( is_wp_error( $validation_result ) ) {
-				$this->error_handler->log( $validation_result->get_error_message(), array( "McpComponentRegistry::add_tool::{$tool->get_name()}" ) );
-
-				// Track tool registration failure
-				if ( $this->should_record_component_registration ) {
-					$this->observability_handler->record_event(
-						'mcp.component.registration',
-						array(
-							'status'         => 'failed',
-							'component_type' => 'tool',
-							'component_name' => $tool->get_name(),
-							'error_code'     => $validation_result->get_error_code(),
-							'server_id'      => $this->mcp_server->get_server_id(),
-						)
-					);
-				}
-				return;
-			}
+			return;
 		}
 
-		// Add the tool to this server
-		$this->tools[ $tool->get_name() ] = $tool;
+		// Case 1: String - treat as ability name.
+		if ( is_string( $tool_item ) ) {
+			$this->register_ability_tool( $tool_item );
 
-		// Track successful tool registration
+			return;
+		}
+
+		$this->error_handler->log(
+			sprintf(
+				'Invalid tool registration item: expected McpTool instance or string ability name, got %s.',
+				is_object( $tool_item ) ? get_class( $tool_item ) : gettype( $tool_item )
+			),
+			array( 'McpComponentRegistry::register_single_tool' ),
+			'warning'
+		);
+	}
+
+	/**
+	 * Register an McpTool directly.
+	 *
+	 * @param \WP\MCP\Domain\Tools\McpTool $mcp_tool McpTool instance.
+	 *
+	 * @return void
+	 * @since 0.3.0
+	 *
+	 */
+	private function add_mcp_tool( McpTool $mcp_tool ): void {
+		/** @var \WP\McpSchema\Server\Tools\DTO\Tool $tool_dto */
+		$tool_dto  = $mcp_tool->get_component();
+		$tool_name = $tool_dto->getName();
+
+		if ( isset( $this->mcp_tools[ $tool_name ] ) ) {
+			$this->error_handler->log(
+				"Tool with name '{$tool_name}' already registered, skipping duplicate.",
+				array( 'McpComponentRegistry::add_mcp_tool' ),
+				'warning'
+			);
+
+			return;
+		}
+
+		$this->mcp_tools[ $tool_name ] = $mcp_tool;
+	}
+
+	/**
+	 * Record a component registration event.
+	 *
+	 * @param string $type Component type.
+	 * @param string $name Component name.
+	 * @param string $status Registration status ('success' or 'failed').
+	 * @param array<string, mixed> $extra Extra event data.
+	 *
+	 * @return void
+	 */
+	private function track_registration( string $type, string $name, string $status, array $extra = array() ): void {
 		if ( ! $this->should_record_component_registration ) {
 			return;
 		}
 
-		$this->observability_handler->record_event(
-			'mcp.component.registration',
+		$event_data = array_merge(
 			array(
-				'status'         => 'success',
-				'component_type' => 'tool',
-				'component_name' => $tool->get_name(),
+				'status'         => $status,
+				'component_type' => $type,
+				'component_name' => $name,
 				'server_id'      => $this->mcp_server->get_server_id(),
-			)
+			),
+			$extra
 		);
+
+		$this->observability_handler->record_event( 'mcp.component.registration', $event_data );
+	}
+
+	/**
+	 * Register a tool from an ability name.
+	 *
+	 * @param string $ability_name Ability name.
+	 *
+	 * @return void
+	 */
+	private function register_ability_tool( string $ability_name ): void {
+		$ability = \wp_get_ability( $ability_name );
+
+		if ( ! $ability ) {
+			$this->error_handler->log( "WordPress ability '{$ability_name}' does not exist.", array( "RegisterAbilityAsMcpTool::{$ability_name}" ) );
+			$this->track_registration( 'ability_tool', $ability_name, 'failed', array( 'failure_reason' => FailureReason::ABILITY_NOT_FOUND ) );
+
+			return;
+		}
+
+		$mcp_tool = McpTool::fromAbility( $ability );
+
+		if ( is_wp_error( $mcp_tool ) ) {
+			$this->error_handler->log( $mcp_tool->get_error_message(), array( "McpTool::fromAbility::{$ability_name}" ) );
+			$this->track_registration(
+				'ability_tool',
+				$ability_name,
+				'failed',
+				array( 'error_code' => $mcp_tool->get_error_code() )
+			);
+
+			return;
+		}
+
+		$this->add_mcp_tool( $mcp_tool );
+		$this->track_registration( 'ability_tool', $ability_name, 'success' );
 	}
 
 	/**
 	 * Register resources to the server.
 	 *
-	 * @param array $abilities Array of ability names to convert to MCP resources.
+	 * @param array<int, string|\WP\MCP\Domain\Resources\McpResource> $resources Array of ability names or McpResource instances.
 	 *
 	 * @return void
 	 */
-	public function register_resources( array $abilities ): void {
-		foreach ( $abilities as $ability_name ) {
-			if ( ! is_string( $ability_name ) ) {
-				continue;
-			}
+	public function register_resources( array $resources ): void {
+		foreach ( $resources as $resource_item ) {
+			$this->register_single_resource( $resource_item );
+		}
+	}
 
-			$ability = wp_get_ability( $ability_name );
+	/**
+	 * Register a single resource to the server.
+	 *
+	 * @param string|\WP\MCP\Domain\Resources\McpResource $resource_item The resource to register.
+	 *
+	 * @return void
+	 */
+	private function register_single_resource( $resource_item ): void {
+		// Case 0: McpResource instance.
+		if ( $resource_item instanceof McpResource ) {
+			$this->add_mcp_resource( $resource_item );
 
-			if ( ! $ability ) {
-				$this->error_handler->log( "WordPress ability '{$ability_name}' does not exist.", array( "RegisterAbilityAsMcpResource::{$ability_name}" ) );
+			/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto */
+			$resource_dto = $resource_item->get_component();
+			$this->track_registration( 'resource', $resource_dto->getUri(), 'success' );
 
-				// Track resource registration failure.
-				if ( $this->should_record_component_registration ) {
-					$this->observability_handler->record_event(
-						'mcp.component.registration',
-						array(
-							'status'         => 'failed',
-							'component_type' => 'resource',
-							'component_name' => $ability_name,
-							'failure_reason' => 'ability_not_found',
-							'server_id'      => $this->mcp_server->get_server_id(),
-						)
-					);
-				}
-				continue;
-			}
+			return;
+		}
 
-			$resource = RegisterAbilityAsMcpResource::make( $ability, $this->mcp_server );
+		// Case 1: String - treat as ability name.
+		if ( is_string( $resource_item ) ) {
+			$this->register_ability_resource( $resource_item );
 
-			// Check if resource creation returned an error
-			if ( is_wp_error( $resource ) ) {
-				$this->error_handler->log( $resource->get_error_message(), array( "RegisterAbilityAsMcpResource::{$ability_name}" ) );
+			return;
+		}
 
-				// Track resource registration failure.
-				if ( $this->should_record_component_registration ) {
-					$this->observability_handler->record_event(
-						'mcp.component.registration',
-						array(
-							'status'         => 'failed',
-							'component_type' => 'resource',
-							'component_name' => $ability_name,
-							'error_code'     => $resource->get_error_code(),
-							'server_id'      => $this->mcp_server->get_server_id(),
-						)
-					);
-				}
-				continue;
-			}
+		// Case 2: Invalid type.
+		$this->error_handler->log(
+			sprintf(
+				'Invalid resource registration item: expected McpResource instance or string ability name, got %s.',
+				is_object( $resource_item ) ? get_class( $resource_item ) : gettype( $resource_item )
+			),
+			array( 'McpComponentRegistry::register_single_resource' ),
+			'warning'
+		);
+	}
 
-			// Add the processed resources to this server.
-			$this->resources[ $resource->get_uri() ] = $resource;
+	/**
+	 * Register an McpResource directly.
+	 *
+	 * @param \WP\MCP\Domain\Resources\McpResource $mcp_resource McpResource instance.
+	 *
+	 * @return bool True if the resource was added, false if it was a duplicate.
+	 * @since 0.3.0
+	 *
+	 */
+	private function add_mcp_resource( McpResource $mcp_resource ): bool {
+		/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto */
+		$resource_dto = $mcp_resource->get_component();
+		$uri          = $resource_dto->getUri();
 
-			// Track successful resource registration.
-			if ( ! $this->should_record_component_registration ) {
-				continue;
-			}
+		if ( isset( $this->mcp_resources[ $uri ] ) ) {
+			$this->error_handler->log(
+				"Resource with URI '{$uri}' already registered, skipping duplicate.",
+				array( 'McpComponentRegistry::add_mcp_resource' ),
+				'warning'
+			);
 
-			$this->observability_handler->record_event(
-				'mcp.component.registration',
+			return false;
+		}
+
+		$this->mcp_resources[ $uri ] = $mcp_resource;
+
+		return true;
+	}
+
+	/**
+	 * Register an ability-backed resource by ability name.
+	 *
+	 * @param string $ability_name Ability name.
+	 *
+	 * @return void
+	 */
+	private function register_ability_resource( string $ability_name ): void {
+		$ability = \wp_get_ability( $ability_name );
+
+		if ( ! $ability ) {
+			$this->error_handler->log( "WordPress ability '{$ability_name}' does not exist.", array( "RegisterAbilityAsMcpResource::{$ability_name}" ) );
+
+			$this->track_registration( 'resource', $ability_name, 'failed', array( 'failure_reason' => FailureReason::ABILITY_NOT_FOUND ) );
+
+			return;
+		}
+
+		$mcp_resource = McpResource::fromAbility( $ability, $this->error_handler );
+
+		// Check if resource creation returned an error.
+		if ( is_wp_error( $mcp_resource ) ) {
+			$this->error_handler->log( $mcp_resource->get_error_message(), array( "McpResource::fromAbility::{$ability_name}" ) );
+
+			$this->track_registration(
+				'resource',
+				$ability_name,
+				'failed',
+				array( 'error_code' => $mcp_resource->get_error_code() )
+			);
+
+			return;
+		}
+
+		$added = $this->add_mcp_resource( $mcp_resource );
+
+		if ( $added ) {
+			$this->track_registration( 'resource', $ability_name, 'success' );
+		} else {
+			/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto */
+			$resource_dto = $mcp_resource->get_component();
+			$this->track_registration(
+				'resource',
+				$ability_name,
+				'failed',
 				array(
-					'status'         => 'success',
-					'component_type' => 'resource',
-					'component_name' => $ability_name,
-					'server_id'      => $this->mcp_server->get_server_id(),
+					'failure_reason' => FailureReason::DUPLICATE_URI,
+					'duplicate_uri'  => $resource_dto->getUri(),
 				)
 			);
 		}
@@ -341,207 +386,275 @@ class McpComponentRegistry {
 	/**
 	 * Register prompts to the server.
 	 *
-	 * @param array $prompts Array of prompts to register. Can be ability names (strings) or prompt builder class names.
+	 * Accepts multiple formats:
+	 * - McpPrompt instances
+	 * - Class name string implementing McpPromptBuilderInterface (instantiated automatically)
+	 * - Ability name string (converted via RegisterAbilityAsMcpPrompt)
+	 * - McpPromptBuilderInterface instance (fluent API or custom builders)
+	 * - Array configuration (converted via McpPrompt::fromArray())
+	 *
+	 * @param array<int, string|\WP\MCP\Domain\Prompts\McpPrompt|\WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface> $prompts Array of prompts to register.
 	 *
 	 * @return void
 	 */
 	public function register_prompts( array $prompts ): void {
 		foreach ( $prompts as $prompt_item ) {
-			if ( ! is_string( $prompt_item ) ) {
-				continue;
-			}
-
-			// Check if it's a class that implements McpPromptBuilderInterface
-			if ( class_exists( $prompt_item ) && in_array( McpPromptBuilderInterface::class, class_implements( $prompt_item ) ?: array(), true ) ) {
-				// Create instance of the prompt builder class
-				try {
-					/** @var \WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface $builder */
-					$builder = new $prompt_item();
-					$prompt  = $builder->build();
-				} catch ( \Throwable $e ) {
-					$this->error_handler->log( "Failed to build prompt from class '{$prompt_item}': {$e->getMessage()}", array( "McpPromptBuilder::{$prompt_item}" ) );
-
-					if ( $this->should_record_component_registration ) {
-						$this->observability_handler->record_event(
-							'mcp.component.registration',
-							array(
-								'status'         => 'failed',
-								'component_type' => 'prompt',
-								'component_name' => $prompt_item,
-								'failure_reason' => 'builder_exception',
-								'server_id'      => $this->mcp_server->get_server_id(),
-							)
-						);
-					}
-					continue;
-				}
-
-				// Set the MCP server after building
-				$prompt->set_mcp_server( $this->mcp_server );
-
-				// Validate if validation is enabled (call validator directly to respect registry's validation flag)
-				if ( $this->mcp_validation_enabled ) {
-					$context_to_use    = "McpPromptBuilder::{$prompt_item}";
-					$validation_result = \WP\MCP\Domain\Prompts\McpPromptValidator::validate_prompt_instance( $prompt, $context_to_use );
-
-					// Check if validation returned an error
-					if ( is_wp_error( $validation_result ) ) {
-						$this->error_handler->log( $validation_result->get_error_message(), array( "McpPromptBuilder::{$prompt_item}" ) );
-
-						// Track prompt registration failure
-						if ( $this->should_record_component_registration ) {
-							$this->observability_handler->record_event(
-								'mcp.component.registration',
-								array(
-									'status'         => 'failed',
-									'component_type' => 'prompt',
-									'component_name' => $prompt_item,
-									'error_code'     => $validation_result->get_error_code(),
-									'server_id'      => $this->mcp_server->get_server_id(),
-								)
-							);
-						}
-						continue;
-					}
-				}
-
-				// Add the prompt to this server
-				$this->prompts[ $prompt->get_name() ] = $prompt;
-
-				// Track successful prompt registration
-				if ( $this->should_record_component_registration ) {
-					$this->observability_handler->record_event(
-						'mcp.component.registration',
-						array(
-							'status'         => 'success',
-							'component_type' => 'prompt',
-							'component_name' => $prompt_item,
-							'server_id'      => $this->mcp_server->get_server_id(),
-						)
-					);
-				}
-			} else {
-				// Treat as ability name (legacy behavior)
-				$ability = wp_get_ability( $prompt_item );
-
-				if ( ! $ability ) {
-					$this->error_handler->log( "WordPress ability '{$prompt_item}' does not exist.", array( "RegisterAbilityAsMcpPrompt::{$prompt_item}" ) );
-
-					// Track prompt registration failure.
-					if ( $this->should_record_component_registration ) {
-						$this->observability_handler->record_event(
-							'mcp.component.registration',
-							array(
-								'status'         => 'failed',
-								'component_type' => 'prompt',
-								'component_name' => $prompt_item,
-								'failure_reason' => 'ability_not_found',
-								'server_id'      => $this->mcp_server->get_server_id(),
-							)
-						);
-					}
-					continue;
-				}
-
-				// Use RegisterMcpPrompt to handle all validation and processing.
-				$prompt = RegisterAbilityAsMcpPrompt::make( $ability, $this->mcp_server );
-
-				// Check if prompt creation returned an error
-				if ( is_wp_error( $prompt ) ) {
-					$this->error_handler->log( $prompt->get_error_message(), array( "RegisterAbilityAsMcpPrompt::{$prompt_item}" ) );
-
-					// Track prompt registration failure.
-					if ( $this->should_record_component_registration ) {
-						$this->observability_handler->record_event(
-							'mcp.component.registration',
-							array(
-								'status'         => 'failed',
-								'component_type' => 'prompt',
-								'component_name' => $prompt_item,
-								'error_code'     => $prompt->get_error_code(),
-								'server_id'      => $this->mcp_server->get_server_id(),
-							)
-						);
-					}
-					continue;
-				}
-
-				// Add the processed prompts to this server.
-				$this->prompts[ $prompt->get_name() ] = $prompt;
-
-				// Track successful prompt registration.
-				if ( $this->should_record_component_registration ) {
-					$this->observability_handler->record_event(
-						'mcp.component.registration',
-						array(
-							'status'         => 'success',
-							'component_type' => 'prompt',
-							'component_name' => $prompt_item,
-							'server_id'      => $this->mcp_server->get_server_id(),
-						)
-					);
-				}
-			}
+			$this->register_single_prompt( $prompt_item );
 		}
+	}
+
+	/**
+	 * Register a single prompt to the server.
+	 *
+	 * @param string|\WP\MCP\Domain\Prompts\McpPrompt|\WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface $prompt_item The prompt to register.
+	 *
+	 * @return void
+	 */
+	private function register_single_prompt( $prompt_item ): void {
+		// Case 0: McpPrompt instance.
+		if ( $prompt_item instanceof McpPrompt ) {
+			$this->add_mcp_prompt( $prompt_item );
+
+			/** @var \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt_dto */
+			$prompt_dto = $prompt_item->get_component();
+			$this->track_registration( 'prompt', $prompt_dto->getName(), 'success' );
+
+			return;
+		}
+
+		// Case 1: McpPromptBuilderInterface instance (fluent API or custom builder).
+		if ( $prompt_item instanceof McpPromptBuilderInterface ) {
+			$this->register_builder_instance( $prompt_item );
+
+			return;
+		}
+
+		// Case 2: String - either a class name or ability name.
+		if ( is_string( $prompt_item ) ) {
+			// Check if it's a class that implements McpPromptBuilderInterface.
+			if ( class_exists( $prompt_item ) && in_array( McpPromptBuilderInterface::class, class_implements( $prompt_item ) ?: array(), true ) ) {
+				$this->register_builder_class( $prompt_item );
+
+				return;
+			}
+
+			// Treat as ability name.
+			$this->register_ability_prompt( $prompt_item );
+
+			return;
+		}
+
+		// Case 3: Invalid type.
+		$this->error_handler->log(
+			sprintf(
+				'Invalid prompt registration item: expected McpPrompt, McpPromptBuilderInterface, or string, got %s.',
+				is_object( $prompt_item ) ? get_class( $prompt_item ) : gettype( $prompt_item )
+			),
+			array( 'McpComponentRegistry::register_single_prompt' ),
+			'warning'
+		);
+	}
+
+	/**
+	 * Add an McpPrompt to the registry.
+	 *
+	 * @param \WP\MCP\Domain\Prompts\McpPrompt $mcp_prompt McpPrompt instance.
+	 *
+	 * @return void
+	 * @since 0.3.0
+	 *
+	 */
+	private function add_mcp_prompt( McpPrompt $mcp_prompt ): void {
+		/** @var \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt */
+		$prompt      = $mcp_prompt->get_component();
+		$prompt_name = $prompt->getName();
+
+		if ( isset( $this->mcp_prompts[ $prompt_name ] ) ) {
+			$this->error_handler->log(
+				"Prompt with name '{$prompt_name}' already registered, skipping duplicate.",
+				array( 'McpComponentRegistry::add_mcp_prompt' ),
+				'warning'
+			);
+
+			return;
+		}
+
+		$this->mcp_prompts[ $prompt_name ] = $mcp_prompt;
+	}
+
+	/**
+	 * Register a McpPromptBuilderInterface instance.
+	 *
+	 * @param \WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface $builder The builder instance.
+	 *
+	 * @return void
+	 */
+	private function register_builder_instance( McpPromptBuilderInterface $builder ): void {
+		$prompt_name = $builder->get_name();
+
+		$mcp_prompt = McpPrompt::fromBuilder( $builder );
+		if ( $mcp_prompt instanceof \WP_Error ) {
+			$this->error_handler->log( $mcp_prompt->get_error_message(), array( "McpPrompt::fromBuilder::{$prompt_name}" ) );
+
+			$this->track_registration(
+				'prompt',
+				$prompt_name,
+				'failed',
+				array( 'error_code' => $mcp_prompt->get_error_code() )
+			);
+
+			return;
+		}
+
+		$this->add_mcp_prompt( $mcp_prompt );
+
+		$this->track_registration( 'prompt', $prompt_name, 'success' );
+	}
+
+	/**
+	 * Register a prompt from a builder class name.
+	 *
+	 * @param string $class_name The fully-qualified class name.
+	 *
+	 * @return void
+	 */
+	private function register_builder_class( string $class_name ): void {
+		try {
+			/** @var \WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface $builder */
+			$builder = new $class_name();
+			$this->register_builder_instance( $builder );
+		} catch ( \Throwable $e ) {
+			$this->error_handler->log( "Failed to build prompt from class '{$class_name}': {$e->getMessage()}", array( "McpPromptBuilder::{$class_name}" ) );
+
+			$this->track_registration( 'prompt', $class_name, 'failed', array( 'failure_reason' => FailureReason::BUILDER_EXCEPTION ) );
+		}
+	}
+
+	/**
+	 * Register a prompt from an ability name.
+	 *
+	 * @param string $ability_name The ability name.
+	 *
+	 * @return void
+	 */
+	private function register_ability_prompt( string $ability_name ): void {
+		$ability = \wp_get_ability( $ability_name );
+
+		if ( ! $ability ) {
+			$this->error_handler->log( "WordPress ability '{$ability_name}' does not exist.", array( "RegisterAbilityAsMcpPrompt::{$ability_name}" ) );
+
+			$this->track_registration( 'prompt', $ability_name, 'failed', array( 'failure_reason' => FailureReason::ABILITY_NOT_FOUND ) );
+
+			return;
+		}
+
+		$mcp_prompt = McpPrompt::fromAbility( $ability );
+
+		if ( is_wp_error( $mcp_prompt ) ) {
+			$this->error_handler->log( $mcp_prompt->get_error_message(), array( "McpPrompt::fromAbility::{$ability_name}" ) );
+
+			$this->track_registration(
+				'prompt',
+				$ability_name,
+				'failed',
+				array( 'error_code' => $mcp_prompt->get_error_code() )
+			);
+
+			return;
+		}
+
+		$this->add_mcp_prompt( $mcp_prompt );
+
+		$this->track_registration( 'prompt', $ability_name, 'success' );
 	}
 
 	/**
 	 * Get all tools registered to the server.
 	 *
-	 * @return \WP\MCP\Domain\Tools\McpTool[]
+	 * @return array<string, \WP\McpSchema\Server\Tools\DTO\Tool>
 	 */
 	public function get_tools(): array {
-		return $this->tools;
+		return array_map(
+			static fn( McpTool $mcp_tool ): Tool => $mcp_tool->get_component(),
+			$this->mcp_tools
+		);
 	}
 
 	/**
 	 * Get all resources registered to the server.
 	 *
-	 * @return \WP\MCP\Domain\Resources\McpResource[]
+	 * @return array<string, \WP\McpSchema\Server\Resources\DTO\Resource>
 	 */
 	public function get_resources(): array {
-		return $this->resources;
+		return array_map(
+			static fn( McpResource $mcp_resource ): Resource => $mcp_resource->get_component(),
+			$this->mcp_resources
+		);
 	}
 
 	/**
 	 * Get all prompts registered to the server.
 	 *
-	 * @return \WP\MCP\Domain\Prompts\McpPrompt[]
+	 * @return array<string, \WP\McpSchema\Server\Prompts\DTO\Prompt>
 	 */
 	public function get_prompts(): array {
-		return $this->prompts;
+		return array_map(
+			static fn( McpPrompt $mcp_prompt ): Prompt => $mcp_prompt->get_component(),
+			$this->mcp_prompts
+		);
 	}
 
 	/**
-	 * Get a specific tool by name.
+	 * Get a specific McpTool by tool name.
 	 *
 	 * @param string $tool_name Tool name.
 	 *
 	 * @return \WP\MCP\Domain\Tools\McpTool|null
+	 * @since 0.3.0
+	 *
 	 */
-	public function get_tool( string $tool_name ): ?McpTool {
-		return $this->tools[ $tool_name ] ?? null;
+	public function get_mcp_tool( string $tool_name ): ?McpTool {
+		return $this->mcp_tools[ $tool_name ] ?? null;
 	}
 
 	/**
-	 * Get a specific resource by URI.
+	 * Get a specific McpResource by URI.
 	 *
 	 * @param string $resource_uri Resource URI.
 	 *
 	 * @return \WP\MCP\Domain\Resources\McpResource|null
+	 * @internal
+	 * @since 0.3.0
+	 *
 	 */
-	public function get_resource( string $resource_uri ): ?McpResource {
-		return $this->resources[ $resource_uri ] ?? null;
+	public function get_mcp_resource( string $resource_uri ): ?McpResource {
+		return $this->mcp_resources[ $resource_uri ] ?? null;
 	}
 
 	/**
-	 * Get a specific prompt by name.
+	 * Get an McpPrompt by prompt name.
 	 *
 	 * @param string $prompt_name Prompt name.
 	 *
 	 * @return \WP\MCP\Domain\Prompts\McpPrompt|null
+	 * @internal
+	 * @since 0.3.0
+	 *
 	 */
-	public function get_prompt( string $prompt_name ): ?McpPrompt {
-		return $this->prompts[ $prompt_name ] ?? null;
+	public function get_mcp_prompt( string $prompt_name ): ?McpPrompt {
+		return $this->mcp_prompts[ $prompt_name ] ?? null;
+	}
+
+	/**
+	 * Get a prompt builder instance by prompt name (builder-based prompts).
+	 *
+	 * @param string $prompt_name Prompt name.
+	 *
+	 * @return \WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface|null
+	 */
+	public function get_prompt_builder( string $prompt_name ): ?McpPromptBuilderInterface {
+		$mcp_prompt = $this->mcp_prompts[ $prompt_name ] ?? null;
+
+		return $mcp_prompt ? $mcp_prompt->get_builder() : null;
 	}
 }

--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Core;
 
+use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
 use WP\MCP\Domain\Prompts\McpPrompt;
 use WP\MCP\Domain\Resources\McpResource;
 use WP\MCP\Domain\Tools\McpTool;
@@ -17,11 +18,26 @@ use WP\MCP\Infrastructure\ErrorHandling\NullMcpErrorHandler;
 use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface;
 use WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
 
 /**
  * WordPress MCP Server - Represents a single MCP server with its tools, resources, and prompts.
  */
 class McpServer {
+	/**
+	 * Error handler instance.
+	 *
+	 * @var \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface
+	 */
+	public McpErrorHandlerInterface $error_handler;
+
+	/**
+	 * Observability handler instance.
+	 *
+	 * @var \WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface
+	 */
+	public McpObservabilityHandlerInterface $observability_handler;
+
 	/**
 	 * Server ID.
 	 *
@@ -79,20 +95,6 @@ class McpServer {
 	private McpTransportFactory $transport_factory;
 
 	/**
-	 * Error handler instance.
-	 *
-	 * @var \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface
-	 */
-	public McpErrorHandlerInterface $error_handler;
-
-	/**
-	 * Observability handler instance.
-	 *
-	 * @var \WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface
-	 */
-	public McpObservabilityHandlerInterface $observability_handler;
-
-	/**
 	 * Whether MCP validation is enabled.
 	 *
 	 * @var bool
@@ -110,19 +112,19 @@ class McpServer {
 	/**
 	 * Constructor.
 	 *
-	 * @param string                                              $server_id Unique identifier for the server.
-	 * @param string                                              $server_route_namespace Server route namespace.
-	 * @param string                                              $server_route Server route.
-	 * @param string                                              $server_name Human-readable server name.
-	 * @param string                                              $server_description Server description.
-	 * @param string                                              $server_version Server version.
-	 * @param array                                               $mcp_transports Array of MCP transport class names to initialize (e.g., [McpRestTransport::class]).
-	 * @param class-string<\WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface>|null         $error_handler Error handler class to use (e.g., NullMcpErrorHandler::class). Must implement McpErrorHandlerInterface. If null, NullMcpErrorHandler will be used.
+	 * @param string $server_id Unique identifier for the server.
+	 * @param string $server_route_namespace Server route namespace.
+	 * @param string $server_route Server route.
+	 * @param string $server_name Human-readable server name.
+	 * @param string $server_description Server description.
+	 * @param string $server_version Server version.
+	 * @param array $mcp_transports Array of MCP transport class names to initialize (e.g., [McpRestTransport::class]).
+	 * @param class-string<\WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface>|null $error_handler Error handler class to use (e.g., NullMcpErrorHandler::class). Must implement McpErrorHandlerInterface. If null, NullMcpErrorHandler will be used.
 	 * @param class-string<\WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface>|null $observability_handler Observability handler class to use (e.g., NullMcpObservabilityHandler::class). Must implement McpObservabilityHandlerInterface. If null, NullMcpObservabilityHandler will be used.
-	 * @param array                                               $tools Optional ability names to register as tools during construction.
-	 * @param array                                               $resources Optional resources to register during construction.
-	 * @param array                                               $prompts Optional prompts to register during construction.
-	 * @param callable|null                                       $transport_permission_callback Optional custom permission callback for transport-level authentication. If null, defaults to is_user_logged_in().
+	 * @param array $tools Optional ability names to register as tools during construction.
+	 * @param array $resources Optional resources to register during construction.
+	 * @param array $prompts Optional prompts to register during construction.
+	 * @param callable|null $transport_permission_callback Optional custom permission callback for transport-level authentication. If null, defaults to is_user_logged_in().
 	 *
 	 * @throws \Exception Thrown if the MCP transport class does not extend AbstractMcpTransport.
 	 */
@@ -150,9 +152,20 @@ class McpServer {
 		$this->server_version                = $server_version;
 		$this->transport_permission_callback = $transport_permission_callback;
 
-		// Setup validation flag. Validation is disabled by default for performance.
-		// Abilities API is also validating all abilities.
-		$this->mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		/**
+		 * Filters whether MCP protocol validation is enabled for a server.
+		 *
+		 * Validation is disabled by default for performance, as the Abilities API
+		 * also validates all abilities. Enable this filter for stricter MCP protocol
+		 * compliance checking during development or debugging.
+		 *
+		 * @since 0.3.0
+		 *
+		 * @param bool      $enabled   Whether validation is enabled. Default false.
+		 * @param string    $server_id The server ID being configured.
+		 * @param \WP\MCP\Core\McpServer $server    The McpServer instance being constructed.
+		 */
+		$this->mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false, $this->server_id, $this );
 
 		// Setup handlers and components
 		$this->setup_handlers( $error_handler, $observability_handler );
@@ -200,8 +213,7 @@ class McpServer {
 		$this->component_registry = new McpComponentRegistry(
 			$this,
 			$this->error_handler,
-			$this->observability_handler,
-			$this->mcp_validation_enabled
+			$this->observability_handler
 		);
 
 		// Initialize transport factory
@@ -268,7 +280,7 @@ class McpServer {
 	}
 
 	/**
-	 * Get server name.
+	 * Get the server name.
 	 *
 	 * @return string
 	 */
@@ -319,7 +331,7 @@ class McpServer {
 	/**
 	 * Get all tools registered to this server.
 	 *
-	 * @return array
+	 * @return array<string, \WP\McpSchema\Server\Tools\DTO\Tool>
 	 */
 	public function get_tools(): array {
 		return $this->component_registry->get_tools();
@@ -328,7 +340,7 @@ class McpServer {
 	/**
 	 * Get all resources registered to this server.
 	 *
-	 * @return \WP\MCP\Domain\Resources\McpResource[]
+	 * @return array<string, \WP\McpSchema\Server\Resources\DTO\Resource>
 	 */
 	public function get_resources(): array {
 		return $this->component_registry->get_resources();
@@ -337,32 +349,38 @@ class McpServer {
 	/**
 	 * Get all prompts registered to this server.
 	 *
-	 * @return array
+	 * @return array<string, \WP\McpSchema\Server\Prompts\DTO\Prompt>
 	 */
 	public function get_prompts(): array {
 		return $this->component_registry->get_prompts();
 	}
 
 	/**
-	 * Get a specific tool by name.
+	 * Get a specific McpTool by name.
 	 *
 	 * @param string $tool_name Tool name.
 	 *
 	 * @return \WP\MCP\Domain\Tools\McpTool|null
+	 * @internal
+	 * @since 0.3.0
+	 *
 	 */
-	public function get_tool( string $tool_name ): ?McpTool {
-		return $this->component_registry->get_tool( $tool_name );
+	public function get_mcp_tool( string $tool_name ): ?McpTool {
+		return $this->component_registry->get_mcp_tool( $tool_name );
 	}
 
 	/**
-	 * Get a specific resource by URI.
+	 * Get a specific McpResource by URI.
 	 *
 	 * @param string $resource_uri Resource URI.
 	 *
 	 * @return \WP\MCP\Domain\Resources\McpResource|null
+	 * @internal
+	 * @since 0.3.0
+	 *
 	 */
-	public function get_resource( string $resource_uri ): ?McpResource {
-		return $this->component_registry->get_resource( $resource_uri );
+	public function get_mcp_resource( string $resource_uri ): ?McpResource {
+		return $this->component_registry->get_mcp_resource( $resource_uri );
 	}
 
 	/**
@@ -370,10 +388,37 @@ class McpServer {
 	 *
 	 * @param string $prompt_name Prompt name.
 	 *
-	 * @return \WP\MCP\Domain\Prompts\McpPrompt|null
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|null
 	 */
-	public function get_prompt( string $prompt_name ): ?McpPrompt {
-		return $this->component_registry->get_prompt( $prompt_name );
+	public function get_prompt( string $prompt_name ): ?Prompt {
+		$mcp_prompt = $this->component_registry->get_mcp_prompt( $prompt_name );
+
+		return $mcp_prompt ? $mcp_prompt->get_component() : null;
+	}
+
+	/**
+	 * Get an McpPrompt by name.
+	 *
+	 * @param string $prompt_name Prompt name.
+	 *
+	 * @return \WP\MCP\Domain\Prompts\McpPrompt|null
+	 * @internal
+	 * @since 0.3.0
+	 *
+	 */
+	public function get_mcp_prompt( string $prompt_name ): ?McpPrompt {
+		return $this->component_registry->get_mcp_prompt( $prompt_name );
+	}
+
+	/**
+	 * Get a prompt builder instance by prompt name (builder-based prompts).
+	 *
+	 * @param string $prompt_name Prompt name.
+	 *
+	 * @return \WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface|null
+	 */
+	public function get_prompt_builder( string $prompt_name ): ?McpPromptBuilderInterface {
+		return $this->component_registry->get_prompt_builder( $prompt_name );
 	}
 
 	/**
@@ -392,14 +437,5 @@ class McpServer {
 	 */
 	public function is_mcp_validation_enabled(): bool {
 		return $this->mcp_validation_enabled;
-	}
-
-	/**
-	 * Get the component registry instance.
-	 *
-	 * @return \WP\MCP\Core\McpComponentRegistry
-	 */
-	public function get_component_registry(): McpComponentRegistry {
-		return $this->component_registry;
 	}
 }

--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -118,12 +118,12 @@ class McpServer {
 	 * @param string $server_name Human-readable server name.
 	 * @param string $server_description Server description.
 	 * @param string $server_version Server version.
-	 * @param array $mcp_transports Array of MCP transport class names to initialize (e.g., [McpRestTransport::class]).
+	 * @param array<class-string<\WP\MCP\Transport\Contracts\McpTransportInterface>> $mcp_transports Array of MCP transport class names to initialize (e.g., [McpRestTransport::class]).
 	 * @param class-string<\WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface>|null $error_handler Error handler class to use (e.g., NullMcpErrorHandler::class). Must implement McpErrorHandlerInterface. If null, NullMcpErrorHandler will be used.
 	 * @param class-string<\WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface>|null $observability_handler Observability handler class to use (e.g., NullMcpObservabilityHandler::class). Must implement McpObservabilityHandlerInterface. If null, NullMcpObservabilityHandler will be used.
-	 * @param array $tools Optional ability names to register as tools during construction.
-	 * @param array $resources Optional resources to register during construction.
-	 * @param array $prompts Optional prompts to register during construction.
+	 * @param array<string> $tools Optional ability names to register as tools during construction.
+	 * @param array<string> $resources Optional resources to register during construction.
+	 * @param array<string> $prompts Optional prompts to register during construction.
 	 * @param callable|null $transport_permission_callback Optional custom permission callback for transport-level authentication. If null, defaults to is_user_logged_in().
 	 *
 	 * @throws \Exception Thrown if the MCP transport class does not extend AbstractMcpTransport.
@@ -201,10 +201,10 @@ class McpServer {
 	/**
 	 * Setup component registry and transport factory.
 	 *
-	 * @param array $tools Tools to register.
-	 * @param array $resources Resources to register.
-	 * @param array $prompts Prompts to register.
-	 * @param array $mcp_transports Transport classes to initialize.
+	 * @param array<string> $tools Tools to register.
+	 * @param array<string> $resources Resources to register.
+	 * @param array<string> $prompts Prompts to register.
+	 * @param array<class-string<\WP\MCP\Transport\Contracts\McpTransportInterface>> $mcp_transports Transport classes to initialize.
 	 *
 	 * @throws \Exception
 	 */
@@ -229,9 +229,9 @@ class McpServer {
 	/**
 	 * Register initial tools, resources, and prompts.
 	 *
-	 * @param array $tools Tools to register.
-	 * @param array $resources Resources to register.
-	 * @param array $prompts Prompts to register.
+	 * @param array<string> $tools Tools to register.
+	 * @param array<string> $resources Resources to register.
+	 * @param array<string> $prompts Prompts to register.
 	 */
 	private function register_mcp_components( array $tools, array $resources, array $prompts ): void {
 		// Register tools if provided

--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -18,7 +18,7 @@ use WP\MCP\Infrastructure\ErrorHandling\NullMcpErrorHandler;
 use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface;
 use WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 
 /**
  * WordPress MCP Server - Represents a single MCP server with its tools, resources, and prompts.
@@ -390,10 +390,10 @@ class McpServer {
 	 *
 	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|null
 	 */
-	public function get_prompt( string $prompt_name ): ?Prompt {
+	public function get_prompt( string $prompt_name ): ?PromptDto {
 		$mcp_prompt = $this->component_registry->get_mcp_prompt( $prompt_name );
 
-		return $mcp_prompt ? $mcp_prompt->get_component() : null;
+		return $mcp_prompt ? $mcp_prompt->get_protocol_dto() : null;
 	}
 
 	/**

--- a/includes/Core/McpTransportFactory.php
+++ b/includes/Core/McpTransportFactory.php
@@ -40,7 +40,7 @@ class McpTransportFactory {
 	/**
 	 * Initialize MCP transports for the server.
 	 *
-	 * @param array $mcp_transports Array of MCP transport class names to initialize.
+	 * @param array<class-string<\WP\MCP\Transport\Contracts\McpTransportInterface>> $mcp_transports Array of MCP transport class names to initialize.
 	 */
 	public function initialize_transports( array $mcp_transports ): void {
 		foreach ( $mcp_transports as $mcp_transport ) {

--- a/includes/Core/McpTransportFactory.php
+++ b/includes/Core/McpTransportFactory.php
@@ -44,12 +44,12 @@ class McpTransportFactory {
 	 */
 	public function initialize_transports( array $mcp_transports ): void {
 		foreach ( $mcp_transports as $mcp_transport ) {
-			// Check if class exists
+			// Check if the class exists
 			if ( ! class_exists( $mcp_transport ) ) {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(
-						/* translators: %s: Transport class name */
+					/* translators: %s: Transport class name */
 						esc_html__( 'Transport class "%s" does not exist. Make sure the class is properly autoloaded or included.', 'mcp-adapter' ),
 						esc_html( $mcp_transport )
 					),
@@ -68,7 +68,7 @@ class McpTransportFactory {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(
-						/* translators: %s: Transport class name */
+					/* translators: %s: Transport class name */
 						esc_html__( 'Transport class "%s" must implement McpTransportInterface. Check your transport implementation.', 'mcp-adapter' ),
 						esc_html( $mcp_transport )
 					),
@@ -89,7 +89,7 @@ class McpTransportFactory {
 	}
 
 	/**
-	 * Create transport context with all required dependencies.
+	 * Create the transport context with all required dependencies.
 	 *
 	 * @return \WP\MCP\Transport\Infrastructure\McpTransportContext
 	 */

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -7,7 +7,7 @@
  * @package WP\MCP
  */
 
-declare(strict_types = 1);
+declare( strict_types=1 );
 
 namespace WP\MCP;
 
@@ -93,7 +93,7 @@ final class Plugin {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				// translators: %s: Class name.
+			// translators: %s: Class name.
 				esc_html__( 'The %s class should not be cloned.', 'mcp-adapter' ),
 				esc_html( self::class ),
 			),
@@ -108,7 +108,7 @@ final class Plugin {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				// translators: %s: Class name.
+			// translators: %s: Class name.
 				esc_html__( 'De-serializing instances of %s is not allowed.', 'mcp-adapter' ),
 				esc_html( self::class ),
 			),

--- a/includes/Servers/DefaultServerFactory.php
+++ b/includes/Servers/DefaultServerFactory.php
@@ -59,7 +59,32 @@ class DefaultServerFactory {
 			'prompts'                => $auto_discovered_prompts,
 		);
 
-		// Apply WordPress filter for customization
+		/**
+		 * Filters the default MCP server configuration.
+		 *
+		 * Allows customization of the default server's settings before creation.
+		 * The filtered array is merged with defaults, so you only need to specify
+		 * the values you want to override.
+		 *
+		 * @since 0.3.0
+		 *
+		 * @param array $config {
+		 *     Default server configuration.
+		 *
+		 *     @type string   $server_id              Server identifier. Default 'mcp-adapter-default-server'.
+		 *     @type string   $server_route_namespace REST API namespace. Default 'mcp-adapter/v1'.
+		 *     @type string   $server_route           REST API route. Default 'mcp'.
+		 *     @type string   $server_name            Human-readable name. Default 'WordPress MCP Server'.
+		 *     @type string   $server_description     Server description.
+		 *     @type string   $server_version         Server version. Default WORDPRESS_MCP_ADAPTER_VERSION.
+		 *     @type string[] $mcp_transports         Transport class names. Default [HttpTransport::class].
+		 *     @type string   $error_handler          Error handler class. Default ErrorLogMcpErrorHandler::class.
+		 *     @type string   $observability_handler  Observability handler class. Default NullMcpObservabilityHandler::class.
+		 *     @type string[] $tools                  Tool ability names to expose.
+		 *     @type string[] $resources              Resource ability names to expose.
+		 *     @type string[] $prompts                Prompt ability names to expose.
+		 * }
+		 */
 		$config = apply_filters( 'mcp_adapter_default_server_config', $wordpress_defaults );
 
 		// Ensure config is an array and merge with defaults

--- a/tests/Unit/Abilities/GetAbilityInfoAbilityTest.php
+++ b/tests/Unit/Abilities/GetAbilityInfoAbilityTest.php
@@ -271,7 +271,6 @@ final class GetAbilityInfoAbilityTest extends TestCase {
 		$this->assertArrayHasKey( 'properties', $input_schema );
 		$this->assertArrayHasKey( 'ability_name', $input_schema['properties'] );
 		$this->assertEquals( array( 'ability_name' ), $input_schema['required'] );
-		$this->assertFalse( $input_schema['additionalProperties'] );
 	}
 
 	public function test_ability_has_correct_output_schema(): void {

--- a/tests/Unit/Core/McpAdapterConfigTest.php
+++ b/tests/Unit/Core/McpAdapterConfigTest.php
@@ -245,13 +245,26 @@ final class McpAdapterConfigTest extends TestCase {
 		$this->assertSame( array( HttpTransport::class ), $received_config['mcp_transports'] );
 		$this->assertSame( ErrorLogMcpErrorHandler::class, $received_config['error_handler'] );
 		$this->assertSame( NullMcpObservabilityHandler::class, $received_config['observability_handler'] );
-		// Auto-discovered resources from test fixtures (test/resource* abilities have mcp.public=true and mcp.type='resource', resulting in 4 discovered resources)
+		// Auto-discovered resources from test fixtures (test/resource* abilities have mcp.public=true and mcp.type='resource')
 		$this->assertSame(
 			array(
 				'test/resource',
 				'test/resource-with-annotations',
 				'test/resource-partial-annotations',
 				'test/resource-invalid-annotations',
+				'test/resource-new-meta',
+				'test/resource-invalid-uri',
+				'test/resource-invalid-mimetype',
+				'test/resource-with-size',
+				'test/resource-invalid-annotations-new-meta',
+				'test/resource-mixed-annotations',
+				'test/resource-with-icons',
+				'test/resource-missing-uri',
+				'test/resource-valid-mimetype',
+				'test/resource-blob-content',
+				'test/resource-multiple-contents',
+				'test/resource-text-with-mimetype',
+				'test/resource-plain-string',
 			),
 			$received_config['resources']
 		);
@@ -262,6 +275,22 @@ final class McpAdapterConfigTest extends TestCase {
 				'test/prompt-with-annotations',
 				'test/prompt-partial-annotations',
 				'test/prompt-invalid-annotations',
+				'test/prompt-flattened-string',
+				'test/prompt-flattened-array',
+				'test/prompt-with-titles',
+				'test/prompt-mixed-required',
+				'test/prompt-empty-object',
+				'test/prompt-no-schema',
+				'test/prompt-with-icons',
+				'test/prompt-with-mixed-icons',
+				'test/prompt-with-custom-meta',
+				'test/prompt-with-icons-and-meta',
+				'test/prompt-explicit-args',
+				'test/prompt-explicit-args-override',
+				'test/prompt-empty-explicit-args',
+				'test/prompt-invalid-explicit-args-no-name',
+				'test/prompt-invalid-explicit-args-not-array',
+				'test/prompt-explicit-args-all-fields',
 			),
 			$received_config['prompts']
 		);

--- a/tests/Unit/Core/McpComponentRegistryTest.php
+++ b/tests/Unit/Core/McpComponentRegistryTest.php
@@ -12,12 +12,12 @@ namespace WP\MCP\Tests\Unit\Core;
 use WP\MCP\Core\McpComponentRegistry;
 use WP\MCP\Core\McpServer;
 use WP\MCP\Domain\Prompts\McpPromptBuilder;
-use WP\MCP\Domain\Tools\McpTool;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
 
 // Test prompt builder for registry testing
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
 class TestRegistryPrompt extends McpPromptBuilder {
 
 	protected function configure(): void {
@@ -42,6 +42,7 @@ class TestRegistryPrompt extends McpPromptBuilder {
 }
 
 // Test prompt builder that throws exception during build
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
 class ExceptionPromptBuilder extends McpPromptBuilder {
 
 	protected function configure(): void {
@@ -87,8 +88,7 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->registry = new McpComponentRegistry(
 			$this->server,
 			new DummyErrorHandler(),
-			new DummyObservabilityHandler(),
-			false // Disable validation for simpler testing
+			new DummyObservabilityHandler()
 		);
 	}
 
@@ -106,8 +106,8 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertArrayHasKey( 'test-always-allowed', $tools );
 
 		$tool = $tools['test-always-allowed'];
-		$this->assertInstanceOf( \WP\MCP\Domain\Tools\McpTool::class, $tool );
-		$this->assertEquals( 'test-always-allowed', $tool->get_name() );
+		$this->assertInstanceOf( \WP\McpSchema\Server\Tools\DTO\Tool::class, $tool );
+		$this->assertEquals( 'test-always-allowed', $tool->getName() );
 
 		// Verify observability event was recorded
 		$events = DummyObservabilityHandler::$events;
@@ -163,40 +163,24 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertArrayHasKey( 'test-always-allowed', $tools );
 	}
 
-	public function test_add_tool_direct(): void {
-		// Create a tool directly
-		$tool = new McpTool(
-			'test/direct-tool',
-			'direct-tool',
-			'Direct Tool',
-			array( 'type' => 'object' ),
-			'Direct Tool Title'
+	public function test_register_tools_accepts_mcp_tools(): void {
+		$mcp_tool = \WP\MCP\Domain\Tools\McpTool::fromArray(
+			array(
+				'name'        => 'direct-mcp-tool',
+				'description' => 'Direct MCP tool',
+				'handler'     => static function () {
+					return array( 'ok' => true );
+				},
+				'permission'  => static function () {
+					return true;
+				},
+			)
 		);
-		$tool->set_mcp_server( $this->server );
 
-		$this->registry->add_tool( $tool );
+		$this->registry->register_tools( array( $mcp_tool ) );
 
-		$tools = $this->registry->get_tools();
-		$this->assertCount( 1, $tools );
-		$this->assertArrayHasKey( 'direct-tool', $tools );
-
-		$retrieved_tool = $this->registry->get_tool( 'direct-tool' );
-		$this->assertSame( $tool, $retrieved_tool );
-
-		// Verify observability event was recorded
-		$events = DummyObservabilityHandler::$events;
-		$this->assertNotEmpty( $events );
-		$event_names = array_column( $events, 'event' );
-		$this->assertContains( 'mcp.component.registration', $event_names );
-
-		// Verify status is 'success'
-		$success_event = array_filter(
-			$events,
-			static function ( $event ) {
-				return 'mcp.component.registration' === $event['event'] && isset( $event['tags']['status'] ) && 'success' === $event['tags']['status'];
-			}
-		);
-		$this->assertNotEmpty( $success_event );
+		$this->assertSame( $mcp_tool, $this->registry->get_mcp_tool( 'direct-mcp-tool' ) );
+		$this->assertArrayHasKey( 'direct-mcp-tool', $this->registry->get_tools() );
 	}
 
 	public function test_register_resources_with_valid_ability(): void {
@@ -207,7 +191,7 @@ final class McpComponentRegistryTest extends TestCase {
 
 		// Get the first resource
 		$resource = array_values( $resources )[0];
-		$this->assertInstanceOf( \WP\MCP\Domain\Resources\McpResource::class, $resource );
+		$this->assertInstanceOf( \WP\McpSchema\Server\Resources\DTO\Resource::class, $resource );
 
 		// Verify observability event was recorded
 		$events = DummyObservabilityHandler::$events;
@@ -261,7 +245,7 @@ final class McpComponentRegistryTest extends TestCase {
 
 		// Get the first prompt
 		$prompt = array_values( $prompts )[0];
-		$this->assertInstanceOf( \WP\MCP\Domain\Prompts\McpPrompt::class, $prompt );
+		$this->assertInstanceOf( \WP\McpSchema\Server\Prompts\DTO\Prompt::class, $prompt );
 
 		// Verify observability event was recorded
 		$events = DummyObservabilityHandler::$events;
@@ -290,8 +274,8 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertArrayHasKey( 'test-registry-prompt', $prompts );
 
 		$prompt = $prompts['test-registry-prompt'];
-		$this->assertInstanceOf( \WP\MCP\Domain\Prompts\McpPrompt::class, $prompt );
-		$this->assertTrue( $prompt->is_builder_based() );
+		$this->assertInstanceOf( \WP\McpSchema\Server\Prompts\DTO\Prompt::class, $prompt );
+		$this->assertNotNull( $this->registry->get_prompt_builder( 'test-registry-prompt' ) );
 
 		// Verify observability event was recorded
 		$events = DummyObservabilityHandler::$events;
@@ -337,38 +321,38 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertNotEmpty( $failure_event );
 	}
 
-	public function test_get_tool_by_name(): void {
+	public function test_get_mcp_tool_by_name(): void {
 		$this->registry->register_tools( array( 'test/always-allowed' ) );
 
-		$tool = $this->registry->get_tool( 'test-always-allowed' );
-		$this->assertInstanceOf( \WP\MCP\Domain\Tools\McpTool::class, $tool );
-		$this->assertEquals( 'test-always-allowed', $tool->get_name() );
+		$mcp_tool = $this->registry->get_mcp_tool( 'test-always-allowed' );
+		$this->assertInstanceOf( \WP\MCP\Domain\Tools\McpTool::class, $mcp_tool );
+		$this->assertEquals( 'test-always-allowed', $mcp_tool->get_component()->getName() );
 
-		$nonexistent = $this->registry->get_tool( 'nonexistent' );
+		$nonexistent = $this->registry->get_mcp_tool( 'nonexistent' );
 		$this->assertNull( $nonexistent );
 	}
 
-	public function test_get_resource_by_uri(): void {
+	public function test_get_mcp_resource_by_uri(): void {
 		$this->registry->register_resources( array( 'test/resource' ) );
 
 		$resources = $this->registry->get_resources();
 		$this->assertNotEmpty( $resources );
 
 		$resource_uri = array_keys( $resources )[0];
-		$resource     = $this->registry->get_resource( $resource_uri );
-		$this->assertInstanceOf( \WP\MCP\Domain\Resources\McpResource::class, $resource );
+		$mcp_resource = $this->registry->get_mcp_resource( $resource_uri );
+		$this->assertInstanceOf( \WP\MCP\Domain\Resources\McpResource::class, $mcp_resource );
 
-		$nonexistent = $this->registry->get_resource( 'nonexistent://resource' );
+		$nonexistent = $this->registry->get_mcp_resource( 'nonexistent://resource' );
 		$this->assertNull( $nonexistent );
 	}
 
-	public function test_get_prompt_by_name(): void {
+	public function test_get_mcp_prompt_by_name(): void {
 		$this->registry->register_prompts( array( 'test/prompt' ) );
 
-		$prompt = $this->registry->get_prompt( 'test-prompt' );
-		$this->assertInstanceOf( \WP\MCP\Domain\Prompts\McpPrompt::class, $prompt );
+		$mcp_prompt = $this->registry->get_mcp_prompt( 'test-prompt' );
+		$this->assertInstanceOf( \WP\MCP\Domain\Prompts\McpPrompt::class, $mcp_prompt );
 
-		$nonexistent = $this->registry->get_prompt( 'nonexistent' );
+		$nonexistent = $this->registry->get_mcp_prompt( 'nonexistent' );
 		$this->assertNull( $nonexistent );
 	}
 
@@ -403,92 +387,6 @@ final class McpComponentRegistryTest extends TestCase {
 			}
 		);
 		$this->assertCount( 4, $success_events );
-	}
-
-	public function test_registry_with_validation_enabled(): void {
-		// Create registry with validation enabled
-		$registry_with_validation = new McpComponentRegistry(
-			$this->server,
-			new DummyErrorHandler(),
-			new DummyObservabilityHandler(),
-			true // Enable validation
-		);
-
-		// This should still work with valid abilities
-		$registry_with_validation->register_tools( array( 'test/always-allowed' ) );
-
-		$tools = $registry_with_validation->get_tools();
-		$this->assertCount( 1, $tools );
-
-		// Verify observability event was recorded
-		$events = DummyObservabilityHandler::$events;
-		$this->assertNotEmpty( $events );
-	}
-
-	public function test_register_tools_with_wp_error_from_validation(): void {
-		// Register an ability that will fail validation when validation is enabled
-		$this->register_ability_in_hook(
-			'test/invalid-tool',
-			array(
-				'label'               => 'Invalid Tool',
-				'description'         => '', // Empty description will fail validation
-				'category'            => 'test',
-				'input_schema'        => array( 'type' => 'object' ),
-				'execute_callback'    => static function () {
-					return array();
-				},
-				'permission_callback' => static function () {
-					return true;
-				},
-				'meta'                => array(
-					'mcp' => array(
-						'public' => true,
-					),
-				),
-			)
-		);
-
-		// Create registry with validation enabled
-		$registry_with_validation = new McpComponentRegistry(
-			$this->server,
-			new DummyErrorHandler(),
-			new DummyObservabilityHandler(),
-			true // Enable validation
-		);
-
-		// Clear previous events
-		DummyObservabilityHandler::$events = array();
-		DummyErrorHandler::$logs           = array();
-
-		// Register the invalid tool
-		$registry_with_validation->register_tools( array( 'test/invalid-tool' ) );
-
-		// Tool should not be registered due to validation failure
-		$tools = $registry_with_validation->get_tools();
-		$this->assertCount( 0, $tools );
-
-		// Verify error was logged
-		$this->assertNotEmpty( DummyErrorHandler::$logs );
-		$log_messages = array_column( DummyErrorHandler::$logs, 'message' );
-		$this->assertStringContainsString( 'WordPress ability \'test/invalid-tool\' does not exist.', implode( ' ', $log_messages ) );
-
-		// Verify failure event was recorded
-		$events = DummyObservabilityHandler::$events;
-		$this->assertNotEmpty( $events );
-		$failure_event = array_filter(
-			$events,
-			static function ( $event ) {
-				return 'mcp.component.registration' === $event['event']
-					&& isset( $event['tags']['status'] )
-					&& 'failed' === $event['tags']['status']
-					&& isset( $event['tags']['component_type'] )
-					&& 'ability_tool' === $event['tags']['component_type'];
-			}
-		);
-		$this->assertNotEmpty( $failure_event );
-
-		// Clean up
-		wp_unregister_ability( 'test/invalid-tool' );
 	}
 
 	public function test_register_resources_with_missing_uri(): void {
@@ -586,185 +484,7 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertNotEmpty( $failure_event );
 	}
 
-	public function test_add_tool_with_validation_failure(): void {
-		// Create registry with validation enabled
-		$registry_with_validation = new McpComponentRegistry(
-			$this->server,
-			new DummyErrorHandler(),
-			new DummyObservabilityHandler(),
-			true // Enable validation
-		);
-
-		// Create an invalid tool (empty description)
-		$invalid_tool = new McpTool(
-			'test/invalid',
-			'invalid-tool',
-			'', // Empty description will fail validation
-			array( 'type' => 'object' )
-		);
-		$invalid_tool->set_mcp_server( $this->server );
-
-		// Clear previous events
-		DummyObservabilityHandler::$events = array();
-		DummyErrorHandler::$logs           = array();
-
-		// Try to add the invalid tool
-		$registry_with_validation->add_tool( $invalid_tool );
-
-		// Tool should not be registered
-		$tools = $registry_with_validation->get_tools();
-		$this->assertCount( 0, $tools );
-
-		// Verify error was logged
-		$this->assertNotEmpty( DummyErrorHandler::$logs );
-		$log_messages = array_column( DummyErrorHandler::$logs, 'message' );
-		$this->assertStringContainsString( 'Tool validation failed', implode( ' ', $log_messages ) );
-
-		// Verify failure event was recorded
-		$events = DummyObservabilityHandler::$events;
-		$this->assertNotEmpty( $events );
-		$failure_event = array_filter(
-			$events,
-			static function ( $event ) {
-				return 'mcp.component.registration' === $event['event']
-					&& isset( $event['tags']['status'] )
-					&& 'failed' === $event['tags']['status']
-					&& isset( $event['tags']['component_type'] )
-					&& 'tool' === $event['tags']['component_type'];
-			}
-		);
-		$this->assertNotEmpty( $failure_event );
-	}
-
-	public function test_register_prompts_with_builder_validation_failure(): void {
-		// Create a prompt builder that will fail validation
-		$invalid_builder = new class() extends McpPromptBuilder {
-			protected function configure(): void {
-				$this->name        = ''; // Empty name will fail validation
-				$this->title       = 'Invalid Prompt';
-				$this->description = 'This prompt will fail validation';
-			}
-
-			public function handle( array $arguments ): array {
-				return array();
-			}
-
-			public function has_permission( array $arguments ): bool {
-				return true;
-			}
-		};
-
-		// Create registry with validation enabled
-		$registry_with_validation = new McpComponentRegistry(
-			$this->server,
-			new DummyErrorHandler(),
-			new DummyObservabilityHandler(),
-			true // Enable validation
-		);
-
-		// Clear previous events
-		DummyObservabilityHandler::$events = array();
-		DummyErrorHandler::$logs           = array();
-
-		// Register the invalid prompt builder
-		$registry_with_validation->register_prompts( array( get_class( $invalid_builder ) ) );
-
-		// Prompt should not be registered
-		$prompts = $registry_with_validation->get_prompts();
-		$this->assertCount( 0, $prompts );
-
-		// Verify error was logged
-		$this->assertNotEmpty( DummyErrorHandler::$logs );
-		$log_messages = array_column( DummyErrorHandler::$logs, 'message' );
-		$this->assertStringContainsString( 'Prompt validation failed', implode( ' ', $log_messages ) );
-
-		// Verify failure event was recorded
-		$events = DummyObservabilityHandler::$events;
-		$this->assertNotEmpty( $events );
-		$failure_event = array_filter(
-			$events,
-			static function ( $event ) {
-				return 'mcp.component.registration' === $event['event']
-					&& isset( $event['tags']['status'] )
-					&& 'failed' === $event['tags']['status']
-					&& isset( $event['tags']['component_type'] )
-					&& 'prompt' === $event['tags']['component_type'];
-			}
-		);
-		$this->assertNotEmpty( $failure_event );
-	}
-
-	public function test_register_prompts_with_wp_error_from_ability(): void {
-		// Register an ability that will fail when converted to prompt (missing input_schema for validation)
-		$this->register_ability_in_hook(
-			'test/invalid-prompt-ability',
-			array(
-				'label'               => 'Invalid Prompt Ability',
-				'description'         => '', // Empty description might fail validation if enabled
-				'category'            => 'test',
-				// No input_schema - might cause issues
-				'execute_callback'    => static function () {
-					return array();
-				},
-				'permission_callback' => static function () {
-					return true;
-				},
-				'meta'                => array(
-					'mcp' => array(
-						'public' => true,
-						'type'   => 'prompt',
-					),
-				),
-			)
-		);
-
-		// Create registry with validation enabled to test WP_Error path
-		$registry_with_validation = new McpComponentRegistry(
-			$this->server,
-			new DummyErrorHandler(),
-			new DummyObservabilityHandler(),
-			true // Enable validation
-		);
-
-		// Clear previous events
-		DummyObservabilityHandler::$events = array();
-		DummyErrorHandler::$logs           = array();
-
-		// Register the prompt - this might fail validation
-		$registry_with_validation->register_prompts( array( 'test/invalid-prompt-ability' ) );
-
-		// Verify error was logged (if validation failed)
-		// The exact behavior depends on prompt validation rules
-		$events = DummyObservabilityHandler::$events;
-		if ( ! empty( DummyErrorHandler::$logs ) ) {
-			// If validation failed, verify the failure was logged
-			$log_messages = array_column( DummyErrorHandler::$logs, 'message' );
-			$has_error    = false;
-			foreach ( $log_messages as $message ) {
-				if ( strpos( $message, 'test/invalid-prompt-ability' ) !== false ) {
-					$has_error = true;
-					break;
-				}
-			}
-			// Error should be logged if validation failed
-			if ( $has_error ) {
-				$failure_event = array_filter(
-					$events,
-					static function ( $event ) {
-						return 'mcp.component.registration' === $event['event']
-							&& isset( $event['tags']['status'] )
-							&& 'failed' === $event['tags']['status'];
-					}
-				);
-				$this->assertNotEmpty( $failure_event, 'Failure event should be recorded when validation fails' );
-			}
-		}
-
-		// Clean up
-		wp_unregister_ability( 'test/invalid-prompt-ability' );
-	}
-
-	// Note: Validation failure tests require complex setup and are covered in integration tests
+	// Note: DTO schema validation is handled by the php-mcp-schema DTO constructors.
 
 	public function test_register_resources_skips_non_strings(): void {
 		$this->registry->register_resources( array( 123, null, array(), 'test/resource' ) );
@@ -788,8 +508,7 @@ final class McpComponentRegistryTest extends TestCase {
 		$registry_no_observability = new McpComponentRegistry(
 			$this->server,
 			new DummyErrorHandler(),
-			new DummyObservabilityHandler(),
-			false
+			new DummyObservabilityHandler()
 		);
 
 		// Clear events from previous tests
@@ -807,5 +526,381 @@ final class McpComponentRegistryTest extends TestCase {
 
 		// Re-enable the filter for subsequent tests
 		add_filter( 'mcp_adapter_observability_record_component_registration', '__return_true' );
+	}
+
+	/**
+	 * Test that registry continues processing other tools when one tool name is invalid.
+	 *
+	 * This verifies that:
+	 * 1. Invalid tool names don't break MCP functionality
+	 * 2. Invalid tool names don't break the WordPress site
+	 * 3. Errors are logged for invalid tools
+	 * 4. Other valid tools are still registered
+	 */
+	public function test_register_tools_continues_after_invalid_tool_name(): void {
+		// Register two test abilities.
+		$this->register_ability_in_hook(
+			'test/first-valid-tool',
+			array(
+				'label'               => 'First Valid Tool',
+				'description'         => 'First tool for continue test',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'ok';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array( 'public' => true ),
+				),
+			)
+		);
+
+		$this->register_ability_in_hook(
+			'test/will-be-invalid',
+			array(
+				'label'               => 'Will Be Invalid Tool',
+				'description'         => 'This tool name will be invalidated by filter',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'ok';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array( 'public' => true ),
+				),
+			)
+		);
+
+		$this->register_ability_in_hook(
+			'test/second-valid-tool',
+			array(
+				'label'               => 'Second Valid Tool',
+				'description'         => 'Second tool for continue test',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return 'ok';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array( 'public' => true ),
+				),
+			)
+		);
+
+		// Filter that invalidates the middle tool's name by returning invalid characters.
+		$filter_callback = static function ( $name ) {
+			if ( 'test-will-be-invalid' === $name ) {
+				return 'invalid name with spaces!!!'; // Invalid: contains spaces and special chars
+			}
+			return $name;
+		};
+		add_filter( 'mcp_adapter_tool_name', $filter_callback );
+
+		// Clear previous logs and events.
+		DummyErrorHandler::$logs           = array();
+		DummyObservabilityHandler::$events = array();
+
+		// Register all three tools - the middle one will fail.
+		$this->registry->register_tools(
+			array(
+				'test/first-valid-tool',
+				'test/will-be-invalid',
+				'test/second-valid-tool',
+			)
+		);
+
+		// Verify both valid tools were registered (invalid one was skipped).
+		$tools = $this->registry->get_tools();
+		$this->assertCount( 2, $tools, 'Both valid tools should be registered despite one invalid tool' );
+		$this->assertArrayHasKey( 'test-first-valid-tool', $tools );
+		$this->assertArrayHasKey( 'test-second-valid-tool', $tools );
+		$this->assertArrayNotHasKey( 'test-will-be-invalid', $tools );
+
+		// Verify error was logged for the invalid tool.
+		$this->assertNotEmpty( DummyErrorHandler::$logs, 'Error should be logged for invalid tool' );
+		$log_messages = array_column( DummyErrorHandler::$logs, 'message' );
+		$this->assertStringContainsString( 'invalid', implode( ' ', $log_messages ) );
+
+		// Verify observability events: 2 successes and 1 failure.
+		$events = DummyObservabilityHandler::$events;
+		$this->assertNotEmpty( $events );
+
+		$success_events = array_filter(
+			$events,
+			static function ( $event ) {
+				return 'mcp.component.registration' === $event['event']
+					&& isset( $event['tags']['status'] )
+					&& 'success' === $event['tags']['status'];
+			}
+		);
+		$this->assertCount( 2, $success_events, 'Two tools should have successful registration events' );
+
+		$failure_events = array_filter(
+			$events,
+			static function ( $event ) {
+				return 'mcp.component.registration' === $event['event']
+					&& isset( $event['tags']['status'] )
+					&& 'failed' === $event['tags']['status'];
+			}
+		);
+		$this->assertCount( 1, $failure_events, 'One tool should have a failed registration event' );
+
+		// Clean up.
+		remove_filter( 'mcp_adapter_tool_name', $filter_callback );
+		wp_unregister_ability( 'test/first-valid-tool' );
+		wp_unregister_ability( 'test/will-be-invalid' );
+		wp_unregister_ability( 'test/second-valid-tool' );
+	}
+
+	/**
+	 * Test that duplicate resource URIs are detected and first registration wins.
+	 */
+	public function test_register_resources_duplicate_uri_first_wins(): void {
+		// Register two abilities with the same URI.
+		$same_uri = 'WordPress://test/duplicate-uri-resource';
+
+		$this->register_ability_in_hook(
+			'test/resource-first',
+			array(
+				'label'               => 'First Resource',
+				'description'         => 'First resource with this URI',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'first content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => $same_uri,
+					),
+				),
+			)
+		);
+
+		$this->register_ability_in_hook(
+			'test/resource-second',
+			array(
+				'label'               => 'Second Resource',
+				'description'         => 'Second resource with same URI',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'second content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => $same_uri,
+					),
+				),
+			)
+		);
+
+		// Clear previous events and logs.
+		DummyObservabilityHandler::$events = array();
+		DummyErrorHandler::$logs           = array();
+
+		// Register both resources (second will be duplicate).
+		$this->registry->register_resources( array( 'test/resource-first', 'test/resource-second' ) );
+
+		// Verify only one resource is registered.
+		$resources = $this->registry->get_resources();
+		$this->assertCount( 1, $resources, 'Only first resource should be registered (first-wins policy)' );
+			$this->assertArrayHasKey( $same_uri, $resources );
+
+			// Verify the registered resource is from the first ability.
+			$mcp_resource = $this->registry->get_mcp_resource( $same_uri );
+			$this->assertNotNull( $mcp_resource );
+			$meta = $mcp_resource->get_adapter_meta();
+			$this->assertSame( 'test/resource-first', $meta['ability'] ?? null, 'First ability should win' );
+
+		// Clean up.
+		wp_unregister_ability( 'test/resource-first' );
+		wp_unregister_ability( 'test/resource-second' );
+	}
+
+	/**
+	 * Test that duplicate resource URIs are logged via error handler.
+	 */
+	public function test_register_resources_duplicate_uri_logs_error(): void {
+		// Register two abilities with the same URI.
+		$same_uri = 'WordPress://test/duplicate-uri-logged';
+
+		$this->register_ability_in_hook(
+			'test/resource-alpha',
+			array(
+				'label'               => 'Alpha Resource',
+				'description'         => 'Alpha resource',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'alpha';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => $same_uri,
+					),
+				),
+			)
+		);
+
+		$this->register_ability_in_hook(
+			'test/resource-beta',
+			array(
+				'label'               => 'Beta Resource',
+				'description'         => 'Beta resource (duplicate)',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'beta';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => $same_uri,
+					),
+				),
+			)
+		);
+
+		// Clear previous logs.
+		DummyErrorHandler::$logs = array();
+
+		// Register both resources.
+		$this->registry->register_resources( array( 'test/resource-alpha', 'test/resource-beta' ) );
+
+		// Verify error was logged for the duplicate.
+		$this->assertNotEmpty( DummyErrorHandler::$logs, 'Error should be logged for duplicate URI' );
+
+		$log_messages = array_column( DummyErrorHandler::$logs, 'message' );
+		$combined     = implode( ' ', $log_messages );
+
+		// Verify the error message contains the URI (simplified message from add_mcp_resource).
+		$this->assertStringContainsString( 'already registered', $combined );
+		$this->assertStringContainsString( $same_uri, $combined );
+
+		// Clean up.
+		wp_unregister_ability( 'test/resource-alpha' );
+		wp_unregister_ability( 'test/resource-beta' );
+	}
+
+	/**
+	 * Test that duplicate resource URIs record observability event.
+	 */
+	public function test_register_resources_duplicate_uri_records_observability_event(): void {
+		// Register two abilities with the same URI.
+		$same_uri = 'WordPress://test/duplicate-uri-observed';
+
+		$this->register_ability_in_hook(
+			'test/resource-observer-first',
+			array(
+				'label'               => 'Observer First',
+				'description'         => 'First resource for observability test',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'first';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => $same_uri,
+					),
+				),
+			)
+		);
+
+		$this->register_ability_in_hook(
+			'test/resource-observer-second',
+			array(
+				'label'               => 'Observer Second',
+				'description'         => 'Second resource for observability test',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'second';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => $same_uri,
+					),
+				),
+			)
+		);
+
+		// Clear previous events.
+		DummyObservabilityHandler::$events = array();
+
+		// Register both resources.
+		$this->registry->register_resources( array( 'test/resource-observer-first', 'test/resource-observer-second' ) );
+
+		// Verify observability events: 1 success + 1 failure.
+		$events = DummyObservabilityHandler::$events;
+		$this->assertNotEmpty( $events );
+
+		// Find the duplicate failure event.
+		$duplicate_events = array_filter(
+			$events,
+			static function ( $event ) {
+				return 'mcp.component.registration' === $event['event']
+					&& isset( $event['tags']['status'] )
+					&& 'failed' === $event['tags']['status']
+					&& isset( $event['tags']['failure_reason'] )
+					&& 'duplicate_uri' === $event['tags']['failure_reason'];
+			}
+		);
+		$this->assertCount( 1, $duplicate_events, 'Should have one duplicate_uri failure event' );
+
+		// Verify the event contains expected data.
+		$duplicate_event = array_values( $duplicate_events )[0];
+		$this->assertSame( 'test/resource-observer-second', $duplicate_event['tags']['component_name'] );
+		$this->assertSame( $same_uri, $duplicate_event['tags']['duplicate_uri'] );
+
+		// Verify success event for first resource.
+		$success_events = array_filter(
+			$events,
+			static function ( $event ) {
+				return 'mcp.component.registration' === $event['event']
+					&& isset( $event['tags']['status'] )
+					&& 'success' === $event['tags']['status']
+					&& isset( $event['tags']['component_type'] )
+					&& 'resource' === $event['tags']['component_type'];
+			}
+		);
+		$this->assertCount( 1, $success_events, 'Should have one success event for the first resource' );
+
+		// Clean up.
+		wp_unregister_ability( 'test/resource-observer-first' );
+		wp_unregister_ability( 'test/resource-observer-second' );
 	}
 }

--- a/tests/Unit/Core/McpComponentRegistryTest.php
+++ b/tests/Unit/Core/McpComponentRegistryTest.php
@@ -15,6 +15,9 @@ use WP\MCP\Domain\Prompts\McpPromptBuilder;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
+use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
+use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 // Test prompt builder for registry testing
 // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
@@ -106,7 +109,7 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertArrayHasKey( 'test-always-allowed', $tools );
 
 		$tool = $tools['test-always-allowed'];
-		$this->assertInstanceOf( \WP\McpSchema\Server\Tools\DTO\Tool::class, $tool );
+		$this->assertInstanceOf( ToolDto::class, $tool );
 		$this->assertEquals( 'test-always-allowed', $tool->getName() );
 
 		// Verify observability event was recorded
@@ -191,7 +194,7 @@ final class McpComponentRegistryTest extends TestCase {
 
 		// Get the first resource
 		$resource = array_values( $resources )[0];
-		$this->assertInstanceOf( \WP\McpSchema\Server\Resources\DTO\Resource::class, $resource );
+		$this->assertInstanceOf( ResourceDto::class, $resource );
 
 		// Verify observability event was recorded
 		$events = DummyObservabilityHandler::$events;
@@ -245,7 +248,7 @@ final class McpComponentRegistryTest extends TestCase {
 
 		// Get the first prompt
 		$prompt = array_values( $prompts )[0];
-		$this->assertInstanceOf( \WP\McpSchema\Server\Prompts\DTO\Prompt::class, $prompt );
+		$this->assertInstanceOf( PromptDto::class, $prompt );
 
 		// Verify observability event was recorded
 		$events = DummyObservabilityHandler::$events;
@@ -274,7 +277,7 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertArrayHasKey( 'test-registry-prompt', $prompts );
 
 		$prompt = $prompts['test-registry-prompt'];
-		$this->assertInstanceOf( \WP\McpSchema\Server\Prompts\DTO\Prompt::class, $prompt );
+		$this->assertInstanceOf( PromptDto::class, $prompt );
 		$this->assertNotNull( $this->registry->get_prompt_builder( 'test-registry-prompt' ) );
 
 		// Verify observability event was recorded
@@ -326,7 +329,7 @@ final class McpComponentRegistryTest extends TestCase {
 
 		$mcp_tool = $this->registry->get_mcp_tool( 'test-always-allowed' );
 		$this->assertInstanceOf( \WP\MCP\Domain\Tools\McpTool::class, $mcp_tool );
-		$this->assertEquals( 'test-always-allowed', $mcp_tool->get_component()->getName() );
+		$this->assertEquals( 'test-always-allowed', $mcp_tool->get_protocol_dto()->getName() );
 
 		$nonexistent = $this->registry->get_mcp_tool( 'nonexistent' );
 		$this->assertNull( $nonexistent );

--- a/tests/Unit/Servers/DefaultServerFactoryTest.php
+++ b/tests/Unit/Servers/DefaultServerFactoryTest.php
@@ -77,7 +77,7 @@ final class DefaultServerFactoryTest extends TestCase {
 		$resources = $server->get_resources();
 		$resource_names = array_map(
 			static function ( $resource ) {
-				return $resource->get_name();
+				return $resource->getName();
 			},
 			$resources
 		);
@@ -105,7 +105,7 @@ final class DefaultServerFactoryTest extends TestCase {
 		$prompts = $server->get_prompts();
 		$prompt_names = array_map(
 			static function ( $prompt ) {
-				return $prompt->get_name();
+				return $prompt->getName();
 			},
 			$prompts
 		);
@@ -159,7 +159,7 @@ final class DefaultServerFactoryTest extends TestCase {
 		$tools = $server->get_tools();
 		$tool_names = array_map(
 			static function ( $tool ) {
-				return $tool->get_name();
+				return $tool->getName();
 			},
 			$tools
 		);


### PR DESCRIPTION
## Summary

Updates the Core layer (McpAdapter, McpServer, McpComponentRegistry), built-in abilities, and plugin bootstrap to work with the new MCP schema DTOs.

## Changes

### Core
- `McpAdapter` — Updated server creation and management
- `McpServer` — Updated component access methods
- `McpComponentRegistry` — Updated to store DTO-based components
- `McpTransportFactory` — Updated transport instantiation

### Built-in Abilities
- `DiscoverAbilitiesAbility` — Updated response format
- `ExecuteAbilityAbility` — Updated execution flow
- `GetAbilityInfoAbility` — Updated info retrieval
- `McpAbilityHelperTrait` — Updated helper methods

### Plugin
- `Plugin` — Updated bootstrap sequence
- `Autoloader` — Updated class loading
- `DefaultServerFactory` — Updated default server creation

### CLI
- `McpCommand` — Updated CLI commands

### Tests
- Core component tests updated
- Ability tests updated
- Server factory tests updated

## Why

- Core layer now produces and consumes MCP schema DTOs
- Built-in abilities return properly formatted MCP responses
- Plugin initialization uses the new DTO-based flow

## Stacked PR

⚠️ **This is PR 5 of 6** in the MCP Schema integration series.

| # | Branch | Description |
|---|--------|-------------|
| 1 | `01-composer-deps` | Composer dependency |
| 2 | `02-infrastructure` | Error handling + observability |
| 3 | `03-domain-utils` | Domain contracts + utilities |
| 4 | `04-domain-components` | Tools, Resources, Prompts |
| **5** | **`05-core`** | **← You are here** |
| 6 | `06-handlers-transport` | Handlers + Transport + CLI |

**Merge order**: 1 → 2 → 3 → 4 → 5 → 6

## Testing

- [ ] Core component tests pass
- [ ] Ability tests pass
- [ ] Server factory tests pass