### PR TITLE
Fix: Preserve empty arrays instead of converting to null

### DIFF
--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -115,7 +115,7 @@ final class ExecuteAbilityAbility {
 		}
 
 		// Check if the user has permission to execute the target ability
-		$parameters        = empty( $input['parameters'] ) ? null : $input['parameters'];
+		$parameters        = $input['parameters'] ?? null;
 		$permission_result = $ability->check_permissions( $parameters );
 
 		// Return WP_Error as-is, or convert other values to boolean
@@ -161,7 +161,7 @@ final class ExecuteAbilityAbility {
 	 */
 	public static function execute( $input = array() ): array {
 		$ability_name = $input['ability_name'] ?? '';
-		$parameters   = empty( $input['parameters'] ) ? null : $input['parameters'];
+		$parameters   = $input['parameters'] ?? null;
 
 		if ( empty( $ability_name ) ) {
 			return array(


### PR DESCRIPTION
## Summary

Fixes a bug where abilities with empty parameter objects fail validation with "input is not of type object" error.

## Root Cause

In `ExecuteAbilityAbility.php`, both `check_permission()` and `execute()` methods used:
```php
$parameters = empty( $input['parameters'] ) ? null : $input['parameters'];
```

In PHP, `empty([])` returns `true` for empty arrays. When an MCP client calls an ability with empty parameters `{}`, this code converted the empty object to `null`, causing target abilities to fail validation because `rest_validate_value_from_schema()` expects an object type, not `null`.

### Example Failing Ability

Abilities with this input schema (empty object with no required properties):
```php
'input_schema' => array(
    'type' => 'object',
    'additionalProperties' => false,
),
```

Expect to receive `[]` (empty array), NOT `null`. When they receive `null`, WordPress's `rest_validate_value_from_schema()` fails with "input is not of type object".

## Fix

Changed both occurrences to use the null coalescing operator:
```php
$parameters = $input['parameters'] ?? null;
```

This preserves empty arrays as `[]` while still handling missing parameters correctly (`null` is only used when the key is truly absent).

## Test Verification

```php
// Before fix
empty([])          // true  → converts to null  → FAILS validation

// After fix
[] ?? null         // []    → passes validation
null ?? null       // null  → still works for missing params
```

## Impact

- Abilities that accept empty parameter objects now work correctly
- Existing behavior for abilities with required or optional parameters is unchanged
- The change is minimal and surgical - only 2 lines modified

## Testing

- All toolset abilities with no required parameters now work correctly
- Abilities with required parameters continue to work as expected
- The fix was verified against real-world abilities in the mcp-abilities-toolset plugin