### PR TITLE
docs: v0.5.0 documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ For detailed information about MCP components, see the [Model Context Protocol s
 │   │   # Shared utilities
 │   ├── Utils/
 │   │   ├── McpNameSanitizer.php            # MCP name sanitization
+│   │   ├── McpValidator.php                # MCP name/URI/schema validation
+│   │   ├── McpAnnotationMapper.php         # Annotation mapping from abilities
+│   │   ├── SchemaTransformer.php           # Schema format transformation
 │   │   ├── ContentBlockHelper.php          # Content block DTO factory
 │   │   └── AbilityArgumentNormalizer.php   # Argument normalization
 │   │   # MCP Tools implementation
@@ -129,10 +132,11 @@ For detailed information about MCP components, see the [Model Context Protocol s
 │       ├── ErrorLogMcpObservabilityHandler.php       # Default handler
 │       ├── NullMcpObservabilityHandler.php           # Null object pattern
 │       ├── McpObservabilityHelperTrait.php           # Helper trait
+│       ├── ConsoleObservabilityHandler.php          # Console output handler
 │       └── FailureReason.php                        # Standardized failure reasons
 │
 │   # Transport layer implementations
-├─── Transport/
+├── Transport/
 │   ├── Contracts/
 │   │   ├── McpTransportInterface.php     # Base transport interface
 │   │   └── McpRestTransportInterface.php # REST transport interface

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ For detailed information about MCP components, see the [Model Context Protocol s
 │
 │   # Business logic and MCP components
 ├── Domain/
+│   │   # Shared contracts
+│   ├── Contracts/
+│   │   └── McpComponentInterface.php       # Contract for MCP components
+│   │   # Shared utilities
+│   ├── Utils/
+│   │   ├── McpNameSanitizer.php            # MCP name sanitization
+│   │   ├── ContentBlockHelper.php          # Content block DTO factory
+│   │   └── AbilityArgumentNormalizer.php   # Argument normalization
 │   │   # MCP Tools implementation
 │   ├── Tools/
 │   │   ├── McpTool.php                   # Base tool class
@@ -120,7 +128,8 @@ For detailed information about MCP components, see the [Model Context Protocol s
 │       │   └── McpObservabilityHandlerInterface.php  # Observability interface
 │       ├── ErrorLogMcpObservabilityHandler.php       # Default handler
 │       ├── NullMcpObservabilityHandler.php           # Null object pattern
-│       └── McpObservabilityHelperTrait.php           # Helper trait
+│       ├── McpObservabilityHelperTrait.php           # Helper trait
+│       └── FailureReason.php                        # Standardized failure reasons
 │
 │   # Transport layer implementations
 ├─── Transport/
@@ -170,6 +179,7 @@ Individual server management with comprehensive configuration:
 
 - **PHP**: >= 7.4
 - **[WordPress Abilities API](https://github.com/WordPress/abilities-api)**: For ability registration and management
+- **[php-mcp-schema](https://github.com/WordPress/php-mcp-schema)** (^0.1.0): Typed DTOs for MCP protocol types (MCP 2025-11-25)
 
 ### WordPress Abilities API Integration
 
@@ -493,6 +503,10 @@ See the [Error Handling Guide](docs/guides/error-handling.md) for detailed imple
 The MCP Adapter includes built-in observability for tracking metrics and events. You can implement custom observability handlers to integrate with monitoring systems, analytics platforms, or performance tracking tools.
 
 See the [Observability Guide](docs/guides/observability.md) for detailed metrics tracking and custom handler implementation.
+
+## Migration
+
+- [Migration Guide: v0.5.0](docs/migration/v0.5.0.md) — Breaking changes and upgrade instructions
 
 ## License
 [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,11 @@ Documentation for the WordPress MCP Adapter - transform WordPress abilities into
 
 - **[Architecture Overview](architecture/overview.md)** - System design and performance considerations
 
+## Migration Guides
+
+- **[Migrating to v0.3.0](migration/v0.3.0.md)** - Breaking changes and upgrade steps for v0.3.0
+- **[Migrating to v0.5.0](migration/v0.5.0.md)** - Breaking changes and upgrade steps for v0.5.0
+
 ## Troubleshooting
 
 - **[Common Issues](troubleshooting/common-issues.md)** - Quick fixes and debugging techniques
@@ -46,6 +51,10 @@ Documentation for the WordPress MCP Adapter - transform WordPress abilities into
 ### Custom Authentication
 1. [Transport Permissions](guides/transport-permissions.md) (recommended)
 2. [Custom Transports](guides/custom-transports.md) (advanced)
+
+### Upgrading
+1. [Migrating to v0.5.0](migration/v0.5.0.md)
+2. [Migrating to v0.3.0](migration/v0.3.0.md)
 
 ### Troubleshooting
 1. [Common Issues](troubleshooting/common-issues.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,13 @@
 
 Documentation for the WordPress MCP Adapter - transform WordPress abilities into AI-accessible tools, resources, and prompts.
 
-## Getting Started
+## Getting started
 
 - **[Quick Start Guide](getting-started/README.md)** - Get running in minutes with working examples
 - **[Installation Guide](getting-started/installation.md)** - Installation methods (Composer recommended)
 - **[Basic Examples](getting-started/basic-examples.md)** - Complete examples for tools, resources, and prompts
 
-## Implementation Guides
+## Implementation guides
 
 - **[Default Server](guides/default-server.md)** - Understanding the built-in MCP server and core abilities
 - **[Creating Abilities](guides/creating-abilities.md)** - Build tools, resources, and prompts with annotations
@@ -18,11 +18,11 @@ Documentation for the WordPress MCP Adapter - transform WordPress abilities into
 - **[Observability](guides/observability.md)** - Metrics tracking and monitoring integration
 - **[CLI Usage](guides/cli-usage.md)** - WP-CLI commands for STDIO transport
 
-## System Design
+## System design
 
 - **[Architecture Overview](architecture/overview.md)** - System design and performance considerations
 
-## Migration Guides
+## Migration guides
 
 - **[Migrating to v0.3.0](migration/v0.3.0.md)** - Breaking changes and upgrade steps for v0.3.0
 - **[Migrating to v0.5.0](migration/v0.5.0.md)** - Breaking changes and upgrade steps for v0.5.0
@@ -36,19 +36,19 @@ Documentation for the WordPress MCP Adapter - transform WordPress abilities into
 - **[Contributing Guide](../CONTRIBUTING.md)** - Development setup, coding standards, and contribution workflow
 - **[Testing Guide](guides/testing.md)** - Running and writing tests with wp-env
 
-## Quick Navigation
+## Quick navigation
 
-### New to MCP Adapter
+### New to MCP Adapter?
 1. [Quick Start Guide](getting-started/README.md)
 2. [Default Server](guides/default-server.md)
 3. [Basic Examples](getting-started/basic-examples.md)
 4. [Architecture Overview](architecture/overview.md)
 
-### Build Custom Tools
+### Build custom tools
 1. [Creating Abilities](guides/creating-abilities.md)
 2. [Basic Examples](getting-started/basic-examples.md)
 
-### Custom Authentication
+### Custom authentication
 1. [Transport Permissions](guides/transport-permissions.md) (recommended)
 2. [Custom Transports](guides/custom-transports.md) (advanced)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,12 +1,12 @@
-# Architecture Overview
+# Architecture overview
 
 This document explains how the MCP Adapter transforms WordPress abilities into MCP components and handles requests from AI agents.
 
-## System Architecture
+## System architecture
 
 The MCP Adapter uses a two-layer architecture that separates protocol concerns from WordPress integration:
 
-### Schema Layer (Protocol DTOs)
+### Schema layer (protocol DTOs)
 
 The Schema Layer is provided by the `php-mcp-schema` package (`WP\McpSchema\` namespace). It contains protocol-only data transfer objects that are safe to expose to MCP clients.
 
@@ -20,7 +20,7 @@ The Schema Layer is provided by the `php-mcp-schema` package (`WP\McpSchema\` na
 
 All DTOs extend `AbstractDataTransferObject`, which provides `toArray()` and `fromArray()` methods for serialization. These types carry no execution logic and no adapter-internal metadata.
 
-### Adapter Layer (WordPress Integration)
+### Adapter layer (WordPress integration)
 
 The Adapter Layer wraps each protocol DTO with execution wiring and WordPress-specific metadata. Domain models `McpTool`, `McpResource`, and `McpPrompt` each implement the `McpComponentInterface` contract:
 
@@ -42,7 +42,7 @@ This separation ensures that:
 
 `McpComponentInterface` is an internal contract (`@internal`). It is not intended for third-party implementation.
 
-### Supporting Layers
+### Supporting layers
 
 The remaining layers wire the Schema and Adapter layers together:
 
@@ -51,14 +51,14 @@ The remaining layers wire the Schema and Adapter layers together:
 - **Transport:** `HttpTransport`, STDIO transport, `RequestRouter`
 - **Infrastructure:** Error handling (`McpErrorHandlerInterface`), Observability (`McpObservabilityHandlerInterface`)
 
-## Core Components
+## Core components
 
-### McpAdapter (Singleton Registry)
+### McpAdapter (singleton registry)
 - **Purpose**: Central registry managing multiple MCP servers
 - **Key Methods**: `create_server()`, `get_server()`, `get_servers()`, `instance()`
 - **Initialization**: Hooks into `rest_api_init` and fires `mcp_adapter_init` action
 
-### McpServer (Server Instance)
+### McpServer (server instance)
 - **Purpose**: Individual MCP server with specific configuration
 - **Components**: Uses `McpComponentRegistry` to manage `McpComponentInterface` instances
 - **Typed access**: `get_tools()`, `get_resources()`, `get_prompts()` return component collections
@@ -80,13 +80,13 @@ The remaining layers wire the Schema and Adapter layers together:
 - **DTO serialization boundary**: Converts `AbstractDataTransferObject` results to arrays via `toArray()` and `JSONRPCErrorResponse` results to error arrays
 - **Observability**: Extracts per-component context from `McpComponentInterface::get_observability_context()` for request tagging
 
-## Request Flow
+## Request flow
 
 ```
 AI Agent --> Transport --> RequestRouter --> Handler --> McpComponentInterface --> Schema DTO --> Response
 ```
 
-### Detailed Flow
+### Detailed flow
 1. **Transport** receives MCP request and authenticates
 2. **RequestRouter** maps method to appropriate handler
 3. **Handler** finds the `McpComponentInterface` component, validates input, and invokes execution
@@ -95,7 +95,7 @@ AI Agent --> Transport --> RequestRouter --> Handler --> McpComponentInterface -
 6. **RequestRouter** calls `toArray()` on the DTO at the serialization boundary
 7. **Transport** wraps the array in a JSON-RPC envelope and returns it
 
-### Method Routing
+### Method routing
 
 The `RequestRouter` maps MCP methods to handlers. All handlers return schema DTOs:
 
@@ -112,9 +112,9 @@ The `RequestRouter` maps MCP methods to handlers. All handlers return schema DTO
 
 Protocol-level errors (tool not found, missing parameters) return `JSONRPCErrorResponse`. Execution-level errors (permission denied, runtime failure) return the appropriate result DTO with `isError: true`.
 
-## Component Creation
+## Component creation
 
-### From WordPress Ability
+### From WordPress ability
 
 WordPress abilities are converted to MCP components using factory methods on each domain model:
 
@@ -129,7 +129,7 @@ $resource = McpResource::fromAbility( $ability );  // Returns McpResource|WP_Err
 $prompt = McpPrompt::fromAbility( $ability );  // Returns McpPrompt|WP_Error
 ```
 
-### From Array Configuration
+### From array configuration
 
 Components can also be created directly without a WordPress ability:
 
@@ -145,7 +145,7 @@ $tool = McpTool::fromArray( [
 ] );
 ```
 
-### Protocol DTO Access
+### Protocol DTO access
 
 Each component exposes its clean protocol DTO for serialization:
 
@@ -156,7 +156,7 @@ $array = $dto->toArray();          // Protocol-safe array for JSON responses
 
 The DTO contains only MCP specification fields. Adapter metadata (ability reference, schema transformation flags) lives on the `McpTool` instance and is never serialized.
 
-## Utility Classes
+## Utility classes
 
 ### McpNameSanitizer
 
@@ -216,9 +216,9 @@ Extended validation for MCP component data per the MCP 2025-11-25 specification:
 - `get_annotation_validation_errors()` -- Annotation field validation (audience, priority, lastModified)
 - `validate_base64()` -- Base64 content validation
 
-## Transport Layer
+## Transport layer
 
-### Transport Interfaces
+### Transport interfaces
 
 ```php
 interface McpTransportInterface {
@@ -232,16 +232,16 @@ interface McpRestTransportInterface extends McpTransportInterface {
 }
 ```
 
-### Built-in Transports
+### Built-in transports
 
 - **HttpTransport**: Recommended (MCP Streamable HTTP compliant)
 - **STDIO Transport**: Via WP-CLI commands
 
-### Dependency Injection
+### Dependency injection
 
 Transports and the `RequestRouter` receive all dependencies through `McpTransportContext`, which bundles the server instance, all handlers, the router, error handler, and observability handler.
 
-### DTO-Aware RequestRouter
+### DTO-aware RequestRouter
 
 The `RequestRouter` is the serialization boundary between typed DTOs and transport-level arrays:
 
@@ -250,9 +250,9 @@ The `RequestRouter` is the serialization boundary between typed DTOs and transpo
 3. For error DTOs, it extracts the error object and returns `['error' => ...]`.
 4. The transport wraps the array in the JSON-RPC 2.0 envelope.
 
-## Error Handling
+## Error handling
 
-### Two-Part System
+### Two-part system
 
 1. **Error Response Creation**: `McpErrorFactory` creates `JSONRPCErrorResponse` DTOs for protocol errors
 2. **Error Logging**: `McpErrorHandlerInterface` implementations log errors for monitoring
@@ -269,14 +269,14 @@ $error_handler->log( 'Tool not found', [
 ], 'error' );
 ```
 
-### Built-in Error Handlers
+### Built-in error handlers
 
 - **ErrorLogMcpErrorHandler**: Logs to PHP error log
 - **NullMcpErrorHandler**: No-op handler (default)
 
 ## Observability
 
-### Event Emission Pattern
+### Event emission pattern
 
 The system emits events rather than storing counters:
 
@@ -286,15 +286,15 @@ interface McpObservabilityHandlerInterface {
 }
 ```
 
-### Tracked Events
+### Tracked events
 
 - **Request events**: `mcp.request` with status, method, transport, and duration tags
 - **Component events**: `mcp.component.registered`, `mcp.component.registration_failed`
 - **Per-component context**: Extracted from `McpComponentInterface::get_observability_context()` and merged into request tags
 
-## Extension Points
+## Extension points
 
-### Custom Transport
+### Custom transport
 
 ```php
 class MyTransport implements McpRestTransportInterface {
@@ -328,7 +328,7 @@ class MyTransport implements McpRestTransportInterface {
 }
 ```
 
-### Custom Error Handler
+### Custom error handler
 
 ```php
 class MyErrorHandler implements McpErrorHandlerInterface {
@@ -338,7 +338,7 @@ class MyErrorHandler implements McpErrorHandlerInterface {
 }
 ```
 
-### Custom Observability Handler
+### Custom observability handler
 
 ```php
 class MyObservabilityHandler implements McpObservabilityHandlerInterface {
@@ -357,7 +357,7 @@ class MyObservabilityHandler implements McpObservabilityHandlerInterface {
 }
 ```
 
-## Design Principles
+## Design principles
 
 - **Two-layer DTO separation**: Protocol DTOs from `php-mcp-schema` carry no adapter-internal fields; `get_protocol_dto()->toArray()` always produces spec-compliant output
 - **Dependency injection**: All transports receive dependencies through `McpTransportContext`; no global state beyond the `McpAdapter` singleton
@@ -365,7 +365,7 @@ class MyObservabilityHandler implements McpObservabilityHandlerInterface {
 - **Event emission over counters**: Observability emits events; external systems handle aggregation — zero overhead when disabled
 - **Lazy loading**: Components created only when needed; validation disabled by default via `mcp_adapter_validation_enabled` filter
 
-## Next Steps
+## Next steps
 
 - **[Creating Abilities](../guides/creating-abilities.md)** -- Build MCP components from WordPress abilities
 - **[Custom Transports](../guides/custom-transports.md)** -- Implement specialized transport protocols

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -4,24 +4,71 @@ This document explains how the MCP Adapter transforms WordPress abilities into M
 
 ## System Architecture
 
-The MCP Adapter uses a layered architecture with clear separation of concerns:
+The MCP Adapter uses a two-layer architecture that separates protocol concerns from WordPress integration:
 
-1. **Transport Layer**: Handles communication protocols (HTTP, STDIO)
-2. **Core Layer**: Manages servers, routing, and component registration  
-3. **Component Layer**: Tools, resources, and prompts
-4. **WordPress Layer**: Abilities API integration
+### Schema Layer (Protocol DTOs)
+
+The Schema Layer is provided by the `php-mcp-schema` package (`WP\McpSchema\` namespace). It contains protocol-only data transfer objects that are safe to expose to MCP clients.
+
+**Key DTOs:**
+
+| Category | Classes |
+|----------|---------|
+| Component definitions | `Tool`, `Resource`, `Prompt`, `PromptArgument`, `ToolAnnotations`, `Annotations` |
+| Result types | `ListToolsResult`, `CallToolResult`, `ListResourcesResult`, `ReadResourceResult`, `ListPromptsResult`, `GetPromptResult` |
+| Content blocks | `TextContent`, `ImageContent`, `AudioContent`, `EmbeddedResource` |
+
+All DTOs extend `AbstractDataTransferObject`, which provides `toArray()` and `fromArray()` methods for serialization. These types carry no execution logic and no adapter-internal metadata.
+
+### Adapter Layer (WordPress Integration)
+
+The Adapter Layer wraps each protocol DTO with execution wiring and WordPress-specific metadata. Domain models `McpTool`, `McpResource`, and `McpPrompt` each implement the `McpComponentInterface` contract:
+
+```php
+interface McpComponentInterface {
+    public function get_protocol_dto(): AbstractDataTransferObject;
+    public function execute( $arguments );
+    public function check_permission( $arguments );
+    public function get_adapter_meta(): array;
+    public function get_observability_context(): array;
+}
+```
+
+This separation ensures that:
+
+- **Protocol DTOs** contain only fields defined by the MCP specification and are serialized directly into responses.
+- **Adapter metadata** (ability references, schema transformation flags, permission callbacks) stays internal and is never exposed to MCP clients.
+- **Observability context** provides structured tags for logging and metrics without polluting DTO `_meta`.
+
+`McpComponentInterface` is an internal contract (`@internal`). It is not intended for third-party implementation.
+
+### Integration Layers
+
+The remaining layers wire the Schema and Adapter layers together:
+
+- **Core:** `McpAdapter` (singleton registry), `McpServer`, `McpComponentRegistry`, `McpTransportFactory`
+- **Handlers:** `InitializeHandler`, `ToolsHandler`, `ResourcesHandler`, `PromptsHandler`, `SystemHandler`
+- **Transport:** `HttpTransport`, STDIO transport, `RequestRouter`
+- **Infrastructure:** Error handling (`McpErrorHandlerInterface`), Observability (`McpObservabilityHandlerInterface`)
 
 ## Core Components
 
 ### McpAdapter (Singleton Registry)
 - **Purpose**: Central registry managing multiple MCP servers
-- **Key Methods**: `create_server()`, `get_servers()`, `instance()`
+- **Key Methods**: `create_server()`, `get_server()`, `get_servers()`, `instance()`
 - **Initialization**: Hooks into `rest_api_init` and fires `mcp_adapter_init` action
 
-### McpServer (Server Instance)  
+### McpServer (Server Instance)
 - **Purpose**: Individual MCP server with specific configuration
-- **Components**: Uses `McpComponentRegistry` to manage tools, resources, prompts
+- **Components**: Uses `McpComponentRegistry` to manage `McpComponentInterface` instances
+- **Typed access**: `get_tools()`, `get_resources()`, `get_prompts()` return component collections
 - **Dependencies**: Error handler, observability handler, transport permission callback
+
+### McpComponentRegistry
+- **Purpose**: Stores and retrieves `McpComponentInterface` instances
+- **Registration**: `register_tools()`, `register_resources()`, `register_prompts()` accept both ability names and `McpComponentInterface` instances
+- **Name sanitization**: Uses `McpNameSanitizer` to normalize tool and prompt names
+- **Validation**: Validates components with `McpValidator` when validation is enabled
 
 ### McpTransportFactory
 - **Purpose**: Creates transport instances with dependency injection
@@ -29,75 +76,145 @@ The MCP Adapter uses a layered architecture with clear separation of concerns:
 - **Validation**: Ensures transport classes implement `McpTransportInterface`
 
 ### RequestRouter
-- **Purpose**: Routes MCP method calls to appropriate handlers
-- **Methods**: Maps method names to handler functions
-- **Observability**: Tracks request metrics and timing
+- **Purpose**: Routes MCP method calls to handlers that return schema DTOs
+- **DTO serialization boundary**: Converts `AbstractDataTransferObject` results to arrays via `toArray()` and `JSONRPCErrorResponse` results to error arrays
+- **Observability**: Extracts per-component context from `McpComponentInterface::get_observability_context()` for request tagging
 
 ## Request Flow
 
-Simple request flow through the system:
-
 ```
-AI Agent → Transport → RequestRouter → Handler → WordPress Ability → Response
+AI Agent --> Transport --> RequestRouter --> Handler --> McpComponentInterface --> Schema DTO --> Response
 ```
 
 ### Detailed Flow
 1. **Transport** receives MCP request and authenticates
 2. **RequestRouter** maps method to appropriate handler
-3. **Handler** finds component (tool/resource/prompt) and validates input
-4. **WordPress Ability** executes with permission checks
-5. **Response** formatted and returned through transport
+3. **Handler** finds the `McpComponentInterface` component, validates input, and invokes execution
+4. **Component** delegates to a WordPress ability or direct callable, returning a result
+5. **Handler** wraps the result in a schema DTO (e.g., `CallToolResult`)
+6. **RequestRouter** calls `toArray()` on the DTO at the serialization boundary
+7. **Transport** wraps the array in a JSON-RPC envelope and returns it
 
 ### Method Routing
 
-The `RequestRouter` maps MCP methods to handlers:
+The `RequestRouter` maps MCP methods to handlers. All handlers return schema DTOs:
 
-```php
-$handlers = [
-    'initialize'          => InitializeHandler,
-    'tools/list'          => ToolsHandler::list_tools(),
-    'tools/call'          => ToolsHandler::call_tool(),
-    'resources/list'      => ResourcesHandler::list_resources(),
-    'resources/read'      => ResourcesHandler::read_resource(),
-    'prompts/list'        => PromptsHandler::list_prompts(),
-    'prompts/get'         => PromptsHandler::get_prompt(),
-    'ping'                => SystemHandler::ping(),
-    'logging/setLevel'    => SystemHandler::set_logging_level(),
-    'completion/complete' => SystemHandler::complete(),
-    'roots/list'          => SystemHandler::list_roots(),
-];
-```
+| Method | Handler | Return Type |
+|--------|---------|-------------|
+| `initialize` | `InitializeHandler::handle()` | `InitializeResult` |
+| `tools/list` | `ToolsHandler::list_tools()` | `ListToolsResult` |
+| `tools/call` | `ToolsHandler::call_tool()` | `CallToolResult` or `JSONRPCErrorResponse` |
+| `resources/list` | `ResourcesHandler::list_resources()` | `ListResourcesResult` |
+| `resources/read` | `ResourcesHandler::read_resource()` | `ReadResourceResult` or `JSONRPCErrorResponse` |
+| `prompts/list` | `PromptsHandler::list_prompts()` | `ListPromptsResult` |
+| `prompts/get` | `PromptsHandler::get_prompt()` | `GetPromptResult` or `JSONRPCErrorResponse` |
+| `ping` | `SystemHandler::ping()` | Empty result DTO |
+
+Protocol-level errors (tool not found, missing parameters) return `JSONRPCErrorResponse`. Execution-level errors (permission denied, runtime failure) return the appropriate result DTO with `isError: true`.
 
 ## Component Creation
 
-### Ability to MCP Component Conversion
+### From WordPress Ability
 
-WordPress abilities are converted to MCP components using factory classes:
-
-```php
-// Tools
-$tool = RegisterAbilityAsMcpTool::make($ability, $server);
-
-// Resources (require 'uri' in ability meta)
-$resource = RegisterAbilityAsMcpResource::make($ability, $server);
-
-// Prompts (support 'arguments' and 'annotations' in ability meta)
-$prompt = RegisterAbilityAsMcpPrompt::make($ability, $server);
-```
-
-### Component Registry
-
-The `McpComponentRegistry` manages component registration:
+WordPress abilities are converted to MCP components using factory methods on each domain model:
 
 ```php
-class McpComponentRegistry {
-    public function register_ability_as_tool(string $ability_name): void;
-    public function register_ability_as_resource(string $ability_name): void;
-    public function register_ability_as_prompt(string $ability_name): void;
-    
-    // Automatic observability tracking for registration events
-}
+// Tool from ability
+$tool = McpTool::fromAbility( $ability );  // Returns McpTool|WP_Error
+
+// Resource from ability
+$resource = McpResource::fromAbility( $ability );  // Returns McpResource|WP_Error
+
+// Prompt from ability
+$prompt = McpPrompt::fromAbility( $ability );  // Returns McpPrompt|WP_Error
 ```
+
+### From Array Configuration
+
+Components can also be created directly without a WordPress ability:
+
+```php
+$tool = McpTool::fromArray( [
+    'name'        => 'my-tool',
+    'title'       => 'My Tool',
+    'description' => 'Does something useful',
+    'inputSchema' => [ 'type' => 'object', 'properties' => [ ... ] ],
+    'handler'     => fn( $args ) => [ 'result' => 'done' ],
+    'permission'  => fn() => current_user_can( 'edit_posts' ),
+    'annotations' => [ 'readOnlyHint' => true ],
+] );
+```
+
+### Protocol DTO Access
+
+Each component exposes its clean protocol DTO for serialization:
+
+```php
+$dto = $tool->get_protocol_dto();  // Returns WP\McpSchema\Server\Tools\DTO\Tool
+$array = $dto->toArray();          // Protocol-safe array for JSON responses
+```
+
+The DTO contains only MCP specification fields. Adapter metadata (ability reference, schema transformation flags) lives on the `McpTool` instance and is never serialized.
+
+## Utility Classes
+
+### McpNameSanitizer
+
+Normalizes component names to MCP-valid format per MCP 2025-11-25 spec.
+
+- **Charset**: `A-Za-z0-9_.-` only
+- **Max length**: 128 characters
+- **Transformations**: `/` to `-`, accent transliteration, invalid character replacement
+- **Truncation**: Long names are truncated with an MD5 hash suffix for uniqueness
+- **Usage**: Applied automatically during tool and prompt registration (not used for resources, which use URIs)
+
+```php
+$name = McpNameSanitizer::sanitize_name( 'my-plugin/action-name' );
+// Returns: 'my-plugin-action-name'
+```
+
+### ContentBlockHelper
+
+Factory for creating typed content block DTOs used in tool call results, prompt messages, and resource contents.
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `text( $text )` | `TextContent` | Plain text content |
+| `json_text( $data )` | `TextContent` | JSON-encoded data as text |
+| `image( $data, $mime_type )` | `ImageContent` | Base64-encoded image |
+| `audio( $data, $mime_type )` | `AudioContent` | Base64-encoded audio |
+| `embedded_text_resource( $uri, $text )` | `EmbeddedResource` | Text resource embedded in content |
+| `embedded_blob_resource( $uri, $blob )` | `EmbeddedResource` | Binary resource embedded in content |
+| `error_text( $message )` | `TextContent` | Semantic alias for error messages |
+| `to_array_list( $blocks )` | `array[]` | Converts content block DTOs to arrays |
+
+### AbilityArgumentNormalizer
+
+Normalizes arguments between MCP clients and WordPress abilities. MCP clients send `{}` (empty object) for tools without arguments, which PHP decodes as `[]` (empty array). Abilities without an input schema expect `null`, not an empty array. This normalizer bridges that gap.
+
+```php
+$args = AbilityArgumentNormalizer::normalize( $ability, $args );
+```
+
+### FailureReason
+
+Provides a centralized, stable vocabulary of failure reason constants for observability events. Categories include:
+
+- **Registration failures**: `ABILITY_NOT_FOUND`, `DUPLICATE_URI`, `ABILITY_CONVERSION_FAILED`
+- **Permission failures**: `PERMISSION_DENIED`, `PERMISSION_CHECK_FAILED`, `NO_PERMISSION_STRATEGY`
+- **Execution failures**: `NOT_FOUND`, `EXECUTION_FAILED`, `EXECUTION_EXCEPTION`
+- **Validation failures**: `MISSING_PARAMETER`, `INVALID_PARAMETER`
+
+### McpValidator
+
+Extended validation for MCP component data per the MCP 2025-11-25 specification:
+
+- `validate_name()` -- Name charset and length validation
+- `validate_resource_uri()` -- URI format per RFC 3986
+- `validate_mime_type()` -- MIME type format validation
+- `validate_icons_array()` -- Icon object validation (src, mimeType, sizes, theme)
+- `get_annotation_validation_errors()` -- Annotation field validation (audience, priority, lastModified)
+- `validate_base64()` -- Base64 content validation
 
 ## Transport Layer
 
@@ -105,57 +222,51 @@ class McpComponentRegistry {
 
 ```php
 interface McpTransportInterface {
-    public function __construct(McpTransportContext $context);
+    public function __construct( McpTransportContext $context );
     public function register_routes(): void;
 }
 
 interface McpRestTransportInterface extends McpTransportInterface {
-    public function check_permission(WP_REST_Request $request);
-    public function handle_request(WP_REST_Request $request): WP_REST_Response;
+    public function check_permission( WP_REST_Request $request );
+    public function handle_request( WP_REST_Request $request ): WP_REST_Response;
 }
 ```
 
 ### Built-in Transports
 
-- **HttpTransport**: Recommended (MCP 2025-06-18 compliant)
+- **HttpTransport**: Recommended (MCP 2025-06-18 Streamable HTTP compliant)
 - **STDIO Transport**: Via WP-CLI commands
 
 ### Dependency Injection
 
-Transports receive all dependencies through `McpTransportContext`:
+Transports and the `RequestRouter` receive all dependencies through `McpTransportContext`, which bundles the server instance, all handlers, the router, error handler, and observability handler.
 
-```php
-class McpTransportContext {
-    public McpServer $mcp_server;
-    public InitializeHandler $initialize_handler;
-    public ToolsHandler $tools_handler;
-    public ResourcesHandler $resources_handler;
-    public PromptsHandler $prompts_handler;
-    public SystemHandler $system_handler;
-    public RequestRouter $request_router;
-    public string $observability_handler;
-    public McpErrorHandlerInterface $error_handler;
-    public $transport_permission_callback;
-}
-```
+### DTO-Aware RequestRouter
+
+The `RequestRouter` is the serialization boundary between typed DTOs and transport-level arrays:
+
+1. It dispatches to the appropriate handler, which returns an `AbstractDataTransferObject` or `JSONRPCErrorResponse`.
+2. For success DTOs, it calls `toArray()` and returns the resulting array.
+3. For error DTOs, it extracts the error object and returns `['error' => ...]`.
+4. The transport wraps the array in the JSON-RPC 2.0 envelope.
 
 ## Error Handling
 
 ### Two-Part System
 
-1. **Error Response Creation**: `McpErrorFactory` creates JSON-RPC error responses
-2. **Error Logging**: `McpErrorHandlerInterface` implementations log errors
+1. **Error Response Creation**: `McpErrorFactory` creates `JSONRPCErrorResponse` DTOs for protocol errors
+2. **Error Logging**: `McpErrorHandlerInterface` implementations log errors for monitoring
 
 ```php
-// Error response (for clients)
-$error_response = McpErrorFactory::tool_not_found($request_id, $tool_name);
+// Protocol error DTO (returned to clients via JSON-RPC)
+$error_response = McpErrorFactory::tool_not_found( $request_id, $tool_name );
 
 // Error logging (for monitoring)
-$error_handler->log('Tool not found', [
+$error_handler->log( 'Tool not found', [
     'tool_name' => $tool_name,
-    'user_id' => get_current_user_id(),
-    'server_id' => $server_id
-], 'error');
+    'user_id'   => get_current_user_id(),
+    'server_id' => $server_id,
+], 'error' );
 ```
 
 ### Built-in Error Handlers
@@ -171,62 +282,15 @@ The system emits events rather than storing counters:
 
 ```php
 interface McpObservabilityHandlerInterface {
-    public static function record_event(string $event, array $tags = []): void;
-    public static function record_timing(string $metric, float $duration_ms, array $tags = []): void;
+    public function record_event( string $event, array $tags = [], ?float $duration_ms = null ): void;
 }
 ```
 
 ### Tracked Events
 
-- **Request events**: `mcp.request.count`, `mcp.request.success`, `mcp.request.error`
+- **Request events**: `mcp.request` with status, method, transport, and duration tags
 - **Component events**: `mcp.component.registered`, `mcp.component.registration_failed`
-- **Tool events**: `mcp.tool.execution_success`, `mcp.tool.execution_failed`
-- **Timing events**: `mcp.request.duration`
-
-## Design Patterns
-
-### Singleton Pattern (McpAdapter)
-
-```php
-class McpAdapter {
-    private static self $instance;
-    
-    public static function instance(): self {
-        if (!isset(self::$instance)) {
-            self::$instance = new self();
-            add_action('rest_api_init', [self::$instance, 'init'], 15);
-        }
-        return self::$instance;
-    }
-}
-```
-
-### Factory Pattern (Component Creation)
-
-```php
-class RegisterAbilityAsMcpTool {
-    public static function make(WP_Ability $ability, McpServer $server): McpTool {
-        // Convert WordPress ability to MCP tool
-        return McpTool::from_array($tool_data, $server);
-    }
-}
-```
-
-### Strategy Pattern (Transport Layer)
-
-Different transport implementations share the same interface:
-
-```php
-class HttpTransport implements McpRestTransportInterface {
-    public function __construct(McpTransportContext $context) {
-        // Dependency injection
-    }
-    
-    public function handle_request(WP_REST_Request $request): WP_REST_Response {
-        // HTTP-specific handling
-    }
-}
-```
+- **Per-component context**: Extracted from `McpComponentInterface::get_observability_context()` and merged into request tags
 
 ## Extension Points
 
@@ -235,30 +299,31 @@ class HttpTransport implements McpRestTransportInterface {
 ```php
 class MyTransport implements McpRestTransportInterface {
     use McpTransportHelperTrait;
-    
+
     private McpTransportContext $context;
-    
-    public function __construct(McpTransportContext $context) {
+
+    public function __construct( McpTransportContext $context ) {
         $this->context = $context;
-        $this->register_routes();
     }
-    
-    public function check_permission(WP_REST_Request $request) {
-        // Custom authentication logic
-        return current_user_can('manage_options');
+
+    public function register_routes(): void {
+        // Register custom REST routes
     }
-    
-    public function handle_request(WP_REST_Request $request): WP_REST_Response {
-        // Route through the injected router
-        $body = $request->get_json_params();
+
+    public function check_permission( WP_REST_Request $request ) {
+        return current_user_can( 'manage_options' );
+    }
+
+    public function handle_request( WP_REST_Request $request ): WP_REST_Response {
+        $body   = $request->get_json_params();
         $result = $this->context->request_router->route_request(
             $body['method'],
             $body['params'] ?? [],
             $body['id'] ?? 0,
-            $this->get_transport_name()
+            'my-transport'
         );
-        
-        return rest_ensure_response($result);
+
+        return rest_ensure_response( $result );
     }
 }
 ```
@@ -267,12 +332,8 @@ class MyTransport implements McpRestTransportInterface {
 
 ```php
 class MyErrorHandler implements McpErrorHandlerInterface {
-    public function log(string $message, array $context = [], string $type = 'error'): void {
-        // Send to your monitoring system
-        MyMonitoringSystem::send($message, $context, $type);
-        
-        // Fallback to local logging
-        error_log("[MCP {$type}] {$message}");
+    public function log( string $message, array $context = [], string $type = 'error' ): void {
+        MyMonitoringSystem::send( $message, $context, $type );
     }
 }
 ```
@@ -282,31 +343,31 @@ class MyErrorHandler implements McpErrorHandlerInterface {
 ```php
 class MyObservabilityHandler implements McpObservabilityHandlerInterface {
     use McpObservabilityHelperTrait;
-    
-    public static function record_event(string $event, array $tags = []): void {
-        $formatted_event = self::format_metric_name($event);
-        $merged_tags = self::merge_tags($tags);
-        
-        // Send to your metrics system
-        MyMetricsSystem::counter($formatted_event, 1, $merged_tags);
-    }
-    
-    public static function record_timing(string $metric, float $duration_ms, array $tags = []): void {
-        $formatted_metric = self::format_metric_name($metric);
-        $merged_tags = self::merge_tags($tags);
-        
-        // Send timing data
-        MyMetricsSystem::timing($formatted_metric, $duration_ms, $merged_tags);
+
+    public function record_event( string $event, array $tags = [], ?float $duration_ms = null ): void {
+        $formatted_event = self::format_metric_name( $event );
+        $merged_tags     = self::merge_tags( $tags );
+
+        MyMetricsSystem::counter( $formatted_event, 1, $merged_tags );
+
+        if ( null !== $duration_ms ) {
+            MyMetricsSystem::timing( $formatted_event, $duration_ms, $merged_tags );
+        }
     }
 }
 ```
 
 ## Key Architectural Decisions
 
+### Two-Layer DTO Separation
+- Protocol DTOs from `php-mcp-schema` are never modified with adapter-internal fields
+- Adapter metadata lives on `McpComponentInterface` implementations
+- Clean serialization: `get_protocol_dto()->toArray()` always produces spec-compliant output
+
 ### Dependency Injection
 - All transports receive dependencies through `McpTransportContext`
-- No global state or static dependencies
-- Easy testing and mocking
+- Handlers receive `McpServer` via constructor injection
+- No global state or static dependencies beyond the `McpAdapter` singleton
 
 ### Interface-Based Design
 - All major components implement interfaces
@@ -327,8 +388,8 @@ class MyObservabilityHandler implements McpObservabilityHandlerInterface {
 
 ### Lazy Loading
 - Components created only when needed
-- Validation can be disabled for performance
-- Null object pattern for disabled features
+- Validation can be disabled via the `mcp_adapter_validation_enabled` filter (default: disabled)
+- Null object pattern for disabled features (e.g., `NullMcpObservabilityHandler`)
 
 ### Caching
 - WordPress object cache integration
@@ -338,11 +399,12 @@ class MyObservabilityHandler implements McpObservabilityHandlerInterface {
 ### Memory Management
 - No persistent state storage
 - Event emission pattern prevents memory leaks
-- Configurable validation to reduce overhead
+- DTO `toArray()` called only at the serialization boundary, not eagerly
 
 ## Next Steps
 
-- **[Creating Abilities](../guides/creating-abilities.md)** - Build MCP components
-- **[Custom Transports](../guides/custom-transports.md)** - Specialized protocols
-- **[Error Handling](../guides/error-handling.md)** - Custom error management
-- **[Observability](../guides/observability.md)** - Metrics and monitoring
+- **[Creating Abilities](../guides/creating-abilities.md)** -- Build MCP components from WordPress abilities
+- **[Custom Transports](../guides/custom-transports.md)** -- Implement specialized transport protocols
+- **[Error Handling](../guides/error-handling.md)** -- Custom error management
+- **[Observability](../guides/observability.md)** -- Metrics and monitoring
+- **[v0.5.0 Migration Guide](../migration/v0.5.0.md)** -- Upgrading from previous versions

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -42,7 +42,7 @@ This separation ensures that:
 
 `McpComponentInterface` is an internal contract (`@internal`). It is not intended for third-party implementation.
 
-### Integration Layers
+### Supporting Layers
 
 The remaining layers wire the Schema and Adapter layers together:
 
@@ -108,7 +108,7 @@ The `RequestRouter` maps MCP methods to handlers. All handlers return schema DTO
 | `resources/read` | `ResourcesHandler::read_resource()` | `ReadResourceResult` or `JSONRPCErrorResponse` |
 | `prompts/list` | `PromptsHandler::list_prompts()` | `ListPromptsResult` |
 | `prompts/get` | `PromptsHandler::get_prompt()` | `GetPromptResult` or `JSONRPCErrorResponse` |
-| `ping` | `SystemHandler::ping()` | Empty result DTO |
+| `ping` | `SystemHandler::ping()` | `Result` |
 
 Protocol-level errors (tool not found, missing parameters) return `JSONRPCErrorResponse`. Execution-level errors (permission denied, runtime failure) return the appropriate result DTO with `isError: true`.
 
@@ -180,7 +180,7 @@ Factory for creating typed content block DTOs used in tool call results, prompt 
 | Method | Returns | Purpose |
 |--------|---------|---------|
 | `text( $text )` | `TextContent` | Plain text content |
-| `json_text( $data )` | `TextContent` | JSON-encoded data as text |
+| `json_text( $data, $flags )` | `TextContent` | JSON-encoded data as text (flags: `JSON_*` constants) |
 | `image( $data, $mime_type )` | `ImageContent` | Base64-encoded image |
 | `audio( $data, $mime_type )` | `AudioContent` | Base64-encoded audio |
 | `embedded_text_resource( $uri, $text )` | `EmbeddedResource` | Text resource embedded in content |
@@ -227,14 +227,14 @@ interface McpTransportInterface {
 }
 
 interface McpRestTransportInterface extends McpTransportInterface {
-    public function check_permission( WP_REST_Request $request );
+    public function check_permission( WP_REST_Request $request ): bool|\WP_Error;
     public function handle_request( WP_REST_Request $request ): WP_REST_Response;
 }
 ```
 
 ### Built-in Transports
 
-- **HttpTransport**: Recommended (MCP 2025-06-18 Streamable HTTP compliant)
+- **HttpTransport**: Recommended (MCP Streamable HTTP compliant)
 - **STDIO Transport**: Via WP-CLI commands
 
 ### Dependency Injection
@@ -323,7 +323,7 @@ class MyTransport implements McpRestTransportInterface {
             'my-transport'
         );
 
-        return rest_ensure_response( $result );
+        return new WP_REST_Response( $result );
     }
 }
 ```
@@ -357,49 +357,13 @@ class MyObservabilityHandler implements McpObservabilityHandlerInterface {
 }
 ```
 
-## Key Architectural Decisions
+## Design Principles
 
-### Two-Layer DTO Separation
-- Protocol DTOs from `php-mcp-schema` are never modified with adapter-internal fields
-- Adapter metadata lives on `McpComponentInterface` implementations
-- Clean serialization: `get_protocol_dto()->toArray()` always produces spec-compliant output
-
-### Dependency Injection
-- All transports receive dependencies through `McpTransportContext`
-- Handlers receive `McpServer` via constructor injection
-- No global state or static dependencies beyond the `McpAdapter` singleton
-
-### Interface-Based Design
-- All major components implement interfaces
-- Swappable implementations (error handlers, observability, transports)
-- Clean separation of concerns
-
-### Event Emission
-- System emits events rather than storing local counters
-- External systems handle aggregation and analysis
-- Zero memory overhead when observability is disabled
-
-### WordPress Integration
-- Leverages WordPress Abilities API for component definition
-- Uses WordPress REST API for HTTP transport
-- Integrates with WordPress permission system
-
-## Performance Considerations
-
-### Lazy Loading
-- Components created only when needed
-- Validation can be disabled via the `mcp_adapter_validation_enabled` filter (default: disabled)
-- Null object pattern for disabled features (e.g., `NullMcpObservabilityHandler`)
-
-### Caching
-- WordPress object cache integration
-- Component registry caching
-- Ability lookup optimization
-
-### Memory Management
-- No persistent state storage
-- Event emission pattern prevents memory leaks
-- DTO `toArray()` called only at the serialization boundary, not eagerly
+- **Two-layer DTO separation**: Protocol DTOs from `php-mcp-schema` carry no adapter-internal fields; `get_protocol_dto()->toArray()` always produces spec-compliant output
+- **Dependency injection**: All transports receive dependencies through `McpTransportContext`; no global state beyond the `McpAdapter` singleton
+- **Interface-based design**: Error handlers, observability, and transports are all swappable via interfaces
+- **Event emission over counters**: Observability emits events; external systems handle aggregation — zero overhead when disabled
+- **Lazy loading**: Components created only when needed; validation disabled by default via `mcp_adapter_validation_enabled` filter
 
 ## Next Steps
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -227,7 +227,7 @@ interface McpTransportInterface {
 }
 
 interface McpRestTransportInterface extends McpTransportInterface {
-    public function check_permission( WP_REST_Request $request ): bool|\WP_Error;
+    public function check_permission( WP_REST_Request $request );
     public function handle_request( WP_REST_Request $request ): WP_REST_Response;
 }
 ```

--- a/docs/guides/creating-abilities.md
+++ b/docs/guides/creating-abilities.md
@@ -56,6 +56,56 @@ wp_register_ability('my-plugin/my-ability', [
 ]);
 ```
 
+## Tool Naming
+
+When abilities are registered on a custom server as MCP tools, the adapter must transform the ability name into an MCP-compliant tool name. The MCP specification (2025-11-25) restricts tool names to the characters `A-Za-z0-9_.-` with a maximum length of 128.
+
+WordPress abilities commonly use namespaced names with forward slashes (e.g., `my-plugin/my-tool`), which are not valid in MCP. The adapter handles this automatically via `McpNameSanitizer::sanitize_name()`.
+
+### Registration Name vs MCP Name
+
+The name you pass to `wp_register_ability()` is the **registration name**. The name MCP clients see is the **MCP tool name**, produced by sanitization:
+
+| Registration Name | MCP Tool Name |
+|-------------------|---------------|
+| `my-plugin/my-tool` | `my-plugin-my-tool` |
+| `fluent/get-posts` | `fluent-get-posts` |
+| `café/résumé-tool` | `cafe-resume-tool` |
+
+### Sanitization Pipeline
+
+The full sanitization pipeline applied to tool names:
+
+1. **Trim** whitespace from both ends
+2. **Replace `/` with `-`** (forward slashes are not allowed in MCP names)
+3. **Early return** if the name is already valid after slash replacement
+4. **Transliterate accents** to ASCII equivalents (e.g., `é` → `e`, `ü` → `u`) via WordPress `remove_accents()`
+5. **Replace remaining invalid characters** with `-`
+6. **Collapse consecutive hyphens** into a single `-`
+7. **Trim leading/trailing** hyphens and underscores
+8. **Truncate long names**: if longer than 128 characters, truncate to 115 characters and append `-` plus a 12-character MD5 hash for uniqueness
+9. **Reject empty results**: if nothing remains after sanitization, return a `WP_Error`
+
+### Customizing Tool Names
+
+You can override the sanitized name using the `mcp_adapter_tool_name` filter. The filter receives the sanitized name and the source `WP_Ability` instance:
+
+```php
+add_filter( 'mcp_adapter_tool_name', function ( string $name, \WP_Ability $ability ): string {
+    // Use a custom name for a specific ability.
+    if ( 'my-plugin/legacy-tool' === $ability->get_name() ) {
+        return 'my-legacy-tool';
+    }
+    return $name;
+}, 10, 2 );
+```
+
+The filter result is validated after application — if it returns an invalid MCP name, the tool registration fails with an error.
+
+> **Note:** This naming transformation applies to **tools** registered on custom servers. The default server exposes abilities indirectly through its built-in meta-tools (`mcp-adapter-discover-abilities`, `mcp-adapter-get-ability-info`, `mcp-adapter-execute-ability`), so ability names pass through as-is in that context. Prompts use the same `McpNameSanitizer` logic. Resources use URIs as identifiers and are not affected by tool name sanitization.
+
+For advanced details, see the source: `includes/Domain/Utils/McpNameSanitizer.php`.
+
 ## Input and Output Schemas
 
 The MCP Adapter supports two schema formats for `input_schema` and `output_schema`:

--- a/docs/guides/creating-abilities.md
+++ b/docs/guides/creating-abilities.md
@@ -9,7 +9,7 @@ WordPress abilities can be registered as different MCP components:
 - **Resources**: Provide access to data or content
 - **Prompts**: Generate structured messages for language models
 
-** Full Annotation Support**: All component types support MCP annotations through the ability's `meta.annotations` field to provide behavior hints to MCP clients.
+**Full annotation support**: All component types support MCP annotations through the ability's `meta.annotations` field to provide behavior hints to MCP clients.
 
 ## MCP Exposure
 
@@ -56,7 +56,7 @@ wp_register_ability('my-plugin/my-ability', [
 ]);
 ```
 
-## Tool Naming
+## Tool naming
 
 When abilities are registered on a custom server as MCP tools, the adapter must transform the ability name into an MCP-compliant tool name. The MCP specification (2025-11-25) restricts tool names to the characters `A-Za-z0-9_.-` with a maximum length of 128.
 

--- a/docs/guides/creating-abilities.md
+++ b/docs/guides/creating-abilities.md
@@ -102,7 +102,7 @@ add_filter( 'mcp_adapter_tool_name', function ( string $name, \WP_Ability $abili
 
 The filter result is validated after application — if it returns an invalid MCP name, the tool registration fails with an error.
 
-> **Note:** This naming transformation applies to **tools** registered on custom servers. The default server exposes abilities indirectly through its built-in meta-tools (`mcp-adapter-discover-abilities`, `mcp-adapter-get-ability-info`, `mcp-adapter-execute-ability`), so ability names pass through as-is in that context. Prompts use the same `McpNameSanitizer` logic. Resources use URIs as identifiers and are not affected by tool name sanitization.
+> **Note:** This naming transformation applies to **tools created from WordPress abilities** (via `McpTool::fromAbility()`). The default server exposes abilities indirectly through its built-in meta-tools (`mcp-adapter-discover-abilities`, `mcp-adapter-get-ability-info`, `mcp-adapter-execute-ability`), so ability names pass through as-is in that context. Prompts use the same `McpNameSanitizer` logic. Resources use URIs as identifiers and are not affected by tool name sanitization.
 
 For advanced details, see the source: `includes/Domain/Utils/McpNameSanitizer.php`.
 

--- a/docs/guides/default-server.md
+++ b/docs/guides/default-server.md
@@ -2,6 +2,101 @@
 
 The MCP Adapter automatically creates a default server that provides core MCP functionality for WordPress abilities. This server acts as a bridge between AI agents and WordPress, allowing them to discover and execute WordPress abilities through the Model Context Protocol.
 
+## Choosing Between Default and Custom Servers
+
+The MCP Adapter supports two approaches for exposing WordPress abilities to AI agents. You can use both at the same time — they serve different purposes.
+
+### Default Server: Layered Discovery
+
+The default server is created automatically when the plugin loads. It exposes three meta-tools that let AI agents dynamically discover and execute any WordPress ability marked with `mcp.public=true` metadata:
+
+1. **`mcp-adapter/discover-abilities`** — Lists all publicly available abilities
+2. **`mcp-adapter/get-ability-info`** — Retrieves the full schema for a specific ability
+3. **`mcp-adapter/execute-ability`** — Executes an ability with provided parameters
+
+The AI agent navigates this layered interface: discover what is available, inspect what it needs, then execute. This keeps the MCP `tools/list` response small (only 3 tool schemas) regardless of how many abilities exist on the site.
+
+The default server also auto-discovers abilities registered with `mcp.public=true` and `mcp.type` set to `resource` or `prompt`, exposing them as MCP resources and prompts alongside the three meta-tools.
+
+**Best for:**
+- General-purpose AI integration where the set of abilities changes over time
+- Sites with many plugins registering abilities — no server reconfiguration needed
+- Scenarios where context window efficiency matters (only 3 tool schemas sent to the AI)
+
+### Custom Server: Direct Tool Registration
+
+A custom server is created explicitly via the `mcp_adapter_init` hook. Each ability you list is registered as a standalone MCP tool, resource, or prompt with its own schema visible directly in `tools/list`:
+
+```php
+add_action( 'mcp_adapter_init', function ( $adapter ) {
+    $adapter->create_server(
+        'content-server',
+        'mcp',
+        'content-server',
+        'Content Server',
+        'Focused content management tools',
+        '1.0.0',
+        array( \WP\MCP\Transport\HttpTransport::class ),
+        \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,
+        null, // observability handler
+        array( 'my-plugin/create-post', 'my-plugin/update-post' ), // tools
+        array(), // resources
+        array()  // prompts
+    );
+} );
+```
+
+The AI agent sees `my-plugin-create-post` and `my-plugin-update-post` as individual tools with their full input schemas — no discovery step required.
+
+**Best for:**
+- Focused integrations exposing a small, well-defined set of tools
+- Cases where AI agents need dedicated schemas with rich parameter descriptions
+- When you want the AI to call tools directly without the discover-then-execute indirection
+
+### Comparison
+
+| Aspect | Default Server | Custom Server |
+|--------|---------------|---------------|
+| Creation | Automatic on plugin load | Manual via `mcp_adapter_init` hook |
+| Tool visibility | 3 meta-tools; abilities discovered at runtime | Each ability is a separate MCP tool |
+| AI interaction | Discover → Inspect → Execute (3 steps) | Call tool directly (1 step) |
+| Scalability | Unlimited abilities without growing `tools/list` | Each tool adds to `tools/list` response |
+| Schema detail | AI fetches schemas on demand via `get-ability-info` | Full schemas visible immediately |
+| Configuration | Zero-config; abilities opt in with `mcp.public=true` | Explicit ability list per server |
+| Auto-discovery | Resources and prompts with `mcp.public=true` auto-discovered | Only explicitly listed components |
+| Transport | HTTP (REST API) by default; STDIO via WP-CLI | Any transport you configure |
+
+### Disabling the Default Server
+
+If you only want custom servers, disable the default server with the `mcp_adapter_create_default_server` filter. This filter is applied in `McpAdapter::maybe_create_default_server()` before any default abilities or the default server factory are registered:
+
+```php
+add_filter( 'mcp_adapter_create_default_server', '__return_false' );
+```
+
+When disabled, the three built-in meta-tools (`mcp-adapter/discover-abilities`, `mcp-adapter/get-ability-info`, `mcp-adapter/execute-ability`) are not registered and the default server endpoint is not created.
+
+### Extending the Default Server
+
+Use the `mcp_adapter_default_server_config` filter to modify the default server's configuration before it is created. The filter receives the full configuration array and must return an array — it is merged with defaults via `wp_parse_args()`:
+
+```php
+add_filter( 'mcp_adapter_default_server_config', function ( $config ) {
+    // Change the server name
+    $config['server_name'] = 'My Site MCP Server';
+
+    // Add a custom tool alongside the 3 meta-tools
+    $config['tools'][] = 'my-plugin/quick-search';
+
+    // Use a custom error handler
+    $config['error_handler'] = \MyPlugin\CustomErrorHandler::class;
+
+    return $config;
+} );
+```
+
+See the [full default configuration](#default-configuration) below for all available keys.
+
 ## Server Configuration
 
 ### Basic Details

--- a/docs/guides/default-server.md
+++ b/docs/guides/default-server.md
@@ -97,6 +97,96 @@ add_filter( 'mcp_adapter_default_server_config', function ( $config ) {
 
 See the [full default configuration](#default-configuration) below for all available keys.
 
+## HTTP Sessions
+
+When using the HTTP REST API transport, MCP clients must follow the session protocol defined by the MCP specification. The STDIO transport (WP-CLI) does not use HTTP sessions — session lifecycle is tied to the WP-CLI process instead.
+
+### Session Flow
+
+Every HTTP client must complete an initialization handshake before sending any other MCP request:
+
+1. **Initialize** — Send a `POST` request with the `initialize` JSON-RPC method. No `Mcp-Session-Id` header is needed for this first request.
+2. **Capture the session ID** — The response includes an `Mcp-Session-Id` header containing a UUID. Store this value.
+3. **Include the header on every subsequent request** — All following `POST`, `GET`, and `DELETE` requests must include the `Mcp-Session-Id` header with the stored value.
+4. **Terminate when done** — Send a `DELETE` request with the `Mcp-Session-Id` header to clean up the session.
+
+### Curl Example
+
+```bash
+# 1. Initialize and capture the session ID
+SESSION_ID=$(curl -s -D - -X POST \
+  "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
+  --user "username:application_password" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"my-client","version":"1.0.0"}}}' \
+  | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r')
+
+echo "Session ID: $SESSION_ID"
+
+# 2. Send initialized notification (required by MCP spec)
+curl -s -X POST \
+  "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
+  --user "username:application_password" \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+# 3. Use the session ID for subsequent requests
+curl -s -X POST \
+  "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
+  --user "username:application_password" \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+
+# 4. Terminate the session when done
+curl -s -X DELETE \
+  "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
+  --user "username:application_password" \
+  -H "Mcp-Session-Id: $SESSION_ID"
+```
+
+### Error Cases
+
+| Condition | JSON-RPC Error Code | HTTP Status | Message |
+|-----------|-------------------|-------------|---------|
+| Missing `Mcp-Session-Id` header on a non-initialize request | `-32600` (Invalid Request) | 400 | Missing Mcp-Session-Id header |
+| Invalid or expired session ID | `-32602` (Invalid Params) | 200 | Invalid or expired session |
+| User not authenticated | `-32010` (Unauthorized) | 401 | User not authenticated |
+
+### Session Configuration
+
+Two filters control session behavior:
+
+**`mcp_adapter_session_max_per_user`** — Maximum number of concurrent sessions a single user can have. When the limit is reached the oldest session is automatically evicted. Default: `32`.
+
+```php
+// Allow at most 5 concurrent sessions per user
+add_filter( 'mcp_adapter_session_max_per_user', function () {
+    return 5;
+} );
+```
+
+**`mcp_adapter_session_inactivity_timeout`** — Number of seconds a session can remain idle before it is considered expired. Default: `DAY_IN_SECONDS` (86 400 seconds / 24 hours).
+
+```php
+// Expire sessions after 1 hour of inactivity
+add_filter( 'mcp_adapter_session_inactivity_timeout', function () {
+    return HOUR_IN_SECONDS;
+} );
+```
+
+Sessions are stored in user meta and are cleaned up automatically when a new session is created or an existing session is validated.
+
+### STDIO Transport (WP-CLI)
+
+The STDIO transport used by WP-CLI does not require HTTP sessions. Each `wp mcp-adapter serve` invocation runs as a single process with its own lifecycle, so session management is unnecessary:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
+  wp mcp-adapter serve --user=admin --server=mcp-adapter-default-server
+```
+
 ## Server Configuration
 
 ### Basic Details

--- a/docs/guides/default-server.md
+++ b/docs/guides/default-server.md
@@ -118,12 +118,12 @@ SESSION_ID=$(curl -s -D - -X POST \
   "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
   --user "username:application_password" \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"my-client","version":"1.0.0"}}}' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"my-client","version":"1.0.0"}}}' \
   | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r')
 
 echo "Session ID: $SESSION_ID"
 
-# 2. Send initialized notification (required by MCP spec)
+# 2. Send initialized notification (tells server the client is ready for requests)
 curl -s -X POST \
   "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
   --user "username:application_password" \
@@ -151,7 +151,7 @@ curl -s -X DELETE \
 | Condition | JSON-RPC Error Code | HTTP Status | Message |
 |-----------|-------------------|-------------|---------|
 | Missing `Mcp-Session-Id` header on a non-initialize request | `-32600` (Invalid Request) | 400 | Missing Mcp-Session-Id header |
-| Invalid or expired session ID | `-32602` (Invalid Params) | 200 | Invalid or expired session |
+| Invalid or expired session ID | `-32602` (Invalid Params) | 200 | Invalid or expired session | <!-- MCP uses HTTP 200 for application-level errors; the error is in the JSON-RPC body -->
 | User not authenticated | `-32010` (Unauthorized) | 401 | User not authenticated |
 
 ### Session Configuration

--- a/docs/guides/default-server.md
+++ b/docs/guides/default-server.md
@@ -2,11 +2,11 @@
 
 The MCP Adapter automatically creates a default server that provides core MCP functionality for WordPress abilities. This server acts as a bridge between AI agents and WordPress, allowing them to discover and execute WordPress abilities through the Model Context Protocol.
 
-## Choosing Between Default and Custom Servers
+## Choosing between default and custom servers
 
 The MCP Adapter supports two approaches for exposing WordPress abilities to AI agents. You can use both at the same time — they serve different purposes.
 
-### Default Server: Layered Discovery
+### Default server: layered discovery
 
 The default server is created automatically when the plugin loads. It exposes three meta-tools that let AI agents dynamically discover and execute any WordPress ability marked with `mcp.public=true` metadata:
 
@@ -23,7 +23,7 @@ The default server also auto-discovers abilities registered with `mcp.public=tru
 - Sites with many plugins registering abilities — no server reconfiguration needed
 - Scenarios where context window efficiency matters (only 3 tool schemas sent to the AI)
 
-### Custom Server: Direct Tool Registration
+### Custom server: direct tool registration
 
 A custom server is created explicitly via the `mcp_adapter_init` hook. Each ability you list is registered as a standalone MCP tool, resource, or prompt with its own schema visible directly in `tools/list`:
 
@@ -66,7 +66,7 @@ The AI agent sees `my-plugin-create-post` and `my-plugin-update-post` as individ
 | Auto-discovery | Resources and prompts with `mcp.public=true` auto-discovered | Only explicitly listed components |
 | Transport | HTTP (REST API) by default; STDIO via WP-CLI | Any transport you configure |
 
-### Disabling the Default Server
+### Disabling the default server
 
 If you only want custom servers, disable the default server with the `mcp_adapter_create_default_server` filter. This filter is applied in `McpAdapter::maybe_create_default_server()` before any default abilities or the default server factory are registered:
 
@@ -76,7 +76,7 @@ add_filter( 'mcp_adapter_create_default_server', '__return_false' );
 
 When disabled, the three built-in meta-tools (`mcp-adapter/discover-abilities`, `mcp-adapter/get-ability-info`, `mcp-adapter/execute-ability`) are not registered and the default server endpoint is not created.
 
-### Extending the Default Server
+### Extending the default server
 
 Use the `mcp_adapter_default_server_config` filter to modify the default server's configuration before it is created. The filter receives the full configuration array and must return an array — it is merged with defaults via `wp_parse_args()`:
 
@@ -97,11 +97,11 @@ add_filter( 'mcp_adapter_default_server_config', function ( $config ) {
 
 See the [full default configuration](#default-configuration) below for all available keys.
 
-## HTTP Sessions
+## HTTP sessions
 
 When using the HTTP REST API transport, MCP clients must follow the session protocol defined by the MCP specification. The STDIO transport (WP-CLI) does not use HTTP sessions — session lifecycle is tied to the WP-CLI process instead.
 
-### Session Flow
+### Session flow
 
 Every HTTP client must complete an initialization handshake before sending any other MCP request:
 
@@ -110,7 +110,7 @@ Every HTTP client must complete an initialization handshake before sending any o
 3. **Include the header on every subsequent request** — All following `POST`, `GET`, and `DELETE` requests must include the `Mcp-Session-Id` header with the stored value.
 4. **Terminate when done** — Send a `DELETE` request with the `Mcp-Session-Id` header to clean up the session.
 
-### Curl Example
+### Curl example
 
 ```bash
 # 1. Initialize and capture the session ID
@@ -146,7 +146,7 @@ curl -s -X DELETE \
   -H "Mcp-Session-Id: $SESSION_ID"
 ```
 
-### Error Cases
+### Error cases
 
 | Condition | JSON-RPC Error Code | HTTP Status | Message |
 |-----------|-------------------|-------------|---------|
@@ -154,7 +154,7 @@ curl -s -X DELETE \
 | Invalid or expired session ID | `-32602` (Invalid Params) | 200 | Invalid or expired session | <!-- MCP uses HTTP 200 for application-level errors; the error is in the JSON-RPC body -->
 | User not authenticated | `-32010` (Unauthorized) | 401 | User not authenticated |
 
-### Session Configuration
+### Session configuration
 
 Two filters control session behavior:
 
@@ -178,7 +178,7 @@ add_filter( 'mcp_adapter_session_inactivity_timeout', function () {
 
 Sessions are stored in user meta and are cleaned up automatically when a new session is created or an existing session is validated.
 
-### STDIO Transport (WP-CLI)
+### STDIO transport (WP-CLI)
 
 The STDIO transport used by WP-CLI does not require HTTP sessions. Each `wp mcp-adapter serve` invocation runs as a single process with its own lifecycle, so session management is unnecessary:
 

--- a/docs/guides/default-server.md
+++ b/docs/guides/default-server.md
@@ -10,9 +10,11 @@ The MCP Adapter supports two approaches for exposing WordPress abilities to AI a
 
 The default server is created automatically when the plugin loads. It exposes three meta-tools that let AI agents dynamically discover and execute any WordPress ability marked with `mcp.public=true` metadata:
 
-1. **`mcp-adapter/discover-abilities`** — Lists all publicly available abilities
-2. **`mcp-adapter/get-ability-info`** — Retrieves the full schema for a specific ability
-3. **`mcp-adapter/execute-ability`** — Executes an ability with provided parameters
+1. **`mcp-adapter-discover-abilities`** — Lists all publicly available abilities
+2. **`mcp-adapter-get-ability-info`** — Retrieves the full schema for a specific ability
+3. **`mcp-adapter-execute-ability`** — Executes an ability with provided parameters
+
+> **Note:** These are the MCP tool names that AI agents use when calling `tools/call`. The underlying WordPress abilities are registered with `/` separators (e.g., `mcp-adapter/discover-abilities`), but `McpNameSanitizer` converts `/` to `-` during registration so that tool names comply with the MCP specification character set. See [Tool naming](creating-abilities.md#tool-naming) for details.
 
 The AI agent navigates this layered interface: discover what is available, inspect what it needs, then execute. This keeps the MCP `tools/list` response small (only 3 tool schemas) regardless of how many abilities exist on the site.
 
@@ -107,7 +109,7 @@ Every HTTP client must complete an initialization handshake before sending any o
 
 1. **Initialize** — Send a `POST` request with the `initialize` JSON-RPC method. No `Mcp-Session-Id` header is needed for this first request.
 2. **Capture the session ID** — The response includes an `Mcp-Session-Id` header containing a UUID. Store this value.
-3. **Include the header on every subsequent request** — All following `POST`, `GET`, and `DELETE` requests must include the `Mcp-Session-Id` header with the stored value.
+3. **Include the header on every subsequent request** — All following `POST` and `DELETE` requests must include the `Mcp-Session-Id` header with the stored value. (The MCP specification also requires the header on `GET` requests for SSE streaming, but SSE is not yet implemented — `GET` currently returns `405 Method Not Allowed`.)
 4. **Terminate when done** — Send a `DELETE` request with the `Mcp-Session-Id` header to clean up the session.
 
 ### Curl example
@@ -192,7 +194,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
 ### Basic Details
 - **Server ID**: `mcp-adapter-default-server`
 - **Endpoint**: `/wp-json/mcp/mcp-adapter-default-server`
-- **Transport**: HTTP (MCP 2025-06-18 compliant)
+- **Transport**: HTTP (MCP Streamable HTTP compliant)
 - **Authentication**: Requires logged-in WordPress user with `read` capability (customizable via filters)
 
 ### Default Configuration

--- a/docs/migration/v0.5.0.md
+++ b/docs/migration/v0.5.0.md
@@ -1,0 +1,495 @@
+# Migration Guide: Version 0.5.0
+
+Version 0.5.0 introduces typed protocol DTOs via `php-mcp-schema`, replacing manual array manipulation with schema-validated data structures. The architecture now cleanly separates the **Schema Layer** (protocol types from `WP\McpSchema\`) from the **Adapter Layer** (WordPress integration in `WP\MCP\`).
+
+## What's Changed
+
+## Breaking Changes
+
+### 1. Domain Models Now Implement McpComponentInterface
+
+`McpTool`, `McpResource`, and `McpPrompt` now implement `McpComponentInterface`, which provides a unified contract for all domain components. Protocol data is stored in clean schema DTOs, while internal adapter metadata lives separately on the component instance.
+
+**Before (v0.4.x):**
+```php
+// Components mixed protocol fields with internal metadata in arrays.
+$tools = $server->get_tools();
+foreach ( $tools as $tool ) {
+    // $tool was an array containing both protocol data and internal _meta
+    $name = $tool['name'];
+    $meta = $tool['_meta'] ?? [];
+    $ability_name = $meta['ability_name'] ?? null;
+}
+```
+
+**After (v0.5.0):**
+```php
+// Components are McpComponentInterface instances.
+// Protocol DTOs and adapter metadata are cleanly separated.
+$mcp_tool = $server->get_mcp_tool( 'my-tool' );
+
+// Protocol DTO — safe for MCP clients.
+$tool_dto = $mcp_tool->get_protocol_dto();
+$name = $tool_dto->getName();
+
+// Internal adapter metadata — never exposed to clients.
+$meta = $mcp_tool->get_adapter_meta();
+
+// Unified execution and permission surface.
+$permission = $mcp_tool->check_permission( $args );
+$result = $mcp_tool->execute( $args );
+
+// Observability context — replaces legacy _metadata extraction.
+$tags = $mcp_tool->get_observability_context();
+// Returns: ['component_type' => 'tool', 'tool_name' => '...', 'source' => 'ability']
+```
+
+The `McpComponentInterface` contract:
+
+```php
+interface McpComponentInterface {
+    public function get_protocol_dto(): AbstractDataTransferObject;
+    public function execute( $arguments );
+    public function check_permission( $arguments );
+    public function get_adapter_meta(): array;
+    public function get_observability_context(): array;
+}
+```
+
+This applies equally to all three component types:
+
+| Component | Protocol DTO class |
+|-----------|-------------------|
+| `McpTool` | `WP\McpSchema\Server\Tools\DTO\Tool` |
+| `McpResource` | `WP\McpSchema\Server\Resources\DTO\Resource` |
+| `McpPrompt` | `WP\McpSchema\Server\Prompts\DTO\Prompt` |
+
+### 2. Handler Return Types Changed from Arrays to DTOs
+
+All handlers now return typed schema DTOs instead of raw PHP arrays.
+
+**Before (v0.4.x):**
+```php
+// ToolsHandler returned arrays
+$result = $tools_handler->list_tools();
+// $result was: ['tools' => [['name' => 'my-tool', ...], ...]]
+
+$result = $tools_handler->call_tool( $params, $request_id );
+// $result was: ['content' => [['type' => 'text', 'text' => '...']], 'isError' => false]
+```
+
+**After (v0.5.0):**
+```php
+// ToolsHandler returns DTOs
+$result = $tools_handler->list_tools();
+// $result is: ListToolsResult DTO
+
+$result = $tools_handler->call_tool( $params, $request_id );
+// $result is: CallToolResult DTO (success/tool error) or JSONRPCErrorResponse DTO (protocol error)
+```
+
+**All affected handlers and their new return types:**
+
+| Handler | Method | Return type (v0.5.0) |
+|---------|--------|---------------------|
+| `ToolsHandler` | `list_tools()` | `WP\McpSchema\Server\Tools\DTO\ListToolsResult` |
+| `ToolsHandler` | `call_tool()` | `CallToolResult` or `JSONRPCErrorResponse` |
+| `ResourcesHandler` | `list_resources()` | `WP\McpSchema\Server\Resources\DTO\ListResourcesResult` |
+| `ResourcesHandler` | `read_resource()` | `ReadResourceResult` or `JSONRPCErrorResponse` |
+| `PromptsHandler` | `list_prompts()` | `WP\McpSchema\Server\Prompts\DTO\ListPromptsResult` |
+| `PromptsHandler` | `get_prompt()` | `GetPromptResult` or `JSONRPCErrorResponse` |
+| `InitializeHandler` | `handle()` | `WP\McpSchema\Common\Protocol\DTO\InitializeResult` |
+
+### 3. McpErrorFactory Returns DTOs Instead of Arrays
+
+`McpErrorFactory` methods now return `JSONRPCErrorResponse` DTOs from `php-mcp-schema`.
+
+**Before (v0.4.x):**
+```php
+$error = McpErrorFactory::tool_not_found( $request_id, $tool_name );
+// $error was a plain array: ['jsonrpc' => '2.0', 'error' => ['code' => -32003, ...], 'id' => ...]
+
+// Could use directly in array responses
+return $error;
+```
+
+**After (v0.5.0):**
+```php
+$error = McpErrorFactory::tool_not_found( $request_id, $tool_name );
+// $error is a JSONRPCErrorResponse DTO
+
+// Access error details via methods
+$error_code = $error->getError()->getCode();
+$error_message = $error->getError()->getMessage();
+
+// Convert to array when needed for serialization
+$error_array = $error->toArray();
+```
+
+All `McpErrorFactory` static methods are affected:
+- `parse_error()`, `invalid_request()`, `method_not_found()`, `invalid_params()`, `internal_error()`
+- `tool_not_found()`, `resource_not_found()`, `prompt_not_found()`
+- `permission_denied()`, `unauthorized()`, `mcp_disabled()`
+- `validation_error()`, `missing_parameter()`, `ability_not_found()`
+- `create_error_response()` (the underlying factory method)
+
+The `create_error()` helper method now returns an `Error` DTO:
+```php
+$error = McpErrorFactory::create_error( -32603, 'Internal error' );
+// Returns WP\McpSchema\Common\JsonRpc\DTO\Error
+```
+
+### 4. RequestRouter Expects DTO Results from Handlers
+
+`RequestRouter::route_request()` now expects handlers to return `AbstractDataTransferObject` instances. It converts DTOs to arrays at the serialization boundary.
+
+**Before (v0.4.x):**
+```php
+// RequestRouter worked with raw arrays from handlers.
+// Handlers returned arrays, router passed them through.
+```
+
+**After (v0.5.0):**
+```php
+// RequestRouter checks the return type:
+// - JSONRPCErrorResponse DTO → extracts error array
+// - AbstractDataTransferObject DTO → calls toArray()
+// - Unexpected type → logs warning, returns internal error
+
+// If your custom handler returns a non-DTO type, RequestRouter
+// will log a warning and return an internal error response.
+```
+
+This means custom code that hooks into the routing layer must return DTOs.
+
+### 5. McpComponentRegistry Stores McpComponentInterface Instances
+
+The registry now stores typed component instances instead of raw arrays.
+
+**Before (v0.4.x):**
+```php
+// Registry stored array representations
+$tools = $registry->get_tools();
+// $tools was: ['tool-name' => ['name' => '...', ...]]
+```
+
+**After (v0.5.0):**
+```php
+// get_tools() returns protocol DTOs (via get_protocol_dto())
+$tools = $registry->get_tools();
+// $tools is: ['tool-name' => ToolDto instance]
+
+// get_mcp_tool() returns the full McpTool instance
+$mcp_tool = $registry->get_mcp_tool( 'tool-name' );
+// $mcp_tool is: McpTool (implements McpComponentInterface)
+```
+
+The same pattern applies for resources and prompts via `get_resources()`, `get_mcp_resource()`, `get_prompts()`, and `get_mcp_prompt()`.
+
+## New Features
+
+### 1. php-mcp-schema Package
+
+New dependency: `wordpress/php-mcp-schema ^0.1.0`. This package provides typed DTOs for all MCP protocol types under the `WP\McpSchema\` namespace.
+
+Key DTO classes used throughout the adapter:
+
+| Category | Class |
+|----------|-------|
+| Tools | `WP\McpSchema\Server\Tools\DTO\Tool` |
+| Tools | `WP\McpSchema\Server\Tools\DTO\ListToolsResult` |
+| Tools | `WP\McpSchema\Server\Tools\DTO\CallToolResult` |
+| Tools | `WP\McpSchema\Server\Tools\DTO\ToolAnnotations` |
+| Resources | `WP\McpSchema\Server\Resources\DTO\Resource` |
+| Resources | `WP\McpSchema\Server\Resources\DTO\ListResourcesResult` |
+| Resources | `WP\McpSchema\Server\Resources\DTO\ReadResourceResult` |
+| Prompts | `WP\McpSchema\Server\Prompts\DTO\Prompt` |
+| Prompts | `WP\McpSchema\Server\Prompts\DTO\ListPromptsResult` |
+| Prompts | `WP\McpSchema\Server\Prompts\DTO\GetPromptResult` |
+| Prompts | `WP\McpSchema\Server\Prompts\DTO\PromptMessage` |
+| Prompts | `WP\McpSchema\Server\Prompts\DTO\PromptArgument` |
+| Content | `WP\McpSchema\Common\Content\DTO\TextContent` |
+| Content | `WP\McpSchema\Common\Content\DTO\ImageContent` |
+| Content | `WP\McpSchema\Common\Content\DTO\AudioContent` |
+| Protocol | `WP\McpSchema\Common\Protocol\DTO\InitializeResult` |
+| Protocol | `WP\McpSchema\Common\Protocol\DTO\Annotations` |
+| Protocol | `WP\McpSchema\Common\Protocol\DTO\TextResourceContents` |
+| Protocol | `WP\McpSchema\Common\Protocol\DTO\BlobResourceContents` |
+| Protocol | `WP\McpSchema\Common\Protocol\DTO\EmbeddedResource` |
+| JSON-RPC | `WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse` |
+| JSON-RPC | `WP\McpSchema\Common\JsonRpc\DTO\Error` |
+| Lifecycle | `WP\McpSchema\Common\Lifecycle\DTO\Implementation` |
+| Lifecycle | `WP\McpSchema\Server\Lifecycle\DTO\ServerCapabilities` |
+| Constants | `WP\McpSchema\Common\McpConstants` |
+
+All DTOs provide `fromArray()` for construction and `toArray()` for serialization.
+
+### 2. McpComponentInterface
+
+New contract (`WP\MCP\Domain\Contracts\McpComponentInterface`) that all domain components implement. Provides:
+
+- `get_protocol_dto()` — Clean schema DTO for MCP client responses
+- `execute( $arguments )` — Unified execution surface (delegates to ability or callable handler)
+- `check_permission( $arguments )` — Unified permission check (delegates to ability or callback)
+- `get_adapter_meta()` — Internal metadata not exposed to clients
+- `get_observability_context()` — Tags for logging and metrics
+
+### 3. New Utility Classes
+
+**`McpNameSanitizer`** (`WP\MCP\Domain\Utils\McpNameSanitizer`)
+Normalizes component names to MCP-valid format (A-Za-z0-9_.- , max 128 characters). Handles transliteration, invalid character replacement, and truncation with hash suffixes.
+
+**`ContentBlockHelper`** (`WP\MCP\Domain\Utils\ContentBlockHelper`)
+Factory for creating MCP content block DTOs. Provides convenience methods:
+- `text()` — TextContent DTO
+- `image()` — ImageContent DTO
+- `audio()` — AudioContent DTO
+- `embedded_text_resource()` — EmbeddedResource with TextResourceContents
+- `embedded_blob_resource()` — EmbeddedResource with BlobResourceContents
+- `json_text()` — TextContent from JSON-encoded data
+- `error_text()` — TextContent for error messages
+
+**`AbilityArgumentNormalizer`** (`WP\MCP\Domain\Utils\AbilityArgumentNormalizer`)
+Normalizes arguments between MCP clients and WordPress Abilities API. Converts empty arrays (from MCP `{}`) to null for abilities without input schemas.
+
+**`FailureReason`** (`WP\MCP\Infrastructure\Observability\FailureReason`)
+Standardized failure reason constants for observability events. Replaces string literals with a typed taxonomy:
+
+```php
+// Before: string literals scattered across the codebase
+'failure_reason' => 'permission_denied'
+
+// After: centralized constants
+'failure_reason' => FailureReason::PERMISSION_DENIED
+```
+
+Categories: registration failures (`ABILITY_NOT_FOUND`, `DUPLICATE_URI`, `BUILDER_EXCEPTION`, `NO_PERMISSION_STRATEGY`, `ABILITY_CONVERSION_FAILED`), permission failures (`PERMISSION_DENIED`, `PERMISSION_CHECK_FAILED`), execution failures (`NOT_FOUND`, `EXECUTION_FAILED`, `EXECUTION_EXCEPTION`), and validation failures (`MISSING_PARAMETER`, `INVALID_PARAMETER`).
+
+## Migration Steps
+
+### Step 1: Update Custom Transport Implementations
+
+If you have implemented `McpTransportInterface` or `McpRestTransportInterface`, update your `handle_request()` method. The `RequestRouter` now returns arrays (it converts DTOs internally), so transport code consuming `route_request()` results should continue working. However, if you were manually inspecting response structures, be aware that error responses now have this shape:
+
+```php
+// Error responses from route_request()
+$result = $this->context->request_router->route_request(
+    $method, $params, $request_id, $this->get_transport_name()
+);
+
+// Error shape: ['error' => ['code' => -32003, 'message' => '...']]
+// Success shape: the DTO's toArray() output (e.g., ['tools' => [...]] for tools/list)
+```
+
+If you call `McpErrorFactory` directly in your transport for pre-routing errors (e.g., authentication failures), update to handle DTOs:
+
+```php
+// Before (v0.4.x)
+$error = McpErrorFactory::unauthorized( $request_id );
+return new \WP_REST_Response( $error, 401 );
+
+// After (v0.5.0)
+$error = McpErrorFactory::unauthorized( $request_id );
+return new \WP_REST_Response( $error->toArray(), 401 );
+```
+
+`McpErrorFactory::get_http_status_for_error()` accepts both DTOs and legacy arrays, so existing HTTP status logic continues to work.
+
+### Step 2: Update Custom Handler Implementations
+
+If you have created custom handlers that the `RequestRouter` calls, they must return schema DTOs.
+
+**Tools handler example:**
+
+```php
+use WP\McpSchema\Server\Tools\DTO\ListToolsResult;
+use WP\McpSchema\Server\Tools\DTO\CallToolResult;
+use WP\MCP\Domain\Utils\ContentBlockHelper;
+use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
+
+// List handler — return ListToolsResult
+public function list_tools(): ListToolsResult {
+    $tools = array_values( $this->mcp->get_tools() );
+    return ListToolsResult::fromArray( [ 'tools' => $tools ] );
+}
+
+// Call handler — return CallToolResult or JSONRPCErrorResponse
+public function call_tool( array $params, $request_id = 0 ) {
+    if ( ! isset( $params['name'] ) ) {
+        return McpErrorFactory::missing_parameter( $request_id, 'tool name' );
+    }
+
+    // Success
+    return CallToolResult::fromArray( [
+        'content' => [ ContentBlockHelper::text( $json_text ) ],
+        'isError' => false,
+    ] );
+}
+```
+
+**Resources handler example:**
+
+```php
+use WP\McpSchema\Server\Resources\DTO\ListResourcesResult;
+use WP\McpSchema\Server\Resources\DTO\ReadResourceResult;
+use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
+
+public function list_resources(): ListResourcesResult {
+    $resources = array_values( $this->mcp->get_resources() );
+    return ListResourcesResult::fromArray( [ 'resources' => $resources ] );
+}
+
+public function read_resource( array $params, $request_id = 0 ) {
+    // ... validation ...
+    $content = TextResourceContents::fromArray( [
+        'uri'  => $uri,
+        'text' => $text,
+    ] );
+    return ReadResourceResult::fromArray( [ 'contents' => [ $content ] ] );
+}
+```
+
+**Prompts handler example:**
+
+```php
+use WP\McpSchema\Server\Prompts\DTO\ListPromptsResult;
+use WP\McpSchema\Server\Prompts\DTO\GetPromptResult;
+use WP\McpSchema\Server\Prompts\DTO\PromptMessage;
+
+public function list_prompts(): ListPromptsResult {
+    $prompts = array_values( $this->mcp->get_prompts() );
+    return ListPromptsResult::fromArray( [ 'prompts' => $prompts ] );
+}
+
+public function get_prompt( array $params, $request_id = 0 ) {
+    // ... validation and execution ...
+    $message = PromptMessage::fromArray( [
+        'role'    => 'user',
+        'content' => [ 'type' => 'text', 'text' => $text ],
+    ] );
+    return GetPromptResult::fromArray( [
+        'messages'    => [ $message ],
+        'description' => $description,
+    ] );
+}
+```
+
+### Step 3: Update Direct Component Registration
+
+The `fromArray()` factory methods on `McpTool`, `McpResource`, and `McpPrompt` have **unchanged signatures**. However, if your code accessed internal `_meta` arrays or protocol fields directly from the component, migrate to the new accessors:
+
+```php
+// Before (v0.4.x) — accessing tool data as array
+$tool_array = $tool->to_array();
+$name = $tool_array['name'];
+$meta = $tool_array['_meta'];
+
+// After (v0.5.0) — use typed accessors
+$tool_dto = $mcp_tool->get_protocol_dto();
+$name = $tool_dto->getName();
+$meta = $mcp_tool->get_adapter_meta();
+```
+
+### Step 4: Update Error Handling Code
+
+If your code consumed `McpErrorFactory` return values as arrays, add `->toArray()` calls:
+
+```php
+// Before (v0.4.x)
+$error = McpErrorFactory::internal_error( $request_id, 'Something went wrong' );
+$error_code = $error['error']['code'];
+
+// After (v0.5.0)
+$error = McpErrorFactory::internal_error( $request_id, 'Something went wrong' );
+$error_code = $error->getError()->getCode();
+
+// Or convert to array first
+$error_array = $error->toArray();
+$error_code = $error_array['error']['code'];
+```
+
+Error constant values are unchanged (`PARSE_ERROR`, `INVALID_REQUEST`, etc.) but are now sourced from `McpConstants`:
+
+```php
+use WP\McpSchema\Common\McpConstants;
+
+// McpErrorFactory constants still work
+McpErrorFactory::PARSE_ERROR;      // -32700
+McpErrorFactory::INTERNAL_ERROR;   // -32603
+
+// Now backed by McpConstants
+McpConstants::PARSE_ERROR;         // -32700
+McpConstants::INTERNAL_ERROR;      // -32603
+```
+
+### Step 5: Update Observability Code
+
+Observability context is now provided by `McpComponentInterface::get_observability_context()` instead of being extracted from DTO `_metadata` arrays. The `RequestRouter` uses this method internally.
+
+```php
+// Before (v0.4.x) — tags derived from response _metadata
+$tags = $response['_metadata'] ?? [];
+$component_type = $tags['component_type'] ?? 'unknown';
+
+// After (v0.5.0) — tags from McpComponentInterface
+$tags = $mcp_tool->get_observability_context();
+// Returns: [
+//     'component_type' => 'tool',
+//     'tool_name'      => 'my-tool',
+//     'ability_name'   => 'my-plugin/my-ability',  // if ability-backed
+//     'source'         => 'ability',                // 'ability' or 'array'
+// ]
+```
+
+Failure reasons now use `FailureReason` constants instead of string literals:
+
+```php
+use WP\MCP\Infrastructure\Observability\FailureReason;
+
+// Before (v0.4.x)
+'failure_reason' => 'permission_denied'
+
+// After (v0.5.0)
+'failure_reason' => FailureReason::PERMISSION_DENIED
+```
+
+If you have custom observability handlers that filter on `failure_reason` tags, the string values are the same (`'permission_denied'`, `'not_found'`, etc.) but are now guaranteed by the `FailureReason` class. Use `FailureReason::all()` to get all valid values and `FailureReason::is_valid()` to validate.
+
+## Backward Compatibility Notes
+
+The following APIs are **unchanged** in v0.5.0:
+
+**Factory method signatures:**
+- `McpTool::fromArray( array $config )` — Same config keys: `name`, `title`, `description`, `inputSchema`, `handler`, `permission`, `annotations`
+- `McpTool::fromAbility( \WP_Ability $ability )`
+- `McpResource::fromArray( array $config )` — Same config keys: `uri`, `name`, `title`, `description`, `handler`, `permission`, `mimeType`, `annotations`
+- `McpResource::fromAbility( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null )`
+- `McpPrompt::fromArray( array $config )` — Same config keys: `name`, `title`, `description`, `arguments`, `handler`, `permission`
+- `McpPrompt::fromAbility( \WP_Ability $ability )`
+- `McpPrompt::fromBuilder( McpPromptBuilderInterface $builder )`
+
+**Public interfaces (signatures unchanged):**
+- `McpErrorHandlerInterface::log( string $message, array $context = [], string $type = 'error' ): void`
+- `McpObservabilityHandlerInterface::record_event( string $event, array $tags = [], ?float $duration_ms = null ): void`
+- `McpTransportInterface` and `McpRestTransportInterface`
+- `McpPromptBuilderInterface`
+
+**Core API:**
+- `McpAdapter::create_server()` — Signature unchanged
+- `McpAdapter::get_server()`, `McpAdapter::get_servers()`
+
+**WordPress hooks:**
+- All action and filter hook names unchanged
+- Hook parameters unchanged
+- `mcp_adapter_init`, `wp_mcp_init`, and all filters listed in the documentation
+
+**RequestRouter::route_request() return format:**
+- Still returns `array` — DTOs are converted to arrays at this boundary
+- Error shape: `['error' => ['code' => int, 'message' => string]]`
+- Success shape: the result DTO's `toArray()` output
+
+## Next Steps
+
+- **[Architecture Overview](../architecture/overview.md)** — Understand the Schema Layer / Adapter Layer separation
+- **[Custom Transports](../guides/custom-transports.md)** — Custom transport implementation guide
+- **[Error Handling](../guides/error-handling.md)** — Error handling patterns

--- a/docs/migration/v0.5.0.md
+++ b/docs/migration/v0.5.0.md
@@ -1,194 +1,45 @@
 # Migration Guide: Version 0.5.0
 
-Version 0.5.0 introduces typed protocol DTOs via `php-mcp-schema`, replacing manual array manipulation with schema-validated data structures. The architecture now cleanly separates the **Schema Layer** (protocol types from `WP\McpSchema\`) from the **Adapter Layer** (WordPress integration in `WP\MCP\`).
+Version 0.5.0 introduces typed protocol DTOs via `php-mcp-schema`, replacing internal array manipulation with schema-validated data structures. The architecture now cleanly separates the **Schema Layer** (protocol types from `WP\McpSchema\`) from the **Adapter Layer** (WordPress integration in `WP\MCP\`).
 
-## What's Changed
+## For Most Users: Seamless Upgrade
 
-## Breaking Changes
+**If you register abilities, create servers via `create_server()`, or use WordPress hooks — nothing breaks.** Update the plugin and everything continues to work.
 
-### 1. Domain Models Now Implement McpComponentInterface
+The following public APIs are **unchanged** in v0.5.0:
 
-`McpTool`, `McpResource`, and `McpPrompt` now implement `McpComponentInterface`, which provides a unified contract for all domain components. Protocol data is stored in clean schema DTOs, while internal adapter metadata lives separately on the component instance.
+**Component registration (unchanged):**
+- `McpTool::fromArray( array $config )` — Same config keys: `name`, `title`, `description`, `inputSchema`, `handler`, `permission`, `annotations`
+- `McpTool::fromAbility( \WP_Ability $ability )`
+- `McpResource::fromArray( array $config )` — Same config keys: `uri`, `name`, `title`, `description`, `handler`, `permission`, `mimeType`, `annotations`
+- `McpResource::fromAbility( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null )`
+- `McpPrompt::fromArray( array $config )` — Same config keys: `name`, `title`, `description`, `arguments`, `handler`, `permission`
+- `McpPrompt::fromAbility( \WP_Ability $ability )`
+- `McpPrompt::fromBuilder( McpPromptBuilderInterface $builder )`
 
-**Before (v0.4.x):**
-```php
-// Components mixed protocol fields with internal metadata in arrays.
-$tools = $server->get_tools();
-foreach ( $tools as $tool ) {
-    // $tool was an array containing both protocol data and internal _meta
-    $name = $tool['name'];
-    $meta = $tool['_meta'] ?? [];
-    $ability_name = $meta['ability_name'] ?? null;
-}
-```
+**Core API (unchanged):**
+- `McpAdapter::create_server()` — Signature unchanged
+- `McpAdapter::get_server()`, `McpAdapter::get_servers()`
 
-**After (v0.5.0):**
-```php
-// Components are McpComponentInterface instances.
-// Protocol DTOs and adapter metadata are cleanly separated.
-$mcp_tool = $server->get_mcp_tool( 'my-tool' );
+**Public interfaces (unchanged):**
+- `McpErrorHandlerInterface::log( string $message, array $context = [], string $type = 'error' ): void`
+- `McpObservabilityHandlerInterface::record_event( string $event, array $tags = [], ?float $duration_ms = null ): void`
+- `McpTransportInterface` and `McpRestTransportInterface`
+- `McpPromptBuilderInterface`
 
-// Protocol DTO — safe for MCP clients.
-$tool_dto = $mcp_tool->get_protocol_dto();
-$name = $tool_dto->getName();
+**WordPress hooks (unchanged):**
+- All action and filter hook names unchanged
+- Hook parameters unchanged
+- `mcp_adapter_init`, `wp_mcp_init`, and all filters listed in the documentation
 
-// Internal adapter metadata — never exposed to clients.
-$meta = $mcp_tool->get_adapter_meta();
-
-// Unified execution and permission surface.
-$permission = $mcp_tool->check_permission( $args );
-$result = $mcp_tool->execute( $args );
-
-// Observability context — replaces legacy _metadata extraction.
-$tags = $mcp_tool->get_observability_context();
-// Returns: ['component_type' => 'tool', 'tool_name' => '...', 'source' => 'ability']
-```
-
-The `McpComponentInterface` contract:
-
-```php
-interface McpComponentInterface {
-    public function get_protocol_dto(): AbstractDataTransferObject;
-    public function execute( $arguments );
-    public function check_permission( $arguments );
-    public function get_adapter_meta(): array;
-    public function get_observability_context(): array;
-}
-```
-
-This applies equally to all three component types:
-
-| Component | Protocol DTO class |
-|-----------|-------------------|
-| `McpTool` | `WP\McpSchema\Server\Tools\DTO\Tool` |
-| `McpResource` | `WP\McpSchema\Server\Resources\DTO\Resource` |
-| `McpPrompt` | `WP\McpSchema\Server\Prompts\DTO\Prompt` |
-
-### 2. Handler Return Types Changed from Arrays to DTOs
-
-All handlers now return typed schema DTOs instead of raw PHP arrays.
-
-**Before (v0.4.x):**
-```php
-// ToolsHandler returned arrays
-$result = $tools_handler->list_tools();
-// $result was: ['tools' => [['name' => 'my-tool', ...], ...]]
-
-$result = $tools_handler->call_tool( $params, $request_id );
-// $result was: ['content' => [['type' => 'text', 'text' => '...']], 'isError' => false]
-```
-
-**After (v0.5.0):**
-```php
-// ToolsHandler returns DTOs
-$result = $tools_handler->list_tools();
-// $result is: ListToolsResult DTO
-
-$result = $tools_handler->call_tool( $params, $request_id );
-// $result is: CallToolResult DTO (success/tool error) or JSONRPCErrorResponse DTO (protocol error)
-```
-
-**All affected handlers and their new return types:**
-
-| Handler | Method | Return type (v0.5.0) |
-|---------|--------|---------------------|
-| `ToolsHandler` | `list_tools()` | `WP\McpSchema\Server\Tools\DTO\ListToolsResult` |
-| `ToolsHandler` | `call_tool()` | `CallToolResult` or `JSONRPCErrorResponse` |
-| `ResourcesHandler` | `list_resources()` | `WP\McpSchema\Server\Resources\DTO\ListResourcesResult` |
-| `ResourcesHandler` | `read_resource()` | `ReadResourceResult` or `JSONRPCErrorResponse` |
-| `PromptsHandler` | `list_prompts()` | `WP\McpSchema\Server\Prompts\DTO\ListPromptsResult` |
-| `PromptsHandler` | `get_prompt()` | `GetPromptResult` or `JSONRPCErrorResponse` |
-| `InitializeHandler` | `handle()` | `WP\McpSchema\Common\Protocol\DTO\InitializeResult` |
-
-### 3. McpErrorFactory Returns DTOs Instead of Arrays
-
-`McpErrorFactory` methods now return `JSONRPCErrorResponse` DTOs from `php-mcp-schema`.
-
-**Before (v0.4.x):**
-```php
-$error = McpErrorFactory::tool_not_found( $request_id, $tool_name );
-// $error was a plain array: ['jsonrpc' => '2.0', 'error' => ['code' => -32003, ...], 'id' => ...]
-
-// Could use directly in array responses
-return $error;
-```
-
-**After (v0.5.0):**
-```php
-$error = McpErrorFactory::tool_not_found( $request_id, $tool_name );
-// $error is a JSONRPCErrorResponse DTO
-
-// Access error details via methods
-$error_code = $error->getError()->getCode();
-$error_message = $error->getError()->getMessage();
-
-// Convert to array when needed for serialization
-$error_array = $error->toArray();
-```
-
-All `McpErrorFactory` static methods are affected:
-- `parse_error()`, `invalid_request()`, `method_not_found()`, `invalid_params()`, `internal_error()`
-- `tool_not_found()`, `resource_not_found()`, `prompt_not_found()`
-- `permission_denied()`, `unauthorized()`, `mcp_disabled()`
-- `validation_error()`, `missing_parameter()`, `ability_not_found()`
-- `create_error_response()` (the underlying factory method)
-
-The `create_error()` helper method now returns an `Error` DTO:
-```php
-$error = McpErrorFactory::create_error( -32603, 'Internal error' );
-// Returns WP\McpSchema\Common\JsonRpc\DTO\Error
-```
-
-### 4. RequestRouter Expects DTO Results from Handlers
-
-`RequestRouter::route_request()` now expects handlers to return `AbstractDataTransferObject` instances. It converts DTOs to arrays at the serialization boundary.
-
-**Before (v0.4.x):**
-```php
-// RequestRouter worked with raw arrays from handlers.
-// Handlers returned arrays, router passed them through.
-```
-
-**After (v0.5.0):**
-```php
-// RequestRouter checks the return type:
-// - JSONRPCErrorResponse DTO → extracts error array
-// - AbstractDataTransferObject DTO → calls toArray()
-// - Unexpected type → logs warning, returns internal error
-
-// If your custom handler returns a non-DTO type, RequestRouter
-// will log a warning and return an internal error response.
-```
-
-This means custom code that hooks into the routing layer must return DTOs.
-
-### 5. McpComponentRegistry Stores McpComponentInterface Instances
-
-The registry now stores typed component instances instead of raw arrays.
-
-**Before (v0.4.x):**
-```php
-// Registry stored array representations
-$tools = $registry->get_tools();
-// $tools was: ['tool-name' => ['name' => '...', ...]]
-```
-
-**After (v0.5.0):**
-```php
-// get_tools() returns protocol DTOs (via get_protocol_dto())
-$tools = $registry->get_tools();
-// $tools is: ['tool-name' => ToolDto instance]
-
-// get_mcp_tool() returns the full McpTool instance
-$mcp_tool = $registry->get_mcp_tool( 'tool-name' );
-// $mcp_tool is: McpTool (implements McpComponentInterface)
-```
-
-The same pattern applies for resources and prompts via `get_resources()`, `get_mcp_resource()`, `get_prompts()`, and `get_mcp_prompt()`.
+**Transport return format (unchanged):**
+- `RequestRouter::route_request()` still returns `array` — DTOs are converted to arrays internally
+- Error shape: `['error' => ['code' => int, 'message' => string]]`
+- Success shape: the result DTO's `toArray()` output
 
 ## New Features
 
-### 1. php-mcp-schema Package
+### php-mcp-schema Package
 
 New dependency: `wordpress/php-mcp-schema ^0.1.0`. This package provides typed DTOs for all MCP protocol types under the `WP\McpSchema\` namespace.
 
@@ -224,9 +75,9 @@ Key DTO classes used throughout the adapter:
 
 All DTOs provide `fromArray()` for construction and `toArray()` for serialization.
 
-### 2. McpComponentInterface
+### McpComponentInterface
 
-New contract (`WP\MCP\Domain\Contracts\McpComponentInterface`) that all domain components implement. Provides:
+New internal contract (`WP\MCP\Domain\Contracts\McpComponentInterface`) that all domain components implement. Provides:
 
 - `get_protocol_dto()` — Clean schema DTO for MCP client responses
 - `execute( $arguments )` — Unified execution surface (delegates to ability or callable handler)
@@ -234,7 +85,7 @@ New contract (`WP\MCP\Domain\Contracts\McpComponentInterface`) that all domain c
 - `get_adapter_meta()` — Internal metadata not exposed to clients
 - `get_observability_context()` — Tags for logging and metrics
 
-### 3. New Utility Classes
+### New Utility Classes
 
 **`McpNameSanitizer`** (`WP\MCP\Domain\Utils\McpNameSanitizer`)
 Normalizes component names to MCP-valid format (A-Za-z0-9_.- , max 128 characters). Handles transliteration, invalid character replacement, and truncation with hash suffixes.
@@ -265,39 +116,129 @@ Standardized failure reason constants for observability events. Replaces string 
 
 Categories: registration failures (`ABILITY_NOT_FOUND`, `DUPLICATE_URI`, `BUILDER_EXCEPTION`, `NO_PERMISSION_STRATEGY`, `ABILITY_CONVERSION_FAILED`), permission failures (`PERMISSION_DENIED`, `PERMISSION_CHECK_FAILED`), execution failures (`NOT_FOUND`, `EXECUTION_FAILED`, `EXECUTION_EXCEPTION`), and validation failures (`MISSING_PARAMETER`, `INVALID_PARAMETER`).
 
-## Migration Steps
+## Advanced: Internal API Changes
 
-### Step 1: Update Custom Transport Implementations
+> **This section only applies if you have custom handlers, custom transports that call `McpErrorFactory` directly, or code that accesses internal component data structures.** If you only use the public APIs listed above, you can skip this section entirely.
 
-If you have implemented `McpTransportInterface` or `McpRestTransportInterface`, update your `handle_request()` method. The `RequestRouter` now returns arrays (it converts DTOs internally), so transport code consuming `route_request()` results should continue working. However, if you were manually inspecting response structures, be aware that error responses now have this shape:
+### Custom Handlers Must Return DTOs
 
+All handlers now return typed schema DTOs instead of raw PHP arrays. If you created custom handlers that the `RequestRouter` calls, they must return DTOs.
+
+**Before (v0.4.x):**
 ```php
-// Error responses from route_request()
-$result = $this->context->request_router->route_request(
-    $method, $params, $request_id, $this->get_transport_name()
-);
-
-// Error shape: ['error' => ['code' => -32003, 'message' => '...']]
-// Success shape: the DTO's toArray() output (e.g., ['tools' => [...]] for tools/list)
+// ToolsHandler returned arrays
+$result = $tools_handler->list_tools();
+// $result was: ['tools' => [['name' => 'my-tool', ...], ...]]
 ```
 
-If you call `McpErrorFactory` directly in your transport for pre-routing errors (e.g., authentication failures), update to handle DTOs:
-
+**After (v0.5.0):**
 ```php
-// Before (v0.4.x)
+// ToolsHandler returns DTOs
+$result = $tools_handler->list_tools();
+// $result is: ListToolsResult DTO
+```
+
+**All affected handlers and their new return types:**
+
+| Handler | Method | Return type (v0.5.0) |
+|---------|--------|---------------------|
+| `ToolsHandler` | `list_tools()` | `WP\McpSchema\Server\Tools\DTO\ListToolsResult` |
+| `ToolsHandler` | `call_tool()` | `CallToolResult` or `JSONRPCErrorResponse` |
+| `ResourcesHandler` | `list_resources()` | `WP\McpSchema\Server\Resources\DTO\ListResourcesResult` |
+| `ResourcesHandler` | `read_resource()` | `ReadResourceResult` or `JSONRPCErrorResponse` |
+| `PromptsHandler` | `list_prompts()` | `WP\McpSchema\Server\Prompts\DTO\ListPromptsResult` |
+| `PromptsHandler` | `get_prompt()` | `GetPromptResult` or `JSONRPCErrorResponse` |
+| `InitializeHandler` | `handle()` | `WP\McpSchema\Common\Protocol\DTO\InitializeResult` |
+
+`RequestRouter` checks the return type and will log a warning if a handler returns a non-DTO type.
+
+### McpErrorFactory Returns DTOs
+
+`McpErrorFactory` methods now return `JSONRPCErrorResponse` DTOs instead of arrays. This only affects you if you call `McpErrorFactory` directly (e.g., in a custom transport for pre-routing errors).
+
+**Before (v0.4.x):**
+```php
 $error = McpErrorFactory::unauthorized( $request_id );
 return new \WP_REST_Response( $error, 401 );
+```
 
-// After (v0.5.0)
+**After (v0.5.0):**
+```php
 $error = McpErrorFactory::unauthorized( $request_id );
 return new \WP_REST_Response( $error->toArray(), 401 );
 ```
 
+All `McpErrorFactory` static methods are affected:
+- `parse_error()`, `invalid_request()`, `method_not_found()`, `invalid_params()`, `internal_error()`
+- `tool_not_found()`, `resource_not_found()`, `prompt_not_found()`
+- `permission_denied()`, `unauthorized()`, `mcp_disabled()`
+- `validation_error()`, `missing_parameter()`, `ability_not_found()`
+- `create_error_response()` (the underlying factory method)
+
+Error constant values are unchanged (`PARSE_ERROR`, `INVALID_REQUEST`, etc.) but are now also available from `McpConstants`:
+
+```php
+use WP\McpSchema\Common\McpConstants;
+
+McpErrorFactory::PARSE_ERROR;      // -32700
+McpConstants::PARSE_ERROR;         // -32700
+```
+
 `McpErrorFactory::get_http_status_for_error()` accepts both DTOs and legacy arrays, so existing HTTP status logic continues to work.
 
-### Step 2: Update Custom Handler Implementations
+### Component Internal Data Structure Changed
 
-If you have created custom handlers that the `RequestRouter` calls, they must return schema DTOs.
+Domain models (`McpTool`, `McpResource`, `McpPrompt`) now implement `McpComponentInterface`. This only affects you if your code accessed internal `_meta` arrays or component data directly.
+
+**Before (v0.4.x):**
+```php
+$tool_array = $tool->to_array();
+$name = $tool_array['name'];
+$meta = $tool_array['_meta'];
+```
+
+**After (v0.5.0):**
+```php
+$tool_dto = $mcp_tool->get_protocol_dto();
+$name = $tool_dto->getName();
+$meta = $mcp_tool->get_adapter_meta();
+```
+
+`McpComponentRegistry::get_tools()` now returns protocol DTOs (via `get_protocol_dto()`). Use `get_mcp_tool()` to get the full `McpTool` instance with execution and permission methods.
+
+### Observability Context Changed
+
+Observability context is now provided by `McpComponentInterface::get_observability_context()` instead of being extracted from response `_metadata` arrays.
+
+```php
+// Before (v0.4.x)
+$tags = $response['_metadata'] ?? [];
+
+// After (v0.5.0)
+$tags = $mcp_tool->get_observability_context();
+// Returns: ['component_type' => 'tool', 'tool_name' => '...', 'source' => 'ability']
+```
+
+Failure reasons now use `FailureReason` constants instead of string literals. The string values are the same (`'permission_denied'`, `'not_found'`, etc.) so filtering logic continues to work.
+
+## Migration Steps for Advanced Users
+
+> Skip this section if you only use the public APIs (component registration, `create_server()`, hooks).
+
+### Step 1: Custom Transports
+
+If you implemented `McpTransportInterface` or `McpRestTransportInterface`, the `route_request()` return format is unchanged (still arrays). Your transport code should work as-is.
+
+Only update if you call `McpErrorFactory` directly for pre-routing errors — add `->toArray()`:
+
+```php
+$error = McpErrorFactory::unauthorized( $request_id );
+return new \WP_REST_Response( $error->toArray(), 401 );
+```
+
+### Step 2: Custom Handlers
+
+If you created custom handlers called by `RequestRouter`, they must return schema DTOs:
 
 **Tools handler example:**
 
@@ -307,19 +248,16 @@ use WP\McpSchema\Server\Tools\DTO\CallToolResult;
 use WP\MCP\Domain\Utils\ContentBlockHelper;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 
-// List handler — return ListToolsResult
 public function list_tools(): ListToolsResult {
     $tools = array_values( $this->mcp->get_tools() );
     return ListToolsResult::fromArray( [ 'tools' => $tools ] );
 }
 
-// Call handler — return CallToolResult or JSONRPCErrorResponse
 public function call_tool( array $params, $request_id = 0 ) {
     if ( ! isset( $params['name'] ) ) {
         return McpErrorFactory::missing_parameter( $request_id, 'tool name' );
     }
 
-    // Success
     return CallToolResult::fromArray( [
         'content' => [ ContentBlockHelper::text( $json_text ) ],
         'isError' => false,
@@ -340,7 +278,6 @@ public function list_resources(): ListResourcesResult {
 }
 
 public function read_resource( array $params, $request_id = 0 ) {
-    // ... validation ...
     $content = TextResourceContents::fromArray( [
         'uri'  => $uri,
         'text' => $text,
@@ -362,7 +299,6 @@ public function list_prompts(): ListPromptsResult {
 }
 
 public function get_prompt( array $params, $request_id = 0 ) {
-    // ... validation and execution ...
     $message = PromptMessage::fromArray( [
         'role'    => 'user',
         'content' => [ 'type' => 'text', 'text' => $text ],
@@ -374,25 +310,9 @@ public function get_prompt( array $params, $request_id = 0 ) {
 }
 ```
 
-### Step 3: Update Direct Component Registration
+### Step 3: Error Handling Code
 
-The `fromArray()` factory methods on `McpTool`, `McpResource`, and `McpPrompt` have **unchanged signatures**. However, if your code accessed internal `_meta` arrays or protocol fields directly from the component, migrate to the new accessors:
-
-```php
-// Before (v0.4.x) — accessing tool data as array
-$tool_array = $tool->to_array();
-$name = $tool_array['name'];
-$meta = $tool_array['_meta'];
-
-// After (v0.5.0) — use typed accessors
-$tool_dto = $mcp_tool->get_protocol_dto();
-$name = $tool_dto->getName();
-$meta = $mcp_tool->get_adapter_meta();
-```
-
-### Step 4: Update Error Handling Code
-
-If your code consumed `McpErrorFactory` return values as arrays, add `->toArray()` calls:
+If your code consumed `McpErrorFactory` return values as arrays:
 
 ```php
 // Before (v0.4.x)
@@ -408,85 +328,20 @@ $error_array = $error->toArray();
 $error_code = $error_array['error']['code'];
 ```
 
-Error constant values are unchanged (`PARSE_ERROR`, `INVALID_REQUEST`, etc.) but are now sourced from `McpConstants`:
+### Step 4: Observability Code
+
+If you have custom observability handlers that extracted tags from response `_metadata`:
 
 ```php
-use WP\McpSchema\Common\McpConstants;
-
-// McpErrorFactory constants still work
-McpErrorFactory::PARSE_ERROR;      // -32700
-McpErrorFactory::INTERNAL_ERROR;   // -32603
-
-// Now backed by McpConstants
-McpConstants::PARSE_ERROR;         // -32700
-McpConstants::INTERNAL_ERROR;      // -32603
-```
-
-### Step 5: Update Observability Code
-
-Observability context is now provided by `McpComponentInterface::get_observability_context()` instead of being extracted from DTO `_metadata` arrays. The `RequestRouter` uses this method internally.
-
-```php
-// Before (v0.4.x) — tags derived from response _metadata
+// Before (v0.4.x)
 $tags = $response['_metadata'] ?? [];
 $component_type = $tags['component_type'] ?? 'unknown';
 
-// After (v0.5.0) — tags from McpComponentInterface
-$tags = $mcp_tool->get_observability_context();
-// Returns: [
-//     'component_type' => 'tool',
-//     'tool_name'      => 'my-tool',
-//     'ability_name'   => 'my-plugin/my-ability',  // if ability-backed
-//     'source'         => 'ability',                // 'ability' or 'array'
-// ]
-```
-
-Failure reasons now use `FailureReason` constants instead of string literals:
-
-```php
-use WP\MCP\Infrastructure\Observability\FailureReason;
-
-// Before (v0.4.x)
-'failure_reason' => 'permission_denied'
-
 // After (v0.5.0)
-'failure_reason' => FailureReason::PERMISSION_DENIED
+$tags = $mcp_tool->get_observability_context();
 ```
 
-If you have custom observability handlers that filter on `failure_reason` tags, the string values are the same (`'permission_denied'`, `'not_found'`, etc.) but are now guaranteed by the `FailureReason` class. Use `FailureReason::all()` to get all valid values and `FailureReason::is_valid()` to validate.
-
-## Backward Compatibility Notes
-
-The following APIs are **unchanged** in v0.5.0:
-
-**Factory method signatures:**
-- `McpTool::fromArray( array $config )` — Same config keys: `name`, `title`, `description`, `inputSchema`, `handler`, `permission`, `annotations`
-- `McpTool::fromAbility( \WP_Ability $ability )`
-- `McpResource::fromArray( array $config )` — Same config keys: `uri`, `name`, `title`, `description`, `handler`, `permission`, `mimeType`, `annotations`
-- `McpResource::fromAbility( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null )`
-- `McpPrompt::fromArray( array $config )` — Same config keys: `name`, `title`, `description`, `arguments`, `handler`, `permission`
-- `McpPrompt::fromAbility( \WP_Ability $ability )`
-- `McpPrompt::fromBuilder( McpPromptBuilderInterface $builder )`
-
-**Public interfaces (signatures unchanged):**
-- `McpErrorHandlerInterface::log( string $message, array $context = [], string $type = 'error' ): void`
-- `McpObservabilityHandlerInterface::record_event( string $event, array $tags = [], ?float $duration_ms = null ): void`
-- `McpTransportInterface` and `McpRestTransportInterface`
-- `McpPromptBuilderInterface`
-
-**Core API:**
-- `McpAdapter::create_server()` — Signature unchanged
-- `McpAdapter::get_server()`, `McpAdapter::get_servers()`
-
-**WordPress hooks:**
-- All action and filter hook names unchanged
-- Hook parameters unchanged
-- `mcp_adapter_init`, `wp_mcp_init`, and all filters listed in the documentation
-
-**RequestRouter::route_request() return format:**
-- Still returns `array` — DTOs are converted to arrays at this boundary
-- Error shape: `['error' => ['code' => int, 'message' => string]]`
-- Success shape: the result DTO's `toArray()` output
+Failure reason string values are unchanged — `FailureReason::PERMISSION_DENIED` resolves to `'permission_denied'`. Use `FailureReason::all()` to get all valid values and `FailureReason::is_valid()` to validate.
 
 ## Next Steps
 

--- a/docs/migration/v0.5.0.md
+++ b/docs/migration/v0.5.0.md
@@ -1,8 +1,8 @@
-# Migration Guide: Version 0.5.0
+# Migration guide: version 0.5.0
 
 Version 0.5.0 introduces typed protocol DTOs via `php-mcp-schema`, replacing internal array manipulation with schema-validated data structures. The architecture now cleanly separates the **Schema Layer** (protocol types from `WP\McpSchema\`) from the **Adapter Layer** (WordPress integration in `WP\MCP\`).
 
-## For Most Users: Seamless Upgrade
+## For most users: seamless upgrade
 
 **If you register abilities, create servers via `create_server()`, or use WordPress hooks — nothing breaks.** Update the plugin and everything continues to work.
 
@@ -37,7 +37,7 @@ The following public APIs are **unchanged** in v0.5.0:
 - Error shape: `['error' => ['code' => int, 'message' => string]]`
 - Success shape: the result DTO's `toArray()` output
 
-## New Features
+## New features
 
 ### php-mcp-schema Package
 
@@ -85,7 +85,7 @@ New internal contract (`WP\MCP\Domain\Contracts\McpComponentInterface`) that all
 - `get_adapter_meta()` — Internal metadata not exposed to clients
 - `get_observability_context()` — Tags for logging and metrics
 
-### New Utility Classes
+### New utility classes
 
 **`McpNameSanitizer`** (`WP\MCP\Domain\Utils\McpNameSanitizer`)
 Normalizes component names to MCP-valid format (A-Za-z0-9_.- , max 128 characters). Handles transliteration, invalid character replacement, and truncation with hash suffixes.
@@ -116,11 +116,11 @@ Standardized failure reason constants for observability events. Replaces string 
 
 Categories: registration failures (`ABILITY_NOT_FOUND`, `DUPLICATE_URI`, `BUILDER_EXCEPTION`, `NO_PERMISSION_STRATEGY`, `ABILITY_CONVERSION_FAILED`), permission failures (`PERMISSION_DENIED`, `PERMISSION_CHECK_FAILED`), execution failures (`NOT_FOUND`, `EXECUTION_FAILED`, `EXECUTION_EXCEPTION`), and validation failures (`MISSING_PARAMETER`, `INVALID_PARAMETER`).
 
-## Advanced: Internal API Changes
+## Advanced: internal API changes
 
 > **This section only applies if you have custom handlers, custom transports that call `McpErrorFactory` directly, or code that accesses internal component data structures.** If you only use the public APIs listed above, you can skip this section entirely.
 
-### Custom Handlers Must Return DTOs
+### Custom handlers must return DTOs
 
 All handlers now return typed schema DTOs instead of raw PHP arrays. If you created custom handlers that the `RequestRouter` calls, they must return DTOs.
 
@@ -152,7 +152,7 @@ $result = $tools_handler->list_tools();
 
 `RequestRouter` checks the return type and will log a warning if a handler returns a non-DTO type.
 
-### McpErrorFactory Returns DTOs
+### McpErrorFactory returns DTOs
 
 `McpErrorFactory` methods now return `JSONRPCErrorResponse` DTOs instead of arrays. This only affects you if you call `McpErrorFactory` directly (e.g., in a custom transport for pre-routing errors).
 
@@ -186,7 +186,7 @@ McpConstants::PARSE_ERROR;         // -32700
 
 `McpErrorFactory::get_http_status_for_error()` accepts both DTOs and legacy arrays, so existing HTTP status logic continues to work.
 
-### Component Internal Data Structure Changed
+### Component internal data structure changed
 
 Domain models (`McpTool`, `McpResource`, `McpPrompt`) now implement `McpComponentInterface`. This only affects you if your code accessed internal `_meta` arrays or component data directly.
 
@@ -206,7 +206,7 @@ $meta = $mcp_tool->get_adapter_meta();
 
 `McpComponentRegistry::get_tools()` now returns protocol DTOs (via `get_protocol_dto()`). Use `get_mcp_tool()` to get the full `McpTool` instance with execution and permission methods.
 
-### Observability Context Changed
+### Observability context changed
 
 Observability context is now provided by `McpComponentInterface::get_observability_context()` instead of being extracted from response `_metadata` arrays.
 
@@ -221,11 +221,11 @@ $tags = $mcp_tool->get_observability_context();
 
 Failure reasons now use `FailureReason` constants instead of string literals. The string values are the same (`'permission_denied'`, `'not_found'`, etc.) so filtering logic continues to work.
 
-## Migration Steps for Advanced Users
+## Migration steps for advanced users
 
 > Skip this section if you only use the public APIs (component registration, `create_server()`, hooks).
 
-### Step 1: Custom Transports
+### Step 1: Custom transports
 
 If you implemented `McpTransportInterface` or `McpRestTransportInterface`, the `route_request()` return format is unchanged (still arrays). Your transport code should work as-is.
 
@@ -236,7 +236,7 @@ $error = McpErrorFactory::unauthorized( $request_id );
 return new \WP_REST_Response( $error->toArray(), 401 );
 ```
 
-### Step 2: Custom Handlers
+### Step 2: Custom handlers
 
 If you created custom handlers called by `RequestRouter`, they must return schema DTOs:
 
@@ -310,7 +310,7 @@ public function get_prompt( array $params, $request_id = 0 ) {
 }
 ```
 
-### Step 3: Error Handling Code
+### Step 3: Error handling code
 
 If your code consumed `McpErrorFactory` return values as arrays:
 
@@ -328,7 +328,7 @@ $error_array = $error->toArray();
 $error_code = $error_array['error']['code'];
 ```
 
-### Step 4: Observability Code
+### Step 4: Observability code
 
 If you have custom observability handlers that extracted tags from response `_metadata`:
 
@@ -343,7 +343,7 @@ $tags = $mcp_tool->get_observability_context();
 
 Failure reason string values are unchanged — `FailureReason::PERMISSION_DENIED` resolves to `'permission_denied'`. Use `FailureReason::all()` to get all valid values and `FailureReason::is_valid()` to validate.
 
-## Next Steps
+## Next steps
 
 - **[Architecture Overview](../architecture/overview.md)** — Understand the Schema Layer / Adapter Layer separation
 - **[Custom Transports](../guides/custom-transports.md)** — Custom transport implementation guide

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -31,7 +31,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | wp mcp-adapter serve --u
 wp user list --fields=ID,user_login,roles
 ```
 
-### HTTP Session Errors (Missing or Invalid Mcp-Session-Id)
+### HTTP session errors (missing or invalid Mcp-Session-Id)
 
 When using the HTTP REST API, all requests after `initialize` must include the `Mcp-Session-Id` header. Omitting it or sending an invalid value are the most common causes of unexpected errors.
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -31,6 +31,45 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | wp mcp-adapter serve --u
 wp user list --fields=ID,user_login,roles
 ```
 
+### HTTP Session Errors (Missing or Invalid Mcp-Session-Id)
+
+When using the HTTP REST API, all requests after `initialize` must include the `Mcp-Session-Id` header. Omitting it or sending an invalid value are the most common causes of unexpected errors.
+
+**Symptom: HTTP 400 — "Missing Mcp-Session-Id header"**
+
+The request is missing the `Mcp-Session-Id` header. Every request except `initialize` must include it.
+
+```bash
+# Wrong — no session header
+curl -s -X POST "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
+  --user "username:application_password" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+
+# Correct — include the session header received from initialize
+curl -s -X POST "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
+  --user "username:application_password" \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session-id-from-initialize>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+```
+
+**Symptom: "Invalid or expired session" in JSON-RPC error response**
+
+The session ID is not recognized or has exceeded the inactivity timeout. Re-initialize to obtain a new session:
+
+```bash
+# Re-initialize to get a fresh session
+curl -s -D - -X POST "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
+  --user "username:application_password" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"my-client","version":"1.0.0"}}}'
+```
+
+**Tip:** The default inactivity timeout is 24 hours (`DAY_IN_SECONDS`). If your client is long-lived, keep the session active by sending requests periodically. You can also adjust the timeout with the `mcp_adapter_session_inactivity_timeout` filter.
+
+**Note:** STDIO transport (WP-CLI) does not use HTTP sessions. If you see session errors, verify you are using the correct transport for your use case. See the [HTTP Sessions section](../guides/default-server.md#http-sessions) for the full session flow.
+
 ## Installation Issues
 
 ### Plugin Not Active

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -63,7 +63,7 @@ The session ID is not recognized or has exceeded the inactivity timeout. Re-init
 curl -s -D - -X POST "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
   --user "username:application_password" \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"my-client","version":"1.0.0"}}}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"my-client","version":"1.0.0"}}}'
 ```
 
 **Tip:** The default inactivity timeout is 24 hours (`DAY_IN_SECONDS`). If your client is long-lived, keep the session active by sending requests periodically. You can also adjust the timeout with the `mcp_adapter_session_inactivity_timeout` filter.

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -368,9 +368,7 @@ if ( ! in_array(
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 
 if ( empty( $params['name'] ) ) {
-    return [
-        'error' => McpErrorFactory::missing_parameter( $request_id, 'name' )['error']
-    ];
+    return McpErrorFactory::missing_parameter( $request_id, 'name' );
 }
 ```
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -35,7 +35,7 @@ wp user list --fields=ID,user_login,roles
 
 When using the HTTP REST API, all requests after `initialize` must include the `Mcp-Session-Id` header. Omitting it or sending an invalid value are the most common causes of unexpected errors.
 
-**Symptom: HTTP 400 — "Missing Mcp-Session-Id header"**
+**Symptom: JSON-RPC error `-32600` — "Missing Mcp-Session-Id header"**
 
 The request is missing the `Mcp-Session-Id` header. Every request except `initialize` must include it.
 

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -177,7 +177,7 @@ final class SessionManager {
 		 *
 		 * @since 0.3.0
 		 *
-		 * @param int $timeout Inactivity timeout in seconds. Default 3600 (1 hour).
+		 * @param int $timeout Inactivity timeout in seconds. Default DAY_IN_SECONDS (86400 / 24 hours).
 		 */
 		$inactivity_timeout = (int) apply_filters( 'mcp_adapter_session_inactivity_timeout', self::DEFAULT_INACTIVITY_TIMEOUT );
 


### PR DESCRIPTION
## Summary

Complete documentation update for v0.5.0 reflecting the architectural changes (schema/adapter separation via php-mcp-schema DTOs) and addressing documentation gaps from #105.

### Changes

- **Architecture overview rewrite** — Two-layer architecture (Schema Layer + Adapter Layer), McpComponentInterface, DTO-based handler returns, utility classes section, updated extension points
- **v0.5.0 migration guide** — Seamless upgrade framing for most users, internal API changes for advanced customizers (custom handlers, McpErrorFactory, observability), before/after code examples
- **Tool naming documentation** — McpNameSanitizer `/`→`-` transformation, sanitization pipeline, `mcp_adapter_tool_name` filter, registration name vs MCP name distinction
- **Server selection guidance** — Default server (layered discovery with 3 meta-tools) vs custom server (direct registration), comparison table, disable/extend filters
- **HTTP session documentation** — Initialize → Mcp-Session-Id flow, curl examples, error cases, session configuration hooks, STDIO exemption, troubleshooting entry
- **README updates** — Component tree with new files, php-mcp-schema dependency, migration guide link
- **Navigation updates** — Migration guides section and upgrading quick nav in docs index
- **WordPress docs standards** — Sentence case headings per WordPress Documentation Style Guide

### Other fixes

- Fixed stale McpErrorFactory array access pattern in troubleshooting guide
- Fixed SessionManager PHPDoc: timeout default corrected from "3600 (1 hour)" to "DAY_IN_SECONDS (86400)"
- All code examples verified against actual source files
- All internal links verified to resolve

Closes #105