### PR TITLE
Adopt list<T> type annotations for sequential arrays

### DIFF
--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -158,9 +158,9 @@ final class McpAdapter {
 	 * @param array<class-string<\WP\MCP\Transport\Contracts\McpTransportInterface>> $mcp_transports Array of MCP transport class names to initialize.
 	 * @param class-string<\WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface>|null $error_handler The error handler class name. If null, NullMcpErrorHandler will be used.
 	 * @param class-string<\WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface>|null $observability_handler The observability handler class name. If null, NullMcpObservabilityHandler will be used.
-	 * @param array<string> $tools Ability names to register as tools.
-	 * @param array<string> $resources Resources to register.
-	 * @param array<string> $prompts Prompts to register.
+	 * @param list<string> $tools Ability names to register as tools.
+	 * @param list<string> $resources Resources to register.
+	 * @param list<string> $prompts Prompts to register.
 	 * @param callable|null $transport_permission_callback Optional custom permission callback for transport-level authentication. If null, defaults to is_user_logged_in().
 	 *
 	 * @return \WP\MCP\Core\McpAdapter|\WP_Error McpAdapter instance on success, WP_Error on failure.

--- a/includes/Core/McpComponentRegistry.php
+++ b/includes/Core/McpComponentRegistry.php
@@ -115,7 +115,7 @@ class McpComponentRegistry {
 	/**
 	 * Register tools to the server.
 	 *
-	 * @param array<int, string|\WP\MCP\Domain\Tools\McpTool> $tools Array of ability names (strings) or McpTool instances.
+	 * @param list<string|\WP\MCP\Domain\Tools\McpTool> $tools Array of ability names (strings) or McpTool instances.
 	 *
 	 * @return void
 	 */
@@ -254,7 +254,7 @@ class McpComponentRegistry {
 	/**
 	 * Register resources to the server.
 	 *
-	 * @param array<int, string|\WP\MCP\Domain\Resources\McpResource> $resources Array of ability names or McpResource instances.
+	 * @param list<string|\WP\MCP\Domain\Resources\McpResource> $resources Array of ability names or McpResource instances.
 	 *
 	 * @return void
 	 */
@@ -393,7 +393,7 @@ class McpComponentRegistry {
 	 * - McpPromptBuilderInterface instance (fluent API or custom builders)
 	 * - Array configuration (converted via McpPrompt::fromArray())
 	 *
-	 * @param array<int, string|\WP\MCP\Domain\Prompts\McpPrompt|\WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface> $prompts Array of prompts to register.
+	 * @param list<string|\WP\MCP\Domain\Prompts\McpPrompt|\WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface> $prompts Array of prompts to register.
 	 *
 	 * @return void
 	 */

--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -121,9 +121,9 @@ class McpServer {
 	 * @param array<class-string<\WP\MCP\Transport\Contracts\McpTransportInterface>> $mcp_transports Array of MCP transport class names to initialize (e.g., [McpRestTransport::class]).
 	 * @param class-string<\WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface>|null $error_handler Error handler class to use (e.g., NullMcpErrorHandler::class). Must implement McpErrorHandlerInterface. If null, NullMcpErrorHandler will be used.
 	 * @param class-string<\WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface>|null $observability_handler Observability handler class to use (e.g., NullMcpObservabilityHandler::class). Must implement McpObservabilityHandlerInterface. If null, NullMcpObservabilityHandler will be used.
-	 * @param array<string> $tools Optional ability names to register as tools during construction.
-	 * @param array<string> $resources Optional resources to register during construction.
-	 * @param array<string> $prompts Optional prompts to register during construction.
+	 * @param list<string> $tools Optional ability names to register as tools during construction.
+	 * @param list<string> $resources Optional resources to register during construction.
+	 * @param list<string> $prompts Optional prompts to register during construction.
 	 * @param callable|null $transport_permission_callback Optional custom permission callback for transport-level authentication. If null, defaults to is_user_logged_in().
 	 *
 	 * @throws \Exception Thrown if the MCP transport class does not extend AbstractMcpTransport.
@@ -201,9 +201,9 @@ class McpServer {
 	/**
 	 * Setup component registry and transport factory.
 	 *
-	 * @param array<string> $tools Tools to register.
-	 * @param array<string> $resources Resources to register.
-	 * @param array<string> $prompts Prompts to register.
+	 * @param list<string> $tools Tools to register.
+	 * @param list<string> $resources Resources to register.
+	 * @param list<string> $prompts Prompts to register.
 	 * @param array<class-string<\WP\MCP\Transport\Contracts\McpTransportInterface>> $mcp_transports Transport classes to initialize.
 	 *
 	 * @throws \Exception
@@ -229,9 +229,9 @@ class McpServer {
 	/**
 	 * Register initial tools, resources, and prompts.
 	 *
-	 * @param array<string> $tools Tools to register.
-	 * @param array<string> $resources Resources to register.
-	 * @param array<string> $prompts Prompts to register.
+	 * @param list<string> $tools Tools to register.
+	 * @param list<string> $resources Resources to register.
+	 * @param list<string> $prompts Prompts to register.
 	 */
 	private function register_mcp_components( array $tools, array $resources, array $prompts ): void {
 		// Register tools if provided

--- a/includes/Domain/Prompts/McpPromptBuilder.php
+++ b/includes/Domain/Prompts/McpPromptBuilder.php
@@ -71,7 +71,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	/**
 	 * The prompt arguments.
 	 *
-	 * @var array<int, array{name: string, title?: string, description?: string, required?: bool}>
+	 * @var list<array{name: string, title?: string, description?: string, required?: bool}>
 	 */
 	protected array $arguments = array();
 
@@ -80,7 +80,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @var array<int, array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}>|null
+	 * @var list<array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}>|null
 	 */
 	protected ?array $icons = null;
 
@@ -205,7 +205,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	/**
 	 * Get the prompt arguments.
 	 *
-	 * @return array<int, array{name: string, title?: string, description?: string, required?: bool}> The prompt arguments.
+	 * @return list<array{name: string, title?: string, description?: string, required?: bool}> The prompt arguments.
 	 */
 	public function get_arguments(): array {
 		return $this->arguments;
@@ -214,7 +214,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	/**
 	 * Get the prompt icons.
 	 *
-	 * @return array<int, array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}> The prompt icons.
+	 * @return list<array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}> The prompt icons.
 	 * @since n.e.x.t
 	 *
 	 */
@@ -232,7 +232,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * - MUST support: image/png, image/jpeg, image/jpg
 	 * - SHOULD support: image/svg+xml, image/webp
 	 *
-	 * @param array<int, array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}> $icons Array of icon definitions.
+	 * @param list<array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}> $icons Array of icon definitions.
 	 *
 	 * @return self
 	 * @since n.e.x.t

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -265,7 +265,7 @@ class RegisterAbilityAsMcpPrompt {
 	/**
 	 * Get explicit arguments from ability meta.mcp.arguments.
 	 *
-	 * @return array<int,array<string,mixed>>|null Explicit arguments array or null if not defined.
+	 * @return list<array<string,mixed>>|null Explicit arguments array or null if not defined.
 	 * @since n.e.x.t
 	 *
 	 */
@@ -280,7 +280,7 @@ class RegisterAbilityAsMcpPrompt {
 			return null;
 		}
 
-		return $mcp['arguments'];
+		return array_values( $mcp['arguments'] );
 	}
 
 	/**
@@ -292,9 +292,9 @@ class RegisterAbilityAsMcpPrompt {
 	 * - description (string, optional): Human-readable description
 	 * - required (boolean, optional): Whether the argument must be provided
 	 *
-	 * @param array<int,array<string,mixed>> $explicit_arguments User-defined arguments array.
+	 * @param list<array<string,mixed>> $explicit_arguments User-defined arguments array.
 	 *
-	 * @return array<int,\WP\McpSchema\Server\Prompts\DTO\PromptArgument>|\WP_Error PromptArgument DTOs or WP_Error.
+	 * @return list<\WP\McpSchema\Server\Prompts\DTO\PromptArgument>|\WP_Error PromptArgument DTOs or WP_Error.
 	 * @since n.e.x.t
 	 *
 	 */
@@ -375,7 +375,7 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * @param array<string,mixed> $input_schema The JSON Schema from ability.
 	 *
-	 * @return array<int, \WP\McpSchema\Server\Prompts\DTO\PromptArgument> Argument DTO list.
+	 * @return list<\WP\McpSchema\Server\Prompts\DTO\PromptArgument> Argument DTO list.
 	 * @since n.e.x.t
 	 *
 	 */

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -28,14 +28,14 @@ class PromptsHandler {
 	/**
 	 * Valid content types from ContentBlockFactory.
 	 *
-	 * @var array<int, string>
+	 * @var list<string>
 	 */
 	private static $valid_content_types = array( 'text', 'image', 'audio', 'resource_link', 'resource' );
 
 	/**
 	 * Valid role values for PromptMessage.
 	 *
-	 * @var array<int, string>
+	 * @var list<string>
 	 */
 	private static $valid_roles = array( 'user', 'assistant' );
 

--- a/tests/Fixtures/DummyErrorHandler.php
+++ b/tests/Fixtures/DummyErrorHandler.php
@@ -8,7 +8,7 @@ use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 
 class DummyErrorHandler implements McpErrorHandlerInterface {
 
-	/** @var array<int, array{message:string,context:array,type:string}> */
+	/** @var list<array{message:string,context:array,type:string}> */
 	public static array $logs = array();
 
 	public static function reset(): void {

--- a/tests/Fixtures/DummyObservabilityHandler.php
+++ b/tests/Fixtures/DummyObservabilityHandler.php
@@ -8,7 +8,7 @@ use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterfa
 
 final class DummyObservabilityHandler implements McpObservabilityHandlerInterface {
 
-	/** @var array<int, array{event:string,tags:array,duration_ms:?float}> */
+	/** @var list<array{event:string,tags:array,duration_ms:?float}> */
 	public static array $events = array();
 
 	public static function reset(): void {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -189,7 +189,7 @@ abstract class TestCase extends PolyfillsTestCase {
 	/**
 	 * Captured `_doing_it_wrong` calls during a test.
 	 *
-	 * @var array<int,array{function:string,message:string,version:string}>
+	 * @var list<array{function:string,message:string,version:string}>
 	 */
 	protected $doing_it_wrong_log = array();
 


### PR DESCRIPTION
## Why

During PR review (#122), @JasonTheAdams suggested using `list<T>` instead of `array<int, T>` for sequential arrays. While both are valid PHPStan types, `list<T>` provides:

- **Semantic precision** — communicates "sequential, zero-indexed" intent that `array<int, T>` only implies
- **Stricter analysis** — PHPStan catches key gaps from `unset()`, non-sequential assignments, and unvalidated metadata arrays that `array<int, T>` silently accepts
- **Better documentation** — readers immediately know the array is a proper list, not an associative structure with integer keys

## What

- Replace all `array<int, T>` PHPDoc annotations with `list<T>` across 9 files (6 in `includes/`, 3 in `tests/`)
- Propagate `list<string>` upstream through `McpAdapter`, `McpServer`, and `McpComponentRegistry` to satisfy PHPStan's stricter type enforcement throughout the call chain
- Add `array_values()` in `RegisterAbilityAsMcpPrompt::get_explicit_arguments()` to guarantee metadata arrays from ability config are proper lists (the one runtime change)

### Files changed

| File | Changes |
|------|---------|
| `includes/Handlers/Prompts/PromptsHandler.php` | 2 `@var` annotations |
| `includes/Domain/Prompts/McpPromptBuilder.php` | 2 `@var` + 2 `@return` + 1 `@param` |
| `includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php` | 2 `@return` + 2 `@param` + `array_values()` fix |
| `includes/Core/McpComponentRegistry.php` | 3 `@param` annotations |
| `includes/Core/McpServer.php` | 9 `@param` annotations (3 methods × 3 params) |
| `includes/Core/McpAdapter.php` | 3 `@param` annotations |
| `tests/TestCase.php` | 1 `@var` annotation |
| `tests/Fixtures/DummyErrorHandler.php` | 1 `@var` annotation |
| `tests/Fixtures/DummyObservabilityHandler.php` | 1 `@var` annotation |

## Validation

- PHPStan Level 8: 0 errors
- PHPUnit: 934 tests, 3,663 assertions — all pass
- PHPCS: clean

Closes #127