### PR TITLE
Import WP_Error class instead of fully qualified references

### DIFF
--- a/includes/Abilities/DiscoverAbilitiesAbility.php
+++ b/includes/Abilities/DiscoverAbilitiesAbility.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Abilities;
 
+use WP_Error;
+
 /**
  * Discover Abilities - Lists all available WordPress abilities in the system.
  *
@@ -120,7 +122,7 @@ final class DiscoverAbilitiesAbility {
 	public static function check_permission( $input = array() ) {
 		// Verify caller identity - ensure user is authenticated
 		if ( ! is_user_logged_in() ) {
-			return new \WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
+			return new WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
 		}
 
 		/**
@@ -136,7 +138,7 @@ final class DiscoverAbilitiesAbility {
 		$required_capability = apply_filters( 'mcp_adapter_discover_abilities_capability', 'read' );
 		// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is determined dynamically via filter
 		if ( ! current_user_can( $required_capability ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'insufficient_capability',
 				sprintf( 'User lacks required capability: %s', $required_capability )
 			);

--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Abilities;
 
 use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
+use WP_Error;
 
 /**
  * Execute Ability - Executes a WordPress ability with provided parameters.
@@ -163,7 +164,7 @@ final class ExecuteAbilityAbility {
 		$ability_name = $input['ability_name'] ?? '';
 
 		if ( empty( $ability_name ) ) {
-			return new \WP_Error( 'missing_ability_name', 'Ability name is required' );
+			return new WP_Error( 'missing_ability_name', 'Ability name is required' );
 		}
 
 		// Validate user authentication and capabilities
@@ -181,7 +182,7 @@ final class ExecuteAbilityAbility {
 		// Get the target ability
 		$ability = wp_get_ability( $ability_name );
 		if ( ! $ability ) {
-			return new \WP_Error( 'ability_not_found', "Ability '{$ability_name}' not found" );
+			return new WP_Error( 'ability_not_found', "Ability '{$ability_name}' not found" );
 		}
 
 		// Normalize parameters for ability's schema requirements
@@ -206,7 +207,7 @@ final class ExecuteAbilityAbility {
 	private static function validate_user_access() {
 		// Verify caller identity - ensure the user is authenticated
 		if ( ! is_user_logged_in() ) {
-			return new \WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
+			return new WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
 		}
 
 		/**
@@ -225,7 +226,7 @@ final class ExecuteAbilityAbility {
 		$required_capability = apply_filters( 'mcp_adapter_execute_ability_capability', 'read' );
 		// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is determined dynamically via filter
 		if ( ! current_user_can( $required_capability ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'insufficient_capability',
 				sprintf( 'User lacks required capability: %s', $required_capability )
 			);

--- a/includes/Abilities/GetAbilityInfoAbility.php
+++ b/includes/Abilities/GetAbilityInfoAbility.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Abilities;
 
+use WP_Error;
+
 /**
  * Get Ability Info - Get detailed information about a specific WordPress ability.
  *
@@ -141,7 +143,7 @@ final class GetAbilityInfoAbility {
 		$ability_name = $input['ability_name'] ?? '';
 
 		if ( empty( $ability_name ) ) {
-			return new \WP_Error( 'missing_ability_name', 'Ability name is required' );
+			return new WP_Error( 'missing_ability_name', 'Ability name is required' );
 		}
 
 		// Validate user authentication and capabilities
@@ -162,7 +164,7 @@ final class GetAbilityInfoAbility {
 	private static function validate_user_access() {
 		// Verify caller identity - ensure user is authenticated
 		if ( ! is_user_logged_in() ) {
-			return new \WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
+			return new WP_Error( 'authentication_required', 'User must be authenticated to access this ability' );
 		}
 
 		/**
@@ -178,7 +180,7 @@ final class GetAbilityInfoAbility {
 		$required_capability = apply_filters( 'mcp_adapter_get_ability_info_capability', 'read' );
 		// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is determined dynamically via filter
 		if ( ! current_user_can( $required_capability ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'insufficient_capability',
 				sprintf( 'User lacks required capability: %s', $required_capability )
 			);

--- a/includes/Abilities/McpAbilityHelperTrait.php
+++ b/includes/Abilities/McpAbilityHelperTrait.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Abilities;
 
+use WP_Error;
+
 /**
  * Trait McpAbilityHelperTrait
  *
@@ -30,14 +32,14 @@ trait McpAbilityHelperTrait {
 		$ability = wp_get_ability( $ability_name );
 
 		if ( ! $ability ) {
-			return new \WP_Error( 'ability_not_found', "Ability '{$ability_name}' not found" );
+			return new WP_Error( 'ability_not_found', "Ability '{$ability_name}' not found" );
 		}
 
 		$meta          = $ability->get_meta();
 		$is_public_mcp = $meta['mcp']['public'] ?? false;
 
 		if ( ! $is_public_mcp ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'ability_not_public_mcp',
 				sprintf( 'Ability "%s" is not exposed via MCP (mcp.public!=true)', $ability_name )
 			);

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -18,6 +18,7 @@ use WP\MCP\Infrastructure\ErrorHandling\NullMcpErrorHandler;
 use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface;
 use WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler;
 use WP\MCP\Servers\DefaultServerFactory;
+use WP_Error;
 
 /**
  * WordPress MCP Registry - Main class for managing multiple MCP servers.
@@ -173,7 +174,7 @@ final class McpAdapter {
 
 		// Validate error handler class exists and implements McpErrorHandlerInterface.
 		if ( ! class_exists( $error_handler ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'invalid_error_handler',
 				sprintf(
 					/* translators: %s: error handler class name */
