### PR TITLE
feat: allow custom annotation fields to pass through McpAnnotationMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Part of the [**AI Building Blocks for WordPress** initiative](https://make.wordp
 
 The official WordPress package for MCP integration that exposes WordPress abilities as [Model Context Protocol (MCP)](https://modelcontextprotocol.io) tools, resources, and prompts for AI agents.
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/WordPress/mcp-adapter)
+
 ## Overview
 
 This adapter bridges WordPress's Abilities API with the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/), providing a standardized way for AI agents to interact with WordPress functionality. It includes HTTP and STDIO transport support, comprehensive error handling, and an extensible architecture for custom integrations.

--- a/includes/Domain/Utils/McpAnnotationMapper.php
+++ b/includes/Domain/Utils/McpAnnotationMapper.php
@@ -82,6 +82,12 @@ class McpAnnotationMapper {
 	 * Only includes annotations applicable to the specified feature type.
 	 * Null values are excluded from the result.
 	 *
+	 * Unknown annotation keys (not part of the MCP specification) are passed through
+	 * as-is for tool and resource feature types. MCP clients ignore unrecognized fields,
+	 * so this is protocol-safe and enables domain-specific metadata on annotations.
+	 *
+	 * @since n.e.x.t
+	 *
 	 * @param array  $ability_annotations WordPress ability annotations.
 	 * @param string $feature_type        The MCP feature type ('tool', 'resource', or 'prompt').
 	 *
@@ -113,7 +119,48 @@ class McpAnnotationMapper {
 			$result[ $mcp_field ] = $normalized;
 		}
 
+		// Pass through unknown annotation keys as-is (no normalization).
+		// Prompts are excluded: MCP clients may not expect custom fields on prompts.
+		if ( 'prompt' !== $feature_type ) {
+			$known_keys = self::get_known_annotation_keys();
+			foreach ( $ability_annotations as $key => $value ) {
+				if ( isset( $known_keys[ $key ] ) || null === $value ) {
+					continue;
+				}
+				$result[ $key ] = $value;
+			}
+		}
+
 		return $result;
+	}
+
+	/**
+	 * Get all known annotation keys (MCP fields and WordPress ability property aliases).
+	 *
+	 * Used to identify which keys in the source annotations are "unknown" and should
+	 * be passed through without normalization.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array<string, true> Map of known keys for fast lookup.
+	 */
+	private static function get_known_annotation_keys(): array {
+		static $known_keys = null;
+
+		if ( null !== $known_keys ) {
+			return $known_keys;
+		}
+
+		$known_keys = array();
+		foreach ( self::$mcp_annotations as $mcp_field => $config ) {
+			$known_keys[ $mcp_field ] = true;
+			if ( null === $config['ability_property'] ) {
+				continue;
+			}
+			$known_keys[ $config['ability_property'] ] = true;
+		}
+
+		return $known_keys;
 	}
 
 	/**

--- a/tests/Unit/Domain/Utils/McpAnnotationMapperTest.php
+++ b/tests/Unit/Domain/Utils/McpAnnotationMapperTest.php
@@ -25,7 +25,7 @@ final class McpAnnotationMapperTest extends TestCase {
 		$this->assertEmpty( $result );
 	}
 
-	public function test_map_filters_out_non_mcp_fields(): void {
+	public function test_map_passes_through_unknown_fields(): void {
 		$annotations = array(
 			'customField'  => 'value',
 			'invalidField' => 123,
@@ -35,8 +35,10 @@ final class McpAnnotationMapperTest extends TestCase {
 		$result = McpAnnotationMapper::map( $annotations, 'resource' );
 
 		$this->assertArrayHasKey( 'audience', $result );
-		$this->assertArrayNotHasKey( 'customField', $result );
-		$this->assertArrayNotHasKey( 'invalidField', $result );
+		$this->assertArrayHasKey( 'customField', $result );
+		$this->assertSame( 'value', $result['customField'] );
+		$this->assertArrayHasKey( 'invalidField', $result );
+		$this->assertSame( 123, $result['invalidField'] );
 	}
 
 	public function test_map_includes_valid_fields_for_resource(): void {
@@ -236,5 +238,131 @@ final class McpAnnotationMapperTest extends TestCase {
 		$this->assertArrayHasKey( 'priority', $result );
 		$this->assertArrayHasKey( 'openWorldHint', $result );
 		$this->assertArrayHasKey( 'title', $result );
+	}
+
+	// Custom annotation pass-through tests.
+
+	public function test_map_passes_through_unknown_fields_for_tools(): void {
+		$annotations = array(
+			'readonly'     => true,
+			'x-vendor-tag' => 'my-value',
+			'customMeta'   => array( 'key' => 'val' ),
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'tool' );
+
+		$this->assertArrayHasKey( 'readOnlyHint', $result );
+		$this->assertArrayHasKey( 'x-vendor-tag', $result );
+		$this->assertSame( 'my-value', $result['x-vendor-tag'] );
+		$this->assertArrayHasKey( 'customMeta', $result );
+		$this->assertSame( array( 'key' => 'val' ), $result['customMeta'] );
+	}
+
+	public function test_map_passes_through_unknown_fields_for_resources(): void {
+		$annotations = array(
+			'audience'     => array( 'user' ),
+			'x-vendor-tag' => 42,
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'resource' );
+
+		$this->assertArrayHasKey( 'audience', $result );
+		$this->assertArrayHasKey( 'x-vendor-tag', $result );
+		$this->assertSame( 42, $result['x-vendor-tag'] );
+	}
+
+	public function test_map_does_not_pass_through_unknown_fields_for_prompts(): void {
+		$annotations = array(
+			'audience'     => array( 'user' ),
+			'x-vendor-tag' => 'should-not-appear',
+			'customMeta'   => 'also-excluded',
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'prompt' );
+
+		$this->assertArrayHasKey( 'audience', $result );
+		$this->assertArrayNotHasKey( 'x-vendor-tag', $result );
+		$this->assertArrayNotHasKey( 'customMeta', $result );
+		$this->assertCount( 1, $result );
+	}
+
+	public function test_map_does_not_pass_through_known_fields_excluded_by_feature_type(): void {
+		$annotations = array(
+			'audience'      => array( 'user' ),
+			'readOnlyHint'  => true,
+			'title'         => 'Tool Title',
+			'x-vendor-tag'  => 'custom',
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'resource' );
+
+		// Shared annotations should be included.
+		$this->assertArrayHasKey( 'audience', $result );
+
+		// Tool-specific known fields should NOT appear — they are excluded by feature type, not passed through.
+		$this->assertArrayNotHasKey( 'readOnlyHint', $result );
+		$this->assertArrayNotHasKey( 'title', $result );
+
+		// Unknown fields should pass through.
+		$this->assertArrayHasKey( 'x-vendor-tag', $result );
+		$this->assertSame( 'custom', $result['x-vendor-tag'] );
+	}
+
+	public function test_map_excludes_null_unknown_fields(): void {
+		$annotations = array(
+			'x-vendor-tag' => null,
+			'x-other'      => 'present',
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'tool' );
+
+		$this->assertArrayNotHasKey( 'x-vendor-tag', $result );
+		$this->assertArrayHasKey( 'x-other', $result );
+		$this->assertSame( 'present', $result['x-other'] );
+	}
+
+	public function test_map_handles_mixed_known_and_unknown_fields(): void {
+		$annotations = array(
+			'readonly'      => true,
+			'destructive'   => false,
+			'title'         => 'My Tool',
+			'x-category'    => 'search',
+			'x-deprecated'  => false,
+			'audience'      => array( 'user' ),
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'tool' );
+
+		// Known fields mapped normally.
+		$this->assertArrayHasKey( 'readOnlyHint', $result );
+		$this->assertTrue( $result['readOnlyHint'] );
+		$this->assertArrayHasKey( 'destructiveHint', $result );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertArrayHasKey( 'audience', $result );
+
+		// Unknown fields passed through as-is.
+		$this->assertArrayHasKey( 'x-category', $result );
+		$this->assertSame( 'search', $result['x-category'] );
+		$this->assertArrayHasKey( 'x-deprecated', $result );
+		$this->assertFalse( $result['x-deprecated'] );
+
+		// WordPress aliases should NOT appear as separate keys.
+		$this->assertArrayNotHasKey( 'readonly', $result );
+		$this->assertArrayNotHasKey( 'destructive', $result );
+	}
+
+	public function test_map_does_not_pass_through_wordpress_ability_property_aliases(): void {
+		$annotations = array(
+			'readonly'    => true,
+			'destructive' => false,
+			'idempotent'  => true,
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'resource' );
+
+		// WordPress aliases are known keys — they should NOT pass through as unknown.
+		$this->assertArrayNotHasKey( 'readonly', $result );
+		$this->assertArrayNotHasKey( 'destructive', $result );
+		$this->assertArrayNotHasKey( 'idempotent', $result );
 	}
 }

--- a/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
+++ b/tests/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
@@ -58,7 +58,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$this->assertArrayNotHasKey( 'lastModified', $arr['annotations'] );
 	}
 
-		public function test_empty_annotations_are_not_included(): void {
+		public function test_custom_annotations_pass_through(): void {
 			$ability = wp_get_ability( 'test/resource' );
 			$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
 
@@ -67,8 +67,10 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 
 			$arr = $resource->to_array();
 
-			// Verify annotations field is not present when empty.
-			$this->assertArrayNotHasKey( 'annotations', $arr );
+			// Custom annotation fields pass through the mapper.
+			$this->assertArrayHasKey( 'annotations', $arr );
+			$this->assertArrayHasKey( 'group', $arr['annotations'] );
+			$this->assertSame( 'tests', $arr['annotations']['group'] );
 		}
 
 		public function test_get_uri_trims_whitespace_from_meta(): void {

--- a/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
+++ b/tests/Unit/Tools/RegisterAbilityAsMcpToolTest.php
@@ -61,7 +61,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertFalse( $arr['annotations']['idempotentHint'] );
 	}
 
-	public function test_instructions_field_is_ignored(): void {
+	public function test_instructions_field_passes_through_as_custom_annotation(): void {
 		$ability = wp_get_ability( 'test/with-instructions' );
 		$this->assertNotNull( $ability, 'Ability test/with-instructions should be registered' );
 
@@ -70,11 +70,12 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$arr = $tool->to_array();
 
-		// Verify instructions field is not in the output.
+		// Custom annotation fields pass through the mapper.
 		$this->assertArrayHasKey( 'annotations', $arr );
-		$this->assertArrayNotHasKey( 'instructions', $arr['annotations'] );
+		$this->assertArrayHasKey( 'instructions', $arr['annotations'] );
+		$this->assertSame( 'These are instructions', $arr['annotations']['instructions'] );
 
-		// Verify other annotations are mapped correctly.
+		// Known annotations are still mapped correctly.
 		$this->assertArrayHasKey( 'readOnlyHint', $arr['annotations'] );
 		$this->assertTrue( $arr['annotations']['readOnlyHint'] );
 	}


### PR DESCRIPTION
Fixes #134

## What

`McpAnnotationMapper::map()` now preserves unknown annotation keys from the
source array, passing them through as-is alongside the mapped MCP fields.

**Changes:**

- After the known-field mapping loop, a second pass collects any keys that
  are not recognized MCP fields or WordPress ability property aliases
- Unknown fields are included without type normalization (they are
  domain-specific metadata the mapper has no schema for)
- A new `get_known_annotation_keys()` private helper builds and caches the
  full set of known keys for fast `isset()` lookups
- Pass-through applies to `tool` and `resource` feature types only; `prompt`
  annotations remain unaffected
- Null unknown values are filtered out, consistent with existing behavior
  for known fields

## Why

The strict whitelist silently discarded any annotation key not in the MCP
specification. This prevented consumers from attaching domain-specific
metadata to tool and resource annotations — metadata that compliant MCP
clients will simply ignore per the protocol's extensibility model.

Passing through unknown fields is protocol-safe and enables use cases like
vendor-prefixed tags (`x-vendor-category`), deprecation markers, or
grouping metadata without requiring upstream schema changes.

## Testing

- 7 new unit tests in `McpAnnotationMapperTest`: pass-through for tools,
  resources, prompt exclusion, feature-type exclusion, null filtering,
  mixed known+unknown fields, and WordPress alias exclusion
- 2 existing integration tests updated to reflect new pass-through behavior
  (`RegisterAbilityAsMcpResourceTest`, `RegisterAbilityAsMcpToolTest`)
- Full suite: 596 tests, 2353 assertions — all pass
- PHPCS clean, PHPStan Level 8 zero errors

Linear: AIINT-273