### PR TITLE
Fix MCP HTTP response code compliance for notifications and sessions

### DIFF
--- a/includes/Infrastructure/ErrorHandling/McpErrorFactory.php
+++ b/includes/Infrastructure/ErrorHandling/McpErrorFactory.php
@@ -40,6 +40,7 @@ class McpErrorFactory {
 	public const RESOURCE_NOT_FOUND = -32002; // Resource not found
 	public const TOOL_NOT_FOUND     = -32003; // Tool not found
 	public const PROMPT_NOT_FOUND   = -32004; // Prompt not found
+	public const SESSION_NOT_FOUND  = -32005; // Session not found or expired
 	public const PERMISSION_DENIED  = -32008; // Access denied/forbidden
 	public const UNAUTHORIZED       = -32010; // Authentication required
 
@@ -289,6 +290,26 @@ class McpErrorFactory {
 	}
 
 	/**
+	 * Create a session not found error response.
+	 *
+	 * Used when an MCP session ID is invalid or expired. Maps to HTTP 404
+	 * per the MCP specification requirement for invalid/expired sessions.
+	 *
+	 * @param string|int|null $id The request ID.
+	 * @param string $details Optional additional details.
+	 *
+	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 */
+	public static function session_not_found( $id, string $details = '' ): JSONRPCErrorResponse {
+		$message = __( 'Session not found', 'mcp-adapter' );
+		if ( $details ) {
+			$message .= ': ' . $details;
+		}
+
+		return self::create_error_response( $id, self::SESSION_NOT_FOUND, $message );
+	}
+
+	/**
 	 * Create a permission denied error response.
 	 *
 	 * @param string|int|null $id The request ID.
@@ -381,6 +402,7 @@ class McpErrorFactory {
 			case self::RESOURCE_NOT_FOUND:
 			case self::TOOL_NOT_FOUND:
 			case self::PROMPT_NOT_FOUND:
+			case self::SESSION_NOT_FOUND:
 			case self::METHOD_NOT_FOUND:
 				return 404;
 

--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -121,6 +121,12 @@ class HttpRequestHandler {
 			}
 		);
 
+		// Per MCP spec 2025-06-18: Notifications return HTTP 202 Accepted with no body.
+		// A null response_body indicates only notifications were processed (no requests with IDs).
+		if ( null === $response_body ) {
+			return new \WP_REST_Response( null, 202 );
+		}
+
 		// Determine HTTP status code based on error type
 		if ( ! $is_batch_request && isset( $response_body['error'] ) ) {
 			$http_status = McpErrorFactory::get_http_status_for_error( $response_body );
@@ -156,6 +162,8 @@ class HttpRequestHandler {
 			return $this->process_jsonrpc_request( $message, $context );
 		}
 
+		// JSON-RPC responses from client (has result/error, no method) also return null.
+		// Per MCP spec: client responses get HTTP 202 Accepted with no body, same as notifications.
 		return null;
 	}
 

--- a/includes/Transport/Infrastructure/HttpSessionValidator.php
+++ b/includes/Transport/Infrastructure/HttpSessionValidator.php
@@ -44,7 +44,7 @@ class HttpSessionValidator {
 
 		// Validate session using SessionManager
 		if ( ! SessionManager::validate_session( $user_id, $session_id ) ) {
-			return McpErrorFactory::invalid_params( null, 'Invalid or expired session' )->toArray();
+			return McpErrorFactory::session_not_found( null, 'Invalid or expired session' )->toArray();
 		}
 
 		return true;

--- a/tests/Integration/HttpTransportTest.php
+++ b/tests/Integration/HttpTransportTest.php
@@ -150,9 +150,9 @@ final class HttpTransportTest extends TestCase {
 
 		$response = $this->transport->handle_request( $request );
 
-		// Notifications return 200 with null body in JSON-RPC over HTTP
+		// Notifications return HTTP 202 Accepted with no body per MCP spec
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 202, $response->get_status() );
 		$this->assertNull( $response->get_data() );
 	}
 
@@ -468,15 +468,15 @@ final class HttpTransportTest extends TestCase {
 		$response = $this->transport->handle_request( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertEquals( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		// Debug: check what we actually get
 		if ( ! isset( $data['result'] ) ) {
-			// If it's an error, that's expected since session might not be properly created
+			// Session not found returns HTTP 404 per MCP spec
+			$this->assertEquals( 404, $response->get_status() );
 			$this->assertArrayHasKey( 'error', $data );
 			$this->assertStringContainsString( 'session', strtolower( $data['error']['message'] ) );
 		} else {
+			$this->assertEquals( 200, $response->get_status() );
 			$this->assertArrayHasKey( 'result', $data );
 		}
 	}
@@ -495,11 +495,11 @@ final class HttpTransportTest extends TestCase {
 		$response = $this->transport->handle_request( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 404, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertArrayHasKey( 'error', $data );
-		$this->assertEquals( McpErrorFactory::INVALID_PARAMS, $data['error']['code'] );
+		$this->assertEquals( McpErrorFactory::SESSION_NOT_FOUND, $data['error']['code'] );
 		$this->assertStringContainsString( 'Invalid or expired session', $data['error']['message'] );
 	}
 

--- a/tests/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
+++ b/tests/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
@@ -164,7 +164,7 @@ final class HttpRequestHandlerTest extends TestCase {
 		$response = $this->handler->handle_request( $context );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 404, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertArrayHasKey( 'error', $data );
@@ -210,11 +210,15 @@ final class HttpRequestHandlerTest extends TestCase {
 		$response = $this->handler->handle_request( $context );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertEquals( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		// Should either have result or error (depending on session validation)
+		// Should either have result (200) or session error (404 per MCP spec)
 		$this->assertTrue( isset( $data['result'] ) || isset( $data['error'] ) );
+		if ( isset( $data['error'] ) ) {
+			$this->assertEquals( 404, $response->get_status() );
+		} else {
+			$this->assertEquals( 200, $response->get_status() );
+		}
 	}
 
 	public function test_handle_request_post_batch(): void {

--- a/tests/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
+++ b/tests/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
@@ -284,7 +284,7 @@ final class HttpRequestHandlerTest extends TestCase {
 		$response = $this->handler->handle_request( $context );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 202, $response->get_status() );
 		$this->assertNull( $response->get_data() );
 	}
 

--- a/tests/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
+++ b/tests/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
@@ -178,7 +178,7 @@ final class HttpSessionValidatorTest extends TestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'error', $result );
-		$this->assertEquals( McpErrorFactory::INVALID_PARAMS, $result['error']['code'] );
+		$this->assertEquals( McpErrorFactory::SESSION_NOT_FOUND, $result['error']['code'] );
 		$this->assertStringContainsString( 'Invalid or expired session', $result['error']['message'] );
 	}
 


### PR DESCRIPTION
## What

Fixes the MCP Streamable HTTP transport to return spec-compliant HTTP status codes in two cases:

1. **Notifications now return HTTP 202 Accepted** instead of 200 — adds a null-check in `HttpRequestHandler` that returns `WP_REST_Response(null, 202)` when only notifications were processed.
2. **Invalid/expired sessions now return HTTP 404 Not Found** instead of 200 — introduces a new `SESSION_NOT_FOUND` (-32005) error code in `McpErrorFactory` and updates `HttpSessionValidator` to use it.
3. **Client JSON-RPC response handling** — adds an explicit comment documenting the fall-through path that correctly returns 202 per spec.

## Why

The MCP specification (2025-06-18 and 2025-11-25) requires specific HTTP status codes for the Streamable HTTP transport:

- Notifications/responses from client → **202 Accepted** (no body)
- Invalid/expired session → **404 Not Found** (MUST)

The transport was returning HTTP 200 in both cases because:
- The notification path had no explicit null-check before the error-status logic
- Session validation used `McpErrorFactory::invalid_params()` (code -32602), which maps to HTTP 200 in the error-to-status switch

## Changes

| File | Change |
|------|--------|
| `McpErrorFactory.php` | Add `SESSION_NOT_FOUND = -32005` constant, `session_not_found()` factory method, and 404 mapping in `mcp_error_to_http_status()` |
| `HttpSessionValidator.php` | Use `session_not_found()` instead of `invalid_params()` for expired sessions |
| `HttpRequestHandler.php` | Add 202 null-check for notifications + comment for JSON-RPC response fall-through |
| `HttpTransportTest.php` | Update 3 assertions (202 notification, 404 sessions) |
| `HttpRequestHandlerTest.php` | Update 2 assertions (404 sessions) |
| `HttpSessionValidatorTest.php` | Update 1 assertion (SESSION_NOT_FOUND error code) |

## Verification

- 934 PHPUnit tests pass (0 failures, 3663 assertions)
- PHPCS clean
- PHPStan Level 8 — zero errors

Closes #125