@@ -184,7 +185,7 @@ final class McpAdapter {
 		}
 
 		if ( ! in_array( McpErrorHandlerInterface::class, class_implements( $error_handler ) ?: array(), true ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'invalid_error_handler',
 				sprintf(
 				/* translators: %s: error handler class name */
@@ -201,7 +202,7 @@ final class McpAdapter {
 
 		// Validate observability handler class exists and implements McpObservabilityHandlerInterface.
 		if ( ! class_exists( $observability_handler ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'invalid_observability_handler',
 				sprintf(
 				/* translators: %s: observability handler class name */
@@ -212,7 +213,7 @@ final class McpAdapter {
 		}
 
 		if ( ! in_array( McpObservabilityHandlerInterface::class, class_implements( $observability_handler ) ?: array(), true ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'invalid_observability_handler',
 				sprintf(
 				/* translators: %s: observability handler class name */
@@ -229,7 +230,7 @@ final class McpAdapter {
 				'0.1.0'
 			);
 
-			return new \WP_Error(
+			return new WP_Error(
 				'invalid_timing',
 				esc_html__( 'MCP Server creation must be done during mcp_adapter_init action.', 'mcp-adapter' )
 			);
@@ -246,7 +247,7 @@ final class McpAdapter {
 				'0.1.0'
 			);
 
-			return new \WP_Error(
+			return new WP_Error(
 				'duplicate_server_id',
 				// translators: %s: server ID.
 				sprintf( esc_html__( 'Server with ID "%s" already exists.', 'mcp-adapter' ), esc_html( $server_id ) )
@@ -271,7 +272,7 @@ final class McpAdapter {
 				$transport_permission_callback
 			);
 		} catch ( \Throwable $e ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'server_creation_failed',
 				sprintf(
 					/* translators: 1: server ID, 2: error message */

--- a/includes/Core/McpComponentRegistry.php
+++ b/includes/Core/McpComponentRegistry.php
@@ -20,6 +20,7 @@ use WP\MCP\Infrastructure\Observability\FailureReason;
 use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
+use WP_Error;
 
 /**
  * Registry for managing MCP server components (tools, resources, prompts).
@@ -493,7 +494,7 @@ class McpComponentRegistry {
 		$prompt_name = $builder->get_name();
 
 		$mcp_prompt = McpPrompt::fromBuilder( $builder );
-		if ( $mcp_prompt instanceof \WP_Error ) {
+		if ( $mcp_prompt instanceof WP_Error ) {
 			$this->error_handler->log( $mcp_prompt->get_error_message(), array( "McpPrompt::fromBuilder::{$prompt_name}" ) );
 
 			$this->track_registration(

--- a/includes/Domain/Prompts/McpPrompt.php
+++ b/includes/Domain/Prompts/McpPrompt.php
@@ -17,6 +17,7 @@ use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\Observability\FailureReason;
 use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
+use WP_Error;
 
 /**
  * Prompt component providing unified execution and permission checks.
@@ -135,11 +136,11 @@ final class McpPrompt implements McpComponentInterface {
 	 */
 	public static function fromArray( array $config ) {
 		if ( empty( $config['name'] ) ) {
-			return new \WP_Error( 'mcp_prompt_missing_name', 'Prompt configuration must include a "name" field.' );
+			return new WP_Error( 'mcp_prompt_missing_name', 'Prompt configuration must include a "name" field.' );
 		}
 
 		if ( ! isset( $config['handler'] ) || ! is_callable( $config['handler'] ) ) {
-			return new \WP_Error( 'mcp_prompt_missing_handler', 'Prompt configuration must include a callable "handler" field.' );
+			return new WP_Error( 'mcp_prompt_missing_handler', 'Prompt configuration must include a callable "handler" field.' );
 		}
 
 		// Validate and prepare icons if set.
@@ -189,7 +190,7 @@ final class McpPrompt implements McpComponentInterface {
 
 			$prompt = PromptDto::fromArray( $prompt_data );
 		} catch ( \Throwable $e ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_prompt_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
@@ -234,7 +235,7 @@ final class McpPrompt implements McpComponentInterface {
 	 */
 	public static function fromAbility( \WP_Ability $ability ) {
 		$prompt_data = RegisterAbilityAsMcpPrompt::build( $ability );
-		if ( $prompt_data instanceof \WP_Error ) {
+		if ( $prompt_data instanceof WP_Error ) {
 			return $prompt_data;
 		}
 
@@ -263,7 +264,7 @@ final class McpPrompt implements McpComponentInterface {
 		try {
 			$prompt = $builder->build();
 		} catch ( \Throwable $throwable ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_prompt_builder_failed',
 				$throwable->getMessage(),
 				array( 'error_type' => get_class( $throwable ) )
@@ -326,7 +327,7 @@ final class McpPrompt implements McpComponentInterface {
 			try {
 				$result = $this->ability->execute( $args );
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_execution_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -336,7 +337,7 @@ final class McpPrompt implements McpComponentInterface {
 			try {
 				$result = $this->builder->handle( $args );
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_execution_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -346,17 +347,17 @@ final class McpPrompt implements McpComponentInterface {
 			try {
 				$result = call_user_func( $this->handler, $args );
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_execution_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
 				);
 			}
 		} else {
-			return new \WP_Error( 'mcp_prompt_no_handler', 'No prompt execution strategy configured.' );
+			return new WP_Error( 'mcp_prompt_no_handler', 'No prompt execution strategy configured.' );
 		}
 
-		if ( $result instanceof \WP_Error ) {
+		if ( $result instanceof WP_Error ) {
 			return $result;
 		}
 
@@ -404,7 +405,7 @@ final class McpPrompt implements McpComponentInterface {
 			try {
 				return $this->ability->check_permissions( $args );
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_permission_check_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -416,7 +417,7 @@ final class McpPrompt implements McpComponentInterface {
 			try {
 				return $this->builder->has_permission( $args );
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_permission_check_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -428,9 +429,9 @@ final class McpPrompt implements McpComponentInterface {
 			try {
 				$result = call_user_func( $this->permission_callback, $args );
 
-				return $result instanceof \WP_Error ? $result : (bool) $result;
+				return $result instanceof WP_Error ? $result : (bool) $result;
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_permission_check_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -438,7 +439,7 @@ final class McpPrompt implements McpComponentInterface {
 			}
 		}
 
-		return new \WP_Error(
+		return new WP_Error(
 			'mcp_permission_denied',
 			'Access denied.',
 			array( 'failure_reason' => FailureReason::NO_PERMISSION_STRATEGY )

--- a/includes/Domain/Prompts/McpPromptValidator.php
+++ b/includes/Domain/Prompts/McpPromptValidator.php
@@ -12,6 +12,7 @@ namespace WP\MCP\Domain\Prompts;
 use WP\MCP\Domain\Resources\McpResourceValidator;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
+use WP_Error;
 
 /**
  * Validates MCP prompts against the Model Context Protocol specification.
@@ -41,7 +42,7 @@ class McpPromptValidator {
 				__( 'Prompt validation failed: %s', 'mcp-adapter' ),
 				implode( ', ', $validation_errors )
 			);
-			return new \WP_Error( 'mcp_prompt_validation_failed', esc_html( $error_message ) );
+			return new WP_Error( 'mcp_prompt_validation_failed', esc_html( $error_message ) );
 		}
 
 		return true;
@@ -76,7 +77,7 @@ class McpPromptValidator {
 		// BaseMetadata has title and name, handled separately.
 
 		if ( ! empty( $errors ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_prompt_validation_failed',
 				sprintf(
 				/* translators: %s: list of validation errors */

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -12,6 +12,7 @@ use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Domain\Utils\SchemaTransformer;
 use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
+use WP_Error;
 
 /**
  * Converts WordPress abilities to MCP prompts according to the specification.
@@ -128,7 +129,7 @@ class RegisterAbilityAsMcpPrompt {
 		try {
 			return PromptDto::fromArray( $built['prompt_data'] );
 		} catch ( \Throwable $e ) {
-			return new \WP_Error( 'mcp_prompt_schema_invalid', $e->getMessage() );
+			return new WP_Error( 'mcp_prompt_schema_invalid', $e->getMessage() );
 		}
 	}
 
@@ -303,7 +304,7 @@ class RegisterAbilityAsMcpPrompt {
 
 		foreach ( $explicit_arguments as $index => $arg ) {
 			if ( ! is_array( $arg ) ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_prompt_invalid_argument',
 					sprintf(
 					/* translators: 1: argument index, 2: ability name */
@@ -316,7 +317,7 @@ class RegisterAbilityAsMcpPrompt {
 
 			// Validate required 'name' field.
 			if ( ! isset( $arg['name'] ) || ! is_string( $arg['name'] ) || '' === trim( $arg['name'] ) ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_prompt_argument_missing_name',
 					sprintf(
 					/* translators: 1: argument index, 2: ability name */
@@ -450,7 +451,7 @@ class RegisterAbilityAsMcpPrompt {
 		try {
 			$prompt_dto = PromptDto::fromArray( $data['prompt_data'] );
 		} catch ( \Throwable $e ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_prompt_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */

--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -16,6 +16,7 @@ use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\Observability\FailureReason;
 use WP\McpSchema\Common\Protocol\DTO\Annotations;
 use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
+use WP_Error;
 
 /**
  * Resource component providing unified execution and permission checks.
@@ -117,22 +118,22 @@ final class McpResource implements McpComponentInterface {
 	 */
 	public static function fromArray( array $config ) {
 		if ( empty( $config['uri'] ) ) {
-			return new \WP_Error( 'mcp_resource_missing_uri', 'Resource configuration must include a "uri" field.' );
+			return new WP_Error( 'mcp_resource_missing_uri', 'Resource configuration must include a "uri" field.' );
 		}
 
 		if ( ! isset( $config['handler'] ) || ! is_callable( $config['handler'] ) ) {
-			return new \WP_Error( 'mcp_resource_missing_handler', 'Resource configuration must include a callable "handler" field.' );
+			return new WP_Error( 'mcp_resource_missing_handler', 'Resource configuration must include a callable "handler" field.' );
 		}
 
 		$uri = trim( $config['uri'] );
 
 		if ( ! McpValidator::validate_resource_uri( $uri ) ) {
-			return new \WP_Error( 'mcp_resource_invalid_uri', 'Resource "uri" must be a valid RFC 3986 URI with a scheme.' );
+			return new WP_Error( 'mcp_resource_invalid_uri', 'Resource "uri" must be a valid RFC 3986 URI with a scheme.' );
 		}
 
 		$name = isset( $config['name'] ) ? trim( $config['name'] ) : $uri;
 		if ( '' === $name ) {
-			return new \WP_Error( 'mcp_resource_missing_name', 'Resource "name" cannot be empty.' );
+			return new WP_Error( 'mcp_resource_missing_name', 'Resource "name" cannot be empty.' );
 		}
 
 		$resource_data = array(
@@ -182,7 +183,7 @@ final class McpResource implements McpComponentInterface {
 
 			$resource = ResourceDto::fromArray( $resource_data );
 		} catch ( \Throwable $e ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_resource_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
@@ -228,7 +229,7 @@ final class McpResource implements McpComponentInterface {
 	 */
 	public static function fromAbility( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null ) {
 		$resource_data = RegisterAbilityAsMcpResource::build( $ability, $error_handler );
-		if ( $resource_data instanceof \WP_Error ) {
+		if ( $resource_data instanceof WP_Error ) {
 			return $resource_data;
 		}
 
@@ -272,7 +273,7 @@ final class McpResource implements McpComponentInterface {
 			try {
 				return $this->ability->execute();
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_execution_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -284,7 +285,7 @@ final class McpResource implements McpComponentInterface {
 			try {
 				return call_user_func( $this->handler, $arguments );
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_execution_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -292,7 +293,7 @@ final class McpResource implements McpComponentInterface {
 			}
 		}
 
-		return new \WP_Error( 'mcp_resource_no_handler', 'No resource execution strategy configured.' );
+		return new WP_Error( 'mcp_resource_no_handler', 'No resource execution strategy configured.' );
 	}
 
 	/**
@@ -308,7 +309,7 @@ final class McpResource implements McpComponentInterface {
 			try {
 				return $this->ability->check_permissions();
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_permission_check_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -320,9 +321,9 @@ final class McpResource implements McpComponentInterface {
 			try {
 				$result = call_user_func( $this->permission_callback, $arguments );
 
-				return $result instanceof \WP_Error ? $result : (bool) $result;
+				return $result instanceof WP_Error ? $result : (bool) $result;
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_permission_check_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -330,7 +331,7 @@ final class McpResource implements McpComponentInterface {
 			}
 		}
 
-		return new \WP_Error(
+		return new WP_Error(
 			'mcp_permission_denied',
 			'Access denied.',
 			array( 'failure_reason' => FailureReason::NO_PERMISSION_STRATEGY )

--- a/includes/Domain/Resources/McpResourceValidator.php
+++ b/includes/Domain/Resources/McpResourceValidator.php
@@ -11,6 +11,7 @@ namespace WP\MCP\Domain\Resources;
 
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
+use WP_Error;
 
 /**
  * Validates MCP resources against the Model Context Protocol specification.
@@ -40,7 +41,7 @@ class McpResourceValidator {
 				__( 'Resource validation failed: %s', 'mcp-adapter' ),
 				implode( ', ', $validation_errors )
 			);
-			return new \WP_Error( 'mcp_resource_validation_failed', esc_html( $error_message ) );
+			return new WP_Error( 'mcp_resource_validation_failed', esc_html( $error_message ) );
 		}
 
 		return true;
@@ -84,7 +85,7 @@ class McpResourceValidator {
 		}
 
 		if ( ! empty( $errors ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_resource_validation_failed',
 				sprintf(
 				/* translators: %s: list of validation errors */

--- a/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -14,6 +14,7 @@ use WP\MCP\Domain\Utils\McpAnnotationMapper;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
+use WP_Error;
 
 /**
  * Converts WordPress abilities to MCP Resource metadata.
@@ -97,7 +98,7 @@ class RegisterAbilityAsMcpResource {
 		try {
 			return ResourceDto::fromArray( $data );
 		} catch ( \Throwable $e ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_resource_schema_invalid',
 				$e->getMessage()
 			);
@@ -233,7 +234,7 @@ class RegisterAbilityAsMcpResource {
 		$uri = $this->get_mcp_meta( 'uri', 'string' );
 
 		if ( null === $uri ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'resource_uri_not_found',
 				sprintf(
 				/* translators: %s: ability name */
@@ -247,7 +248,7 @@ class RegisterAbilityAsMcpResource {
 
 		// Validate URI format (RFC 3986).
 		if ( ! McpValidator::validate_resource_uri( $uri ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'resource_uri_invalid',
 				sprintf(
 				/* translators: 1: ability name, 2: invalid URI */
@@ -271,7 +272,7 @@ class RegisterAbilityAsMcpResource {
 
 		// Validate post-filter.
 		if ( ! is_string( $filtered_uri ) || ! McpValidator::validate_resource_uri( $filtered_uri ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_resource_uri_filter_invalid',
 				sprintf(
 				/* translators: %s: invalid URI returned by filter */
@@ -451,7 +452,7 @@ class RegisterAbilityAsMcpResource {
 		try {
 			$resource_dto = ResourceDto::fromArray( $data['resource_data'] );
 		} catch ( \Throwable $e ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_resource_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */

--- a/includes/Domain/Tools/McpTool.php
+++ b/includes/Domain/Tools/McpTool.php
@@ -16,6 +16,7 @@ use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\Observability\FailureReason;
 use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 use WP\McpSchema\Server\Tools\DTO\ToolAnnotations;
+use WP_Error;
 
 /**
  * Tool component providing unified execution and permission checks.
@@ -121,11 +122,11 @@ final class McpTool implements McpComponentInterface {
 	 */
 	public static function fromArray( array $config ) {
 		if ( empty( $config['name'] ) ) {
-			return new \WP_Error( 'mcp_tool_missing_name', 'Tool configuration must include a "name" field.' );
+			return new WP_Error( 'mcp_tool_missing_name', 'Tool configuration must include a "name" field.' );
 		}
 
 		if ( ! isset( $config['handler'] ) || ! is_callable( $config['handler'] ) ) {
-			return new \WP_Error( 'mcp_tool_missing_handler', 'Tool configuration must include a callable "handler" field.' );
+			return new WP_Error( 'mcp_tool_missing_handler', 'Tool configuration must include a callable "handler" field.' );
 		}
 
 		// Prepare input schema - ensure it's an object type for MCP compliance.
@@ -175,7 +176,7 @@ final class McpTool implements McpComponentInterface {
 
 			$tool = ToolDto::fromArray( $tool_data );
 		} catch ( \Throwable $e ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_tool_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
@@ -220,7 +221,7 @@ final class McpTool implements McpComponentInterface {
 	 */
 	public static function fromAbility( \WP_Ability $ability ) {
 		$tool_data = RegisterAbilityAsMcpTool::build( $ability );
-		if ( $tool_data instanceof \WP_Error ) {
+		if ( $tool_data instanceof WP_Error ) {
 			return $tool_data;
 		}
 
@@ -267,7 +268,7 @@ final class McpTool implements McpComponentInterface {
 			try {
 				$result = $this->ability->execute( $args );
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_execution_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -277,17 +278,17 @@ final class McpTool implements McpComponentInterface {
 			try {
 				$result = call_user_func( $this->handler, $args );
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_execution_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
 				);
 			}
 		} else {
-			return new \WP_Error( 'mcp_tool_no_handler', 'No tool execution strategy configured.' );
+			return new WP_Error( 'mcp_tool_no_handler', 'No tool execution strategy configured.' );
 		}
 
-		if ( $result instanceof \WP_Error ) {
+		if ( $result instanceof WP_Error ) {
 			return $result;
 		}
 
@@ -357,7 +358,7 @@ final class McpTool implements McpComponentInterface {
 			try {
 				return $this->ability->check_permissions( $args );
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_permission_check_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -370,9 +371,9 @@ final class McpTool implements McpComponentInterface {
 			try {
 				$result = call_user_func( $this->permission_callback, $args );
 
-				return $result instanceof \WP_Error ? $result : (bool) $result;
+				return $result instanceof WP_Error ? $result : (bool) $result;
 			} catch ( \Throwable $throwable ) {
-				return new \WP_Error(
+				return new WP_Error(
 					'mcp_permission_check_failed',
 					$throwable->getMessage(),
 					array( 'error_type' => get_class( $throwable ) )
@@ -381,7 +382,7 @@ final class McpTool implements McpComponentInterface {
 		}
 
 		// Defensive fallback: should never reach here if factories are used correctly.
-		return new \WP_Error(
+		return new WP_Error(
 			'mcp_permission_denied',
 			'Access denied.',
 			array(

--- a/includes/Domain/Tools/McpToolValidator.php
+++ b/includes/Domain/Tools/McpToolValidator.php
@@ -11,6 +11,7 @@ namespace WP\MCP\Domain\Tools;
 
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
+use WP_Error;
 
 /**
  * Validates MCP tools against the Model Context Protocol specification.
@@ -53,7 +54,7 @@ class McpToolValidator {
 				__( 'Tool validation failed: %s', 'mcp-adapter' ),
 				implode( ', ', $validation_errors )
 			);
-			return new \WP_Error( 'mcp_tool_validation_failed', esc_html( $error_message ) );
+			return new WP_Error( 'mcp_tool_validation_failed', esc_html( $error_message ) );
 		}
 
 		return true;
@@ -132,7 +133,7 @@ class McpToolValidator {
 		}
 
 		if ( ! empty( $errors ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_tool_validation_failed',
 				sprintf(
 				/* translators: %s: list of validation errors */

--- a/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -15,6 +15,7 @@ use WP\MCP\Domain\Utils\McpNameSanitizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Domain\Utils\SchemaTransformer;
 use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
+use WP_Error;
 
 /**
  * RegisterAbilityAsMcpTool class.
@@ -67,7 +68,7 @@ class RegisterAbilityAsMcpTool {
 		try {
 			$tool_dto = ToolDto::fromArray( $data['tool_data'] );
 		} catch ( \Throwable $e ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_tool_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
@@ -226,7 +227,7 @@ class RegisterAbilityAsMcpTool {
 
 		// Validate post-filter (in case filter broke it).
 		if ( ! is_string( $filtered_name ) || ! McpValidator::validate_name( $filtered_name ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_tool_name_filter_invalid',
 				sprintf(
 				/* translators: %s: invalid tool name returned by filter */

--- a/includes/Domain/Utils/McpNameSanitizer.php
+++ b/includes/Domain/Utils/McpNameSanitizer.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Utils;
 
+use WP_Error;
+
 /**
  * Utility class for sanitizing names to MCP-valid format.
  *
@@ -97,7 +99,7 @@ class McpNameSanitizer {
 		// Step 6: Final check - only empty is possible failure after sanitization.
 		// Characters are guaranteed valid (replaced), length is handled (truncated).
 		if ( empty( $name ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'mcp_name_invalid',
 				sprintf(
 				/* translators: %s: original ability name */

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -10,6 +10,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Transport\Infrastructure;
 
+use WP_Error;
+
 /**
  * MCP Session Manager
  *
@@ -197,7 +199,7 @@ final class SessionManager {
 	 */
 	public static function get_session( int $user_id, string $session_id ) {
 		if ( ! $user_id || ! $session_id ) {
-			return new \WP_Error( 403, 'Invalid user ID or session ID.' );
+			return new WP_Error( 403, 'Invalid user ID or session ID.' );
 		}
 
 		$sessions = self::get_all_user_sessions( $user_id );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -161,7 +161,13 @@
 			</property>
 		</properties>
 	</rule>
-	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions" />
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions">
+		<properties>
+			<property name="ignoredNames" type="array">
+				<element value="WP_Error" />
+			</property>
+		</properties>
+	</rule>
 	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses" />
 	<rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
 	<rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace" />

--- a/tests/Integration/HttpTransportTest.php
+++ b/tests/Integration/HttpTransportTest.php
@@ -23,6 +23,7 @@ use WP\MCP\Transport\HttpTransport;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
 use WP_REST_Request;
 use WP_REST_Response;
+use WP_Error;
 
 /**
  * Test MCP HTTP Transport behavior against the MCP 2025-11-25 baseline.
@@ -606,7 +607,7 @@ final class HttpTransportTest extends TestCase {
 				'request_router'                => $this->context->request_router,
 				'error_handler'                 => new DummyErrorHandler(), // Add error_handler
 				'transport_permission_callback' => static function () {
-					return new \WP_Error( 'permission_denied', 'Custom permission error' );
+					return new WP_Error( 'permission_denied', 'Custom permission error' );
 				},
 			)
 		);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ use WP\MCP\Tests\Fixtures\DummyAbility;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase as PolyfillsTestCase;
+use WP_Error;
 
 abstract class TestCase extends PolyfillsTestCase {
 
@@ -171,7 +172,7 @@ abstract class TestCase extends PolyfillsTestCase {
 	 * @return void
 	 */
 	public function assertWPError( $actual, string $message = '' ): void {
-		$this->assertInstanceOf( \WP_Error::class, $actual, $message );
+		$this->assertInstanceOf( WP_Error::class, $actual, $message );
 	}
 
 	/**
@@ -183,7 +184,7 @@ abstract class TestCase extends PolyfillsTestCase {
 	 * @return void
 	 */
 	public function assertNotWPError( $actual, string $message = '' ): void {
-		$this->assertNotInstanceOf( \WP_Error::class, $actual, $message );
+		$this->assertNotInstanceOf( WP_Error::class, $actual, $message );
 	}
 
 	/**

--- a/tests/Unit/Abilities/DiscoverAbilitiesAbilityTest.php
+++ b/tests/Unit/Abilities/DiscoverAbilitiesAbilityTest.php
@@ -11,6 +11,7 @@ namespace WP\MCP\Tests\Unit\Abilities;
 
 use WP\MCP\Abilities\DiscoverAbilitiesAbility;
 use WP\MCP\Tests\TestCase;
+use WP_Error;
 
 /**
  * Test DiscoverAbilitiesAbility functionality.
@@ -81,7 +82,7 @@ final class DiscoverAbilitiesAbilityTest extends TestCase {
 
 		$result = DiscoverAbilitiesAbility::check_permission( array() );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'authentication_required', $result->get_error_code() );
 	}
 
@@ -142,7 +143,7 @@ final class DiscoverAbilitiesAbilityTest extends TestCase {
 
 		$result = DiscoverAbilitiesAbility::check_permission( array() );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'insufficient_capability', $result->get_error_code() );
 
 		// Clean up

--- a/tests/Unit/Abilities/ExecuteAbilityAbilityTest.php
+++ b/tests/Unit/Abilities/ExecuteAbilityAbilityTest.php
@@ -11,6 +11,7 @@ namespace WP\MCP\Tests\Unit\Abilities;
 
 use WP\MCP\Abilities\ExecuteAbilityAbility;
 use WP\MCP\Tests\TestCase;
+use WP_Error;
 
 /**
  * Test ExecuteAbilityAbility functionality.
@@ -97,7 +98,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'missing_ability_name', $result->get_error_code() );
 	}
 
@@ -109,7 +110,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'missing_ability_name', $result->get_error_code() );
 	}
 
@@ -121,7 +122,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'ability_not_found', $result->get_error_code() );
 	}
 
@@ -136,7 +137,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 				'execute_callback'    => static function () {
 					return array( 'test' => 'result' ); },
 				'permission_callback' => static function () {
-					return new \WP_Error( 'permission_denied', 'Custom permission error' );
+					return new WP_Error( 'permission_denied', 'Custom permission error' );
 				},
 				'meta'                => array(
 					'mcp' => array(
@@ -154,7 +155,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 		);
 
 		// WP_Error should be returned as-is
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'permission_denied', $result->get_error_code() );
 		$this->assertEquals( 'Custom permission error', $result->get_error_message() );
 
@@ -173,7 +174,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'authentication_required', $result->get_error_code() );
 
 		// Restore authenticated user for other tests
@@ -204,7 +205,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'insufficient_capability', $result->get_error_code() );
 
 		// Clean up
@@ -244,7 +245,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 				'parameters'   => array(),
 			)
 		);
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'ability_not_public_mcp', $result->get_error_code() );
 
 		// Clean up
@@ -260,7 +261,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'ability_not_found', $result->get_error_code() );
 	}
 
@@ -338,7 +339,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 				'description'         => 'Returns WP_Error for execution',
 				'category'            => 'test',
 				'execute_callback'    => static function () {
-					return new \WP_Error( 'execution_failed', 'Custom execution error' );
+					return new WP_Error( 'execution_failed', 'Custom execution error' );
 				},
 				'permission_callback' => static function () {
 					return true; },

--- a/tests/Unit/Abilities/GetAbilityInfoAbilityTest.php
+++ b/tests/Unit/Abilities/GetAbilityInfoAbilityTest.php
@@ -11,6 +11,7 @@ namespace WP\MCP\Tests\Unit\Abilities;
 
 use WP\MCP\Abilities\GetAbilityInfoAbility;
 use WP\MCP\Tests\TestCase;
+use WP_Error;
 
 /**
  * Test GetAbilityInfoAbility functionality.
@@ -81,7 +82,7 @@ final class GetAbilityInfoAbilityTest extends TestCase {
 
 		$result = GetAbilityInfoAbility::check_permission( array( 'ability_name' => 'test/always-allowed' ) );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'authentication_required', $result->get_error_code() );
 	}
 
@@ -115,7 +116,7 @@ final class GetAbilityInfoAbilityTest extends TestCase {
 				'ability_name' => 'test/not-public-info',
 			)
 		);
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'ability_not_public_mcp', $result->get_error_code() );
 
 		// Clean up
@@ -145,7 +146,7 @@ final class GetAbilityInfoAbilityTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'insufficient_capability', $result->get_error_code() );
 
 		// Clean up
@@ -156,7 +157,7 @@ final class GetAbilityInfoAbilityTest extends TestCase {
 	public function test_check_permission_with_missing_ability_name(): void {
 		$result = GetAbilityInfoAbility::check_permission( array() );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'missing_ability_name', $result->get_error_code() );
 	}
 

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -11,6 +11,7 @@ use WP\McpSchema\Server\Prompts\DTO\GetPromptResult;
 use WP\McpSchema\Server\Prompts\DTO\ListPromptsResult;
 use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 use WP\McpSchema\Server\Prompts\DTO\PromptMessage;
+use WP_Error;
 
 final class PromptsHandlerTest extends TestCase {
 
@@ -138,7 +139,7 @@ final class PromptsHandlerTest extends TestCase {
 					),
 				),
 				'execute_callback'    => static function () {
-					return new \WP_Error( 'test_error', 'Test error message' );
+					return new WP_Error( 'test_error', 'Test error message' );
 				},
 				'permission_callback' => static function () {
 					return true;

--- a/tests/Unit/Handlers/ResourcesHandlerTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerTest.php
@@ -16,6 +16,7 @@ use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
 use WP\McpSchema\Server\Resources\DTO\ListResourcesResult;
 use WP\McpSchema\Server\Resources\DTO\ReadResourceResult;
 use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
+use WP_Error;
 
 /**
  * Test ResourcesHandler functionality.
@@ -143,7 +144,7 @@ final class ResourcesHandlerTest extends TestCase {
 				'description'         => 'Returns WP_Error from execute',
 				'category'            => 'test',
 				'execute_callback'    => static function () {
-					return new \WP_Error( 'test_error', 'Test error message' );
+					return new WP_Error( 'test_error', 'Test error message' );
 				},
 				'permission_callback' => static function () {
 					return true;

--- a/tests/Unit/Handlers/ToolsHandlerTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerTest.php
@@ -16,6 +16,7 @@ use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
 use WP\McpSchema\Server\Tools\DTO\CallToolResult;
 use WP\McpSchema\Server\Tools\DTO\ListToolsResult;
 use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
+use WP_Error;
 
 /**
  * Test ToolsHandler functionality.
@@ -111,7 +112,7 @@ final class ToolsHandlerTest extends TestCase {
 				'category'            => 'test',
 				'input_schema'        => array( 'type' => 'object' ),
 				'execute_callback'    => static function () {
-					return new \WP_Error( 'test_error', 'Test error message' );
+					return new WP_Error( 'test_error', 'Test error message' );
 				},
 				'permission_callback' => static function () {
 					return true;

--- a/tests/Unit/Prompts/McpPromptTest.php
+++ b/tests/Unit/Prompts/McpPromptTest.php
@@ -7,6 +7,7 @@ namespace WP\MCP\Tests\Unit\Prompts;
 use WP\MCP\Domain\Prompts\McpPrompt;
 use WP\MCP\Tests\TestCase;
 use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
+use WP_Error;
 
 /**
  * Tests for McpPrompt array configuration.
@@ -104,7 +105,7 @@ final class McpPromptTest extends TestCase {
 
 		// Without explicit permission callback, access should be denied.
 		$result = $prompt->check_permission( array() );
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
 	}
 
@@ -172,7 +173,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_prompt_missing_name', $result->get_error_code() );
 	}
 
@@ -183,7 +184,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_prompt_missing_handler', $result->get_error_code() );
 	}
 
@@ -314,7 +315,7 @@ final class McpPromptTest extends TestCase {
 
 		$result = $prompt->check_permission( array() );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
 		$this->assertArrayHasKey( 'failure_reason', $result->get_error_data() );
 		$this->assertSame( 'no_permission_strategy', $result->get_error_data()['failure_reason'] );
@@ -376,7 +377,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_prompt_dto_creation_failed', $result->get_error_code() );
 		// PHP 8 throws "Undefined array key 'name'", PHP 7.4 returns NULL triggering "Expected string, got NULL".
 		$message = $result->get_error_message();

--- a/tests/Unit/Resources/McpResourceTest.php
+++ b/tests/Unit/Resources/McpResourceTest.php
@@ -7,6 +7,7 @@ namespace WP\MCP\Tests\Unit\Resources;
 use WP\MCP\Domain\Resources\McpResource;
 use WP\MCP\Tests\TestCase;
 use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
+use WP_Error;
 
 final class McpResourceTest extends TestCase {
 
@@ -146,7 +147,7 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_resource_missing_uri', $result->get_error_code() );
 	}
 
@@ -157,7 +158,7 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_resource_missing_handler', $result->get_error_code() );
 	}
 
@@ -169,7 +170,7 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_resource_invalid_uri', $result->get_error_code() );
 	}
 
@@ -267,7 +268,7 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_resource_dto_creation_failed', $result->get_error_code() );
 		$this->assertStringContainsString( 'Expected float', $result->get_error_message() );
 	}
@@ -290,7 +291,7 @@ final class McpResourceTest extends TestCase {
 
 		$result = $resource->check_permission( array() );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
 		$this->assertArrayHasKey( 'failure_reason', $result->get_error_data() );
 		$this->assertSame( 'no_permission_strategy', $result->get_error_data()['failure_reason'] );

--- a/tests/Unit/Tools/McpToolTest.php
+++ b/tests/Unit/Tools/McpToolTest.php
@@ -7,6 +7,7 @@ namespace WP\MCP\Tests\Unit\Tools;
 use WP\MCP\Domain\Tools\McpTool;
 use WP\MCP\Tests\TestCase;
 use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
+use WP_Error;
 
 final class McpToolTest extends TestCase {
 
@@ -346,7 +347,7 @@ final class McpToolTest extends TestCase {
 
 		// Without explicit permission callback, access should be denied.
 		$result = $tool->check_permission( array() );
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
 	}
 
@@ -417,7 +418,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_tool_missing_name', $result->get_error_code() );
 	}
 
@@ -428,7 +429,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_tool_missing_handler', $result->get_error_code() );
 	}
 
@@ -500,7 +501,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_tool_dto_creation_failed', $result->get_error_code() );
 		$this->assertStringContainsString( 'Expected bool', $result->get_error_message() );
 	}
@@ -563,7 +564,7 @@ final class McpToolTest extends TestCase {
 
 		$result = $tool->check_permission( array() );
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'mcp_permission_denied', $result->get_error_code() );
 		$this->assertArrayHasKey( 'failure_reason', $result->get_error_data() );
 		$this->assertSame( 'no_permission_strategy', $result->get_error_data()['failure_reason'] );


### PR DESCRIPTION
## What

- Add `WP_Error` to `ignoredNames` in the `SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions` PHPCS rule
- Import `WP_Error` via `use` statements and replace `\WP_Error` with `WP_Error` in code across 28 files (17 source + 11 test)
- Keep `\WP_Error` fully qualified in PHPDoc annotations (required by `FullyQualifiedClassNameInAnnotation` rule)

## Why

`WP_Error` is not an exception class — it doesn't extend `Exception` or `Throwable`. The `FullyQualifiedExceptions` rule was enforcing FQN for it solely because the class name ends with "Error". The rule's `ignoredNames` property exists for exactly this case, allowing imported short names in code while annotations remain fully qualified.

Closes #128