### PR TITLE
Add 11 handler filter hooks for extensibility

### DIFF
--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -8,6 +8,7 @@
 
 namespace WP\MCP\Domain\Prompts;
 
+use WP\MCP\Domain\Utils\McpNameSanitizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Domain\Utils\SchemaTransformer;
 use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
@@ -211,9 +212,13 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 */
 	private function get_data() {
-		$ability_name = trim( $this->ability->get_name() );
-		$prompt_data  = array(
-			'name' => str_replace( '/', '-', $ability_name ),
+		$prompt_name = $this->resolve_prompt_name();
+		if ( is_wp_error( $prompt_name ) ) {
+			return $prompt_name;
+		}
+
+		$prompt_data = array(
+			'name' => $prompt_name,
 		);
 
 		// Add optional title from ability label.
@@ -425,6 +430,48 @@ class RegisterAbilityAsMcpPrompt {
 		}
 
 		return $arguments;
+	}
+
+	/**
+	 * Resolve the MCP prompt name from ability.
+	 *
+	 * Sanitizes the ability name to MCP-valid format, applies filter, and validates result.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string|\WP_Error Valid prompt name or error.
+	 */
+	private function resolve_prompt_name() {
+		// Sanitize ability name to MCP-valid format.
+		$sanitized_name = McpNameSanitizer::sanitize_name( $this->ability->get_name() );
+
+		if ( is_wp_error( $sanitized_name ) ) {
+			return $sanitized_name;
+		}
+
+		/**
+		 * Filters the MCP prompt name derived from an ability.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param string      $name    The sanitized prompt name.
+		 * @param \WP_Ability $ability The source ability instance.
+		 */
+		$filtered_name = apply_filters( 'mcp_adapter_prompt_name', $sanitized_name, $this->ability );
+
+		// Validate post-filter (in case filter broke it).
+		if ( ! is_string( $filtered_name ) || ! McpValidator::validate_name( $filtered_name ) ) {
+			return new WP_Error(
+				'mcp_prompt_name_filter_invalid',
+				sprintf(
+					/* translators: %s: invalid prompt name returned by filter */
+					__( 'Filter returned invalid MCP prompt name: %s', 'mcp-adapter' ),
+					is_string( $filtered_name ) ? $filtered_name : gettype( $filtered_name )
+				)
+			);
+		}
+
+		return $filtered_name;
 	}
 
 	/**

--- a/includes/Handlers/HandlerHelperTrait.php
+++ b/includes/Handlers/HandlerHelperTrait.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Handlers;
 
+use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
+
 /**
  * Provides common helper methods for MCP handlers.
  */
@@ -25,5 +27,38 @@ trait HandlerHelperTrait {
 	 */
 	protected function extract_params( array $data ): array {
 		return $data['params'] ?? $data;
+	}
+
+	/**
+	 * Validate that a filtered list value is still an array.
+	 *
+	 * If a filter callback returns a non-array value, logs a warning
+	 * and falls back to the original unfiltered array to prevent
+	 * downstream type errors.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param mixed                    $filtered    The value returned by apply_filters.
+	 * @param array                    $original    The original unfiltered array.
+	 * @param string                   $filter_name The filter hook name (for logging).
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface $error_handler The error handler for logging.
+	 *
+	 * @return array The validated array (filtered if valid, original if not).
+	 */
+	protected function validate_filtered_list( $filtered, array $original, string $filter_name, McpErrorHandlerInterface $error_handler ): array {
+		if ( is_array( $filtered ) ) {
+			return $filtered;
+		}
+
+		$error_handler->log(
+			'Filter returned non-array value, falling back to original list',
+			array(
+				'filter'        => $filter_name,
+				'returned_type' => gettype( $filtered ),
+			),
+			'warning'
+		);
+
+		return $original;
 	}
 }

--- a/includes/Handlers/Initialize/InitializeHandler.php
+++ b/includes/Handlers/Initialize/InitializeHandler.php
@@ -73,7 +73,7 @@ class InitializeHandler {
 			)
 		);
 
-		return InitializeResult::fromArray(
+		$result = InitializeResult::fromArray(
 			array(
 				'protocolVersion' => $negotiated_version,
 				'capabilities'    => $capabilities,
@@ -81,5 +81,20 @@ class InitializeHandler {
 				'instructions'    => $this->mcp->get_server_description(),
 			)
 		);
+
+		/**
+		 * Filters the initialize response before returning to the client.
+		 *
+		 * Use this filter to modify server capabilities, instructions, or
+		 * other initialization data dynamically. To modify the result, call
+		 * `$result->toArray()`, change the data, and return
+		 * `InitializeResult::fromArray( $modified_data )`.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param \WP\McpSchema\Common\Protocol\DTO\InitializeResult $result The initialize result DTO.
+		 * @param \WP\MCP\Core\McpServer                             $server The MCP server instance.
+		 */
+		return apply_filters( 'mcp_adapter_initialize_response', $result, $this->mcp );
 	}
 }

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -162,7 +162,7 @@ class PromptsHandler {
 			 *
 			 * @since n.e.x.t
 			 *
-			 * @param mixed                              $result      The raw execution result.
+			 * @param mixed|\WP_Error                    $result      The raw execution result (may be WP_Error).
 			 * @param array                              $arguments   The prompt arguments used.
 			 * @param string                             $prompt_name The prompt name.
 			 * @param \WP\MCP\Domain\Prompts\McpPrompt   $mcp_prompt  The MCP prompt instance.

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -133,10 +133,10 @@ class PromptsHandler {
 			}
 
 			/**
-			 * Filters prompt arguments before execution.
+			 * Filters prompt arguments before execution, or short-circuits execution entirely.
 			 *
-			 * Use this filter for argument normalization, context injection,
-			 * or additional validation before a prompt is built.
+			 * Return the (optionally modified) arguments array to proceed with execution,
+			 * or return a WP_Error to block execution and return an error to the client.
 			 *
 			 * @since n.e.x.t
 			 *
@@ -145,7 +145,12 @@ class PromptsHandler {
 			 * @param \WP\MCP\Domain\Prompts\McpPrompt   $mcp_prompt  The MCP prompt instance.
 			 * @param \WP\MCP\Core\McpServer             $server      The MCP server instance.
 			 */
-			$arguments = apply_filters( 'mcp_adapter_prompt_get_pre', $arguments, $prompt_name, $mcp_prompt, $this->mcp );
+			$arguments = apply_filters( 'mcp_adapter_pre_prompt_get', $arguments, $prompt_name, $mcp_prompt, $this->mcp );
+
+			// Allow pre-filter to short-circuit execution by returning WP_Error.
+			if ( is_wp_error( $arguments ) ) {
+				return McpErrorFactory::permission_denied( $request_id, $arguments->get_error_message() );
+			}
 
 			$result = $mcp_prompt->execute( $arguments );
 
@@ -163,7 +168,7 @@ class PromptsHandler {
 			 * @param \WP\MCP\Domain\Prompts\McpPrompt   $mcp_prompt  The MCP prompt instance.
 			 * @param \WP\MCP\Core\McpServer             $server      The MCP server instance.
 			 */
-			$result = apply_filters( 'mcp_adapter_prompt_get_post', $result, $arguments, $prompt_name, $mcp_prompt, $this->mcp );
+			$result = apply_filters( 'mcp_adapter_prompt_get_result', $result, $arguments, $prompt_name, $mcp_prompt, $this->mcp );
 
 			if ( is_wp_error( $result ) ) {
 				$this->mcp->error_handler->log(

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -70,6 +70,19 @@ class PromptsHandler {
 	public function list_prompts(): ListPromptsResult {
 		$prompts = array_values( $this->mcp->get_prompts() );
 
+		/**
+		 * Filters the list of prompts before returning to the client.
+		 *
+		 * Use this filter to filter prompts by context, add dynamic prompts,
+		 * or reorder the prompts list.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param array<\WP\McpSchema\Server\Prompts\DTO\Prompt> $prompts Array of Prompt DTOs.
+		 * @param \WP\MCP\Core\McpServer                         $server  The MCP server instance.
+		 */
+		$prompts = apply_filters( 'mcp_adapter_prompts_list', $prompts, $this->mcp );
+
 		return ListPromptsResult::fromArray(
 			array(
 				'prompts' => $prompts,

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -81,7 +81,12 @@ class PromptsHandler {
 		 * @param array<\WP\McpSchema\Server\Prompts\DTO\Prompt> $prompts Array of Prompt DTOs.
 		 * @param \WP\MCP\Core\McpServer                         $server  The MCP server instance.
 		 */
-		$prompts = apply_filters( 'mcp_adapter_prompts_list', $prompts, $this->mcp );
+		$prompts = $this->validate_filtered_list(
+			apply_filters( 'mcp_adapter_prompts_list', $prompts, $this->mcp ),
+			$prompts,
+			'mcp_adapter_prompts_list',
+			$this->mcp->error_handler
+		);
 
 		return ListPromptsResult::fromArray(
 			array(

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -132,7 +132,39 @@ class PromptsHandler {
 				return McpErrorFactory::permission_denied( $request_id, $error_message );
 			}
 
+			/**
+			 * Filters prompt arguments before execution.
+			 *
+			 * Use this filter for argument normalization, context injection,
+			 * or additional validation before a prompt is built.
+			 *
+			 * @since n.e.x.t
+			 *
+			 * @param array                              $arguments   The prompt arguments.
+			 * @param string                             $prompt_name The prompt name being retrieved.
+			 * @param \WP\MCP\Domain\Prompts\McpPrompt   $mcp_prompt  The MCP prompt instance.
+			 * @param \WP\MCP\Core\McpServer             $server      The MCP server instance.
+			 */
+			$arguments = apply_filters( 'mcp_adapter_prompt_get_pre', $arguments, $prompt_name, $mcp_prompt, $this->mcp );
+
 			$result = $mcp_prompt->execute( $arguments );
+
+			/**
+			 * Filters the prompt execution result before normalization.
+			 *
+			 * Use this filter for message transformation, context injection,
+			 * content enrichment, or audit logging.
+			 *
+			 * @since n.e.x.t
+			 *
+			 * @param mixed                              $result      The raw execution result.
+			 * @param array                              $arguments   The prompt arguments used.
+			 * @param string                             $prompt_name The prompt name.
+			 * @param \WP\MCP\Domain\Prompts\McpPrompt   $mcp_prompt  The MCP prompt instance.
+			 * @param \WP\MCP\Core\McpServer             $server      The MCP server instance.
+			 */
+			$result = apply_filters( 'mcp_adapter_prompt_get_post', $result, $arguments, $prompt_name, $mcp_prompt, $this->mcp );
+
 			if ( is_wp_error( $result ) ) {
 				$this->mcp->error_handler->log(
 					'Prompt execution returned WP_Error',

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -117,7 +117,38 @@ class ResourcesHandler {
 				return McpErrorFactory::permission_denied( $request_id, $error_message );
 			}
 
+			/**
+			 * Filters resource parameters before execution.
+			 *
+			 * Use this filter for access control, caching lookups,
+			 * or parameter normalization before a resource is read.
+			 *
+			 * @since n.e.x.t
+			 *
+			 * @param array                                $params       The request parameters.
+			 * @param string                               $uri          The resource URI.
+			 * @param \WP\MCP\Domain\Resources\McpResource $mcp_resource The MCP resource instance.
+			 * @param \WP\MCP\Core\McpServer               $server       The MCP server instance.
+			 */
+			$request_params = apply_filters( 'mcp_adapter_resource_read_pre', $request_params, $uri, $mcp_resource, $this->mcp );
+
 			$contents = $mcp_resource->execute( $request_params );
+
+			/**
+			 * Filters the resource contents after execution.
+			 *
+			 * Use this filter for content transformation, caching storage,
+			 * PII redaction, or audit logging.
+			 *
+			 * @since n.e.x.t
+			 *
+			 * @param mixed                                $contents     The raw resource contents.
+			 * @param array                                $params       The request parameters used.
+			 * @param string                               $uri          The resource URI.
+			 * @param \WP\MCP\Domain\Resources\McpResource $mcp_resource The MCP resource instance.
+			 * @param \WP\MCP\Core\McpServer               $server       The MCP server instance.
+			 */
+			$contents = apply_filters( 'mcp_adapter_resource_read_post', $contents, $request_params, $uri, $mcp_resource, $this->mcp );
 
 			// Handle WP_Error objects returned by McpResource execution.
 			if ( is_wp_error( $contents ) ) {

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -62,7 +62,12 @@ class ResourcesHandler {
 		 * @param array<\WP\McpSchema\Server\Resources\DTO\Resource> $resources Array of Resource DTOs.
 		 * @param \WP\MCP\Core\McpServer                             $server    The MCP server instance.
 		 */
-		$resources = apply_filters( 'mcp_adapter_resources_list', $resources, $this->mcp );
+		$resources = $this->validate_filtered_list(
+			apply_filters( 'mcp_adapter_resources_list', $resources, $this->mcp ),
+			$resources,
+			'mcp_adapter_resources_list',
+			$this->mcp->error_handler
+		);
 
 		return ListResourcesResult::fromArray(
 			array(

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -147,7 +147,7 @@ class ResourcesHandler {
 			 *
 			 * @since n.e.x.t
 			 *
-			 * @param mixed                                $contents     The raw resource contents.
+			 * @param mixed|\WP_Error                      $contents     The raw resource contents (may be WP_Error).
 			 * @param array                                $params       The request parameters used.
 			 * @param string                               $uri          The resource URI.
 			 * @param \WP\MCP\Domain\Resources\McpResource $mcp_resource The MCP resource instance.

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -51,6 +51,19 @@ class ResourcesHandler {
 	public function list_resources(): ListResourcesResult {
 		$resources = array_values( $this->mcp->get_resources() );
 
+		/**
+		 * Filters the list of resources before returning to the client.
+		 *
+		 * Use this filter to filter resources by context, add dynamic resources,
+		 * or reorder the resources list.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param array<\WP\McpSchema\Server\Resources\DTO\Resource> $resources Array of Resource DTOs.
+		 * @param \WP\MCP\Core\McpServer                             $server    The MCP server instance.
+		 */
+		$resources = apply_filters( 'mcp_adapter_resources_list', $resources, $this->mcp );
+
 		return ListResourcesResult::fromArray(
 			array(
 				'resources' => $resources,

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -118,10 +118,10 @@ class ResourcesHandler {
 			}
 
 			/**
-			 * Filters resource parameters before execution.
+			 * Filters resource parameters before execution, or short-circuits execution entirely.
 			 *
-			 * Use this filter for access control, caching lookups,
-			 * or parameter normalization before a resource is read.
+			 * Return the (optionally modified) parameters array to proceed with execution,
+			 * or return a WP_Error to block execution and return an error to the client.
 			 *
 			 * @since n.e.x.t
 			 *
@@ -130,7 +130,12 @@ class ResourcesHandler {
 			 * @param \WP\MCP\Domain\Resources\McpResource $mcp_resource The MCP resource instance.
 			 * @param \WP\MCP\Core\McpServer               $server       The MCP server instance.
 			 */
-			$request_params = apply_filters( 'mcp_adapter_resource_read_pre', $request_params, $uri, $mcp_resource, $this->mcp );
+			$request_params = apply_filters( 'mcp_adapter_pre_resource_read', $request_params, $uri, $mcp_resource, $this->mcp );
+
+			// Allow pre-filter to short-circuit execution by returning WP_Error.
+			if ( is_wp_error( $request_params ) ) {
+				return McpErrorFactory::internal_error( $request_id, $request_params->get_error_message() );
+			}
 
 			$contents = $mcp_resource->execute( $request_params );
 
@@ -148,7 +153,7 @@ class ResourcesHandler {
 			 * @param \WP\MCP\Domain\Resources\McpResource $mcp_resource The MCP resource instance.
 			 * @param \WP\MCP\Core\McpServer               $server       The MCP server instance.
 			 */
-			$contents = apply_filters( 'mcp_adapter_resource_read_post', $contents, $request_params, $uri, $mcp_resource, $this->mcp );
+			$contents = apply_filters( 'mcp_adapter_resource_read_result', $contents, $request_params, $uri, $mcp_resource, $this->mcp );
 
 			// Handle WP_Error objects returned by McpResource execution.
 			if ( is_wp_error( $contents ) ) {

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -163,7 +163,38 @@ class ToolsHandler {
 				);
 			}
 
+			/**
+			 * Filters tool arguments before execution.
+			 *
+			 * Use this filter to transform arguments, inject context, add rate
+			 * limiting, or perform additional permission checks before a tool runs.
+			 *
+			 * @since n.e.x.t
+			 *
+			 * @param array                        $args      The tool arguments.
+			 * @param string                       $tool_name The tool name being called.
+			 * @param \WP\MCP\Domain\Tools\McpTool $mcp_tool  The MCP tool instance.
+			 * @param \WP\MCP\Core\McpServer       $server    The MCP server instance.
+			 */
+			$args = apply_filters( 'mcp_adapter_tool_call_pre', $args, $tool_name, $mcp_tool, $this->mcp );
+
 			$result = $mcp_tool->execute( $args );
+
+			/**
+			 * Filters the tool execution result before response assembly.
+			 *
+			 * Use this filter for result transformation, PII redaction,
+			 * audit logging, or content enrichment.
+			 *
+			 * @since n.e.x.t
+			 *
+			 * @param mixed                        $result    The raw execution result.
+			 * @param array                        $args      The tool arguments used.
+			 * @param string                       $tool_name The tool name that was called.
+			 * @param \WP\MCP\Domain\Tools\McpTool $mcp_tool  The MCP tool instance.
+			 * @param \WP\MCP\Core\McpServer       $server    The MCP server instance.
+			 */
+			$result = apply_filters( 'mcp_adapter_tool_call_post', $result, $args, $tool_name, $mcp_tool, $this->mcp );
 
 			if ( is_wp_error( $result ) ) {
 				$this->mcp->error_handler->log(

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -73,6 +73,19 @@ class ToolsHandler {
 	public function list_tools(): ListToolsResult {
 		$tools = array_values( $this->mcp->get_tools() );
 
+		/**
+		 * Filters the list of tools before returning to the client.
+		 *
+		 * Use this filter to hide tools per user/role, add dynamic tools,
+		 * or reorder the tools list.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param array<\WP\McpSchema\Server\Tools\DTO\Tool> $tools  Array of Tool DTOs.
+		 * @param \WP\MCP\Core\McpServer                     $server The MCP server instance.
+		 */
+		$tools = apply_filters( 'mcp_adapter_tools_list', $tools, $this->mcp );
+
 		return ListToolsResult::fromArray(
 			array(
 				'tools' => $tools,

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -84,7 +84,12 @@ class ToolsHandler {
 		 * @param array<\WP\McpSchema\Server\Tools\DTO\Tool> $tools  Array of Tool DTOs.
 		 * @param \WP\MCP\Core\McpServer                     $server The MCP server instance.
 		 */
-		$tools = apply_filters( 'mcp_adapter_tools_list', $tools, $this->mcp );
+		$tools = $this->validate_filtered_list(
+			apply_filters( 'mcp_adapter_tools_list', $tools, $this->mcp ),
+			$tools,
+			'mcp_adapter_tools_list',
+			$this->mcp->error_handler
+		);
 
 		return ListToolsResult::fromArray(
 			array(

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -154,13 +154,7 @@ class ToolsHandler {
 					);
 				}
 
-				return CallToolResult::fromArray(
-					array(
-						'content'           => array( ContentBlockHelper::text( $error_message ) ),
-						'structuredContent' => null,
-						'isError'           => true,
-					)
-				);
+				return $this->create_error_result( $error_message );
 			}
 
 			/**
@@ -180,13 +174,7 @@ class ToolsHandler {
 
 			// Allow pre-filter to short-circuit execution by returning WP_Error.
 			if ( is_wp_error( $args ) ) {
-				return CallToolResult::fromArray(
-					array(
-						'content'           => array( ContentBlockHelper::text( $args->get_error_message() ) ),
-						'structuredContent' => null,
-						'isError'           => true,
-					)
-				);
+				return $this->create_error_result( $args->get_error_message() );
 			}
 
 			$result = $mcp_tool->execute( $args );
@@ -218,13 +206,7 @@ class ToolsHandler {
 					)
 				);
 
-				return CallToolResult::fromArray(
-					array(
-						'content'           => array( ContentBlockHelper::text( $result->get_error_message() ) ),
-						'structuredContent' => null,
-						'isError'           => true,
-					)
-				);
+				return $this->create_error_result( $result->get_error_message() );
 			}
 
 			// Backward compatibility: treat `{ success: false, error: string }` as tool execution error.
@@ -236,13 +218,7 @@ class ToolsHandler {
 				&& is_string( $result['error'] )
 				&& '' !== trim( $result['error'] )
 			) {
-				return CallToolResult::fromArray(
-					array(
-						'content'           => array( ContentBlockHelper::text( $result['error'] ) ),
-						'structuredContent' => null,
-						'isError'           => true,
-					)
-				);
+				return $this->create_error_result( $result['error'] );
 			}
 
 			// Successful tool execution - build CallToolResult DTO.
@@ -334,5 +310,24 @@ class ToolsHandler {
 
 			return McpErrorFactory::internal_error( $request_id, 'Failed to execute tool' );
 		}
+	}
+
+	/**
+	 * Create an error CallToolResult from a message string.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $message The error message.
+	 *
+	 * @return \WP\McpSchema\Server\Tools\DTO\CallToolResult
+	 */
+	private function create_error_result( string $message ): CallToolResult {
+		return CallToolResult::fromArray(
+			array(
+				'content'           => array( ContentBlockHelper::text( $message ) ),
+				'structuredContent' => null,
+				'isError'           => true,
+			)
+		);
 	}
 }

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -164,10 +164,10 @@ class ToolsHandler {
 			}
 
 			/**
-			 * Filters tool arguments before execution.
+			 * Filters tool arguments before execution, or short-circuits execution entirely.
 			 *
-			 * Use this filter to transform arguments, inject context, add rate
-			 * limiting, or perform additional permission checks before a tool runs.
+			 * Return the (optionally modified) arguments array to proceed with execution,
+			 * or return a WP_Error to block execution and return an error to the client.
 			 *
 			 * @since n.e.x.t
 			 *
@@ -176,7 +176,18 @@ class ToolsHandler {
 			 * @param \WP\MCP\Domain\Tools\McpTool $mcp_tool  The MCP tool instance.
 			 * @param \WP\MCP\Core\McpServer       $server    The MCP server instance.
 			 */
-			$args = apply_filters( 'mcp_adapter_tool_call_pre', $args, $tool_name, $mcp_tool, $this->mcp );
+			$args = apply_filters( 'mcp_adapter_pre_tool_call', $args, $tool_name, $mcp_tool, $this->mcp );
+
+			// Allow pre-filter to short-circuit execution by returning WP_Error.
+			if ( is_wp_error( $args ) ) {
+				return CallToolResult::fromArray(
+					array(
+						'content'           => array( ContentBlockHelper::text( $args->get_error_message() ) ),
+						'structuredContent' => null,
+						'isError'           => true,
+					)
+				);
+			}
 
 			$result = $mcp_tool->execute( $args );
 
@@ -194,7 +205,7 @@ class ToolsHandler {
 			 * @param \WP\MCP\Domain\Tools\McpTool $mcp_tool  The MCP tool instance.
 			 * @param \WP\MCP\Core\McpServer       $server    The MCP server instance.
 			 */
-			$result = apply_filters( 'mcp_adapter_tool_call_post', $result, $args, $tool_name, $mcp_tool, $this->mcp );
+			$result = apply_filters( 'mcp_adapter_tool_call_result', $result, $args, $tool_name, $mcp_tool, $this->mcp );
 
 			if ( is_wp_error( $result ) ) {
 				$this->mcp->error_handler->log(

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -187,7 +187,7 @@ class ToolsHandler {
 			 *
 			 * @since n.e.x.t
 			 *
-			 * @param mixed                        $result    The raw execution result.
+			 * @param mixed|\WP_Error              $result    The raw execution result (may be WP_Error).
 			 * @param array                        $args      The tool arguments used.
 			 * @param string                       $tool_name The tool name that was called.
 			 * @param \WP\MCP\Domain\Tools\McpTool $mcp_tool  The MCP tool instance.

--- a/tests/Unit/Handlers/InitializeHandlerTest.php
+++ b/tests/Unit/Handlers/InitializeHandlerTest.php
@@ -225,4 +225,33 @@ final class InitializeHandlerTest extends TestCase {
 		// Verify other fields are still correct.
 		$this->assertSame( 'Test Server', $result->getServerInfo()->getName() );
 	}
+
+	public function test_handle_applies_initialize_response_filter(): void {
+		$server = new McpServer(
+			'test',
+			'mcp/v1',
+			'/mcp',
+			'Test Server',
+			'Original instructions',
+			'1.0.0',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+		);
+
+		$filter = static function ( InitializeResult $result ): InitializeResult {
+			$data                 = $result->toArray();
+			$data['instructions'] = 'Custom instructions';
+
+			return InitializeResult::fromArray( $data );
+		};
+		add_filter( 'mcp_adapter_initialize_response', $filter );
+
+		$handler = new InitializeHandler( $server );
+		$result  = $handler->handle( McpConstants::LATEST_PROTOCOL_VERSION );
+
+		$this->assertSame( 'Custom instructions', $result->getInstructions() );
+
+		remove_filter( 'mcp_adapter_initialize_response', $filter );
+	}
 }

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -244,7 +244,7 @@ final class PromptsHandlerTest extends TestCase {
 		wp_unregister_ability( 'test/prompt-execute-exception' );
 	}
 
-	public function test_get_prompt_applies_pre_filter(): void {
+	public function test_pre_prompt_get_filter_can_modify_arguments(): void {
 		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
 		$handler = new PromptsHandler( $server );
 
@@ -254,7 +254,7 @@ final class PromptsHandlerTest extends TestCase {
 
 			return $arguments;
 		};
-		add_filter( 'mcp_adapter_prompt_get_pre', $filter, 10, 2 );
+		add_filter( 'mcp_adapter_pre_prompt_get', $filter, 10, 2 );
 
 		$handler->get_prompt(
 			array(
@@ -268,10 +268,37 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertIsArray( $received_args );
 		$this->assertSame( 'value', $received_args['key'] );
 
-		remove_filter( 'mcp_adapter_prompt_get_pre', $filter );
+		remove_filter( 'mcp_adapter_pre_prompt_get', $filter );
 	}
 
-	public function test_get_prompt_applies_post_filter(): void {
+	public function test_pre_prompt_get_filter_can_short_circuit_with_wp_error(): void {
+		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
+		$handler = new PromptsHandler( $server );
+
+		$filter = static function () {
+			return new \WP_Error( 'blocked', 'Prompt access blocked' );
+		};
+		add_filter( 'mcp_adapter_pre_prompt_get', $filter );
+
+		$result = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => array(),
+				),
+			)
+		);
+
+		// Short-circuit returns JSONRPCErrorResponse.
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$error = $result->getError();
+		$this->assertNotNull( $error );
+		$this->assertStringContainsString( 'Prompt access blocked', $error->getMessage() );
+
+		remove_filter( 'mcp_adapter_pre_prompt_get', $filter );
+	}
+
+	public function test_prompt_get_result_filter_can_modify_result(): void {
 		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
 		$handler = new PromptsHandler( $server );
 
@@ -281,7 +308,7 @@ final class PromptsHandlerTest extends TestCase {
 
 			return $result;
 		};
-		add_filter( 'mcp_adapter_prompt_get_post', $filter );
+		add_filter( 'mcp_adapter_prompt_get_result', $filter );
 
 		$handler->get_prompt(
 			array(
@@ -294,7 +321,7 @@ final class PromptsHandlerTest extends TestCase {
 
 		$this->assertTrue( $filter_was_called );
 
-		remove_filter( 'mcp_adapter_prompt_get_post', $filter );
+		remove_filter( 'mcp_adapter_prompt_get_result', $filter );
 	}
 
 	// Note: Error path testing for prompts is covered by integration tests

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -244,6 +244,59 @@ final class PromptsHandlerTest extends TestCase {
 		wp_unregister_ability( 'test/prompt-execute-exception' );
 	}
 
+	public function test_get_prompt_applies_pre_filter(): void {
+		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
+		$handler = new PromptsHandler( $server );
+
+		$received_args = null;
+		$filter        = static function ( array $arguments, string $prompt_name ) use ( &$received_args ): array {
+			$received_args = $arguments;
+
+			return $arguments;
+		};
+		add_filter( 'mcp_adapter_prompt_get_pre', $filter, 10, 2 );
+
+		$handler->get_prompt(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => array( 'key' => 'value' ),
+				),
+			)
+		);
+
+		$this->assertIsArray( $received_args );
+		$this->assertSame( 'value', $received_args['key'] );
+
+		remove_filter( 'mcp_adapter_prompt_get_pre', $filter );
+	}
+
+	public function test_get_prompt_applies_post_filter(): void {
+		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
+		$handler = new PromptsHandler( $server );
+
+		$filter_was_called = false;
+		$filter            = static function ( $result ) use ( &$filter_was_called ) {
+			$filter_was_called = true;
+
+			return $result;
+		};
+		add_filter( 'mcp_adapter_prompt_get_post', $filter );
+
+		$handler->get_prompt(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => array(),
+				),
+			)
+		);
+
+		$this->assertTrue( $filter_was_called );
+
+		remove_filter( 'mcp_adapter_prompt_get_post', $filter );
+	}
+
 	// Note: Error path testing for prompts is covered by integration tests
 	// and the existing basic error tests above.
 

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -28,6 +28,22 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertContainsOnlyInstancesOf( PromptDto::class, $prompts );
 	}
 
+	public function test_list_prompts_applies_prompts_list_filter(): void {
+		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
+		$handler = new PromptsHandler( $server );
+
+		$filter = static function (): array {
+			return array();
+		};
+		add_filter( 'mcp_adapter_prompts_list', $filter );
+
+		$result = $handler->list_prompts();
+		$this->assertInstanceOf( ListPromptsResult::class, $result );
+		$this->assertEmpty( $result->getPrompts() );
+
+		remove_filter( 'mcp_adapter_prompts_list', $filter );
+	}
+
 	public function test_get_prompt_missing_name_returns_error(): void {
 		$server  = $this->makeServer( array(), array(), array( 'test/prompt' ) );
 		$handler = new PromptsHandler( $server );

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WP\MCP\Tests\Unit\Handlers;
 
 use WP\MCP\Handlers\Prompts\PromptsHandler;
+use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\TestCase;
 use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
 use WP\McpSchema\Server\Prompts\DTO\GetPromptResult;
@@ -930,5 +931,28 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertEquals( 'some value', $decoded['value'] );
 
 		wp_unregister_ability( 'test/invalid-content-prompt' );
+	}
+
+	public function test_list_prompts_withFilterReturningNonArray_fallsBackToOriginal(): void {
+		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
+		$handler = new PromptsHandler( $server );
+
+		$filter = static function (): string {
+			return 'not an array';
+		};
+		add_filter( 'mcp_adapter_prompts_list', $filter );
+
+		DummyErrorHandler::reset();
+		$result = $handler->list_prompts();
+
+		$this->assertInstanceOf( ListPromptsResult::class, $result );
+		$this->assertNotEmpty( $result->getPrompts() );
+
+		$this->assertNotEmpty( DummyErrorHandler::$logs );
+		$last_log = end( DummyErrorHandler::$logs );
+		$this->assertSame( 'warning', $last_log['type'] );
+		$this->assertStringContainsString( 'mcp_adapter_prompts_list', $last_log['context']['filter'] );
+
+		remove_filter( 'mcp_adapter_prompts_list', $filter );
 	}
 }

--- a/tests/Unit/Handlers/ResourcesHandlerListTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerListTest.php
@@ -49,6 +49,26 @@ final class ResourcesHandlerListTest extends TestCase {
 		$this->assertArrayHasKey( 'name', $resource_array );
 	}
 
+	public function test_list_resources_applies_resources_list_filter(): void {
+		$server  = $this->makeServer( array(), array( 'test/resource' ) );
+		$handler = new ResourcesHandler( $server );
+
+		// Verify resources exist before filtering.
+		$before = $handler->list_resources();
+		$this->assertNotEmpty( $before->getResources() );
+
+		$filter = static function (): array {
+			return array();
+		};
+		add_filter( 'mcp_adapter_resources_list', $filter );
+
+		$result = $handler->list_resources();
+		$this->assertInstanceOf( ListResourcesResult::class, $result );
+		$this->assertEmpty( $result->getResources() );
+
+		remove_filter( 'mcp_adapter_resources_list', $filter );
+	}
+
 	public function test_list_resources_does_not_call_ability_execute(): void {
 		wp_set_current_user( 1 );
 

--- a/tests/Unit/Handlers/ResourcesHandlerListTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerListTest.php
@@ -157,4 +157,27 @@ final class ResourcesHandlerListTest extends TestCase {
 		$this->assertArrayNotHasKey( 'text', $resource_array );
 		$this->assertArrayNotHasKey( 'blob', $resource_array );
 	}
+
+	public function test_list_resources_withFilterReturningNonArray_fallsBackToOriginal(): void {
+		$server  = $this->makeServer( array(), array( 'test/resource' ) );
+		$handler = new ResourcesHandler( $server );
+
+		$filter = static function (): string {
+			return 'not an array';
+		};
+		add_filter( 'mcp_adapter_resources_list', $filter );
+
+		DummyErrorHandler::reset();
+		$result = $handler->list_resources();
+
+		$this->assertInstanceOf( ListResourcesResult::class, $result );
+		$this->assertNotEmpty( $result->getResources() );
+
+		$this->assertNotEmpty( DummyErrorHandler::$logs );
+		$last_log = end( DummyErrorHandler::$logs );
+		$this->assertSame( 'warning', $last_log['type'] );
+		$this->assertStringContainsString( 'mcp_adapter_resources_list', $last_log['context']['filter'] );
+
+		remove_filter( 'mcp_adapter_resources_list', $filter );
+	}
 }

--- a/tests/Unit/Handlers/ResourcesHandlerReadTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerReadTest.php
@@ -155,7 +155,7 @@ final class ResourcesHandlerReadTest extends TestCase {
 		$this->assertSame( 'WordPress://local/resource-plain-string', $contents[0]->getUri() );
 	}
 
-	public function test_read_resource_applies_pre_filter(): void {
+	public function test_pre_resource_read_filter_can_modify_params(): void {
 		wp_set_current_user( 1 );
 		$server  = $this->makeServer( array(), array( 'test/resource' ) );
 		$handler = new ResourcesHandler( $server );
@@ -166,7 +166,7 @@ final class ResourcesHandlerReadTest extends TestCase {
 
 			return $params;
 		};
-		add_filter( 'mcp_adapter_resource_read_pre', $filter, 10, 2 );
+		add_filter( 'mcp_adapter_pre_resource_read', $filter, 10, 2 );
 
 		$handler->read_resource(
 			array(
@@ -176,10 +176,35 @@ final class ResourcesHandlerReadTest extends TestCase {
 
 		$this->assertIsArray( $received_params );
 
-		remove_filter( 'mcp_adapter_resource_read_pre', $filter );
+		remove_filter( 'mcp_adapter_pre_resource_read', $filter );
 	}
 
-	public function test_read_resource_applies_post_filter(): void {
+	public function test_pre_resource_read_filter_can_short_circuit_with_wp_error(): void {
+		wp_set_current_user( 1 );
+		$server  = $this->makeServer( array(), array( 'test/resource' ) );
+		$handler = new ResourcesHandler( $server );
+
+		$filter = static function () {
+			return new \WP_Error( 'blocked', 'Resource access blocked' );
+		};
+		add_filter( 'mcp_adapter_pre_resource_read', $filter );
+
+		$result = $handler->read_resource(
+			array(
+				'params' => array( 'uri' => 'WordPress://local/resource-1' ),
+			)
+		);
+
+		// Short-circuit returns JSONRPCErrorResponse.
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$error = $result->getError();
+		$this->assertNotNull( $error );
+		$this->assertStringContainsString( 'Resource access blocked', $error->getMessage() );
+
+		remove_filter( 'mcp_adapter_pre_resource_read', $filter );
+	}
+
+	public function test_resource_read_result_filter_can_modify_contents(): void {
 		wp_set_current_user( 1 );
 		$server  = $this->makeServer( array(), array( 'test/resource' ) );
 		$handler = new ResourcesHandler( $server );
@@ -190,7 +215,7 @@ final class ResourcesHandlerReadTest extends TestCase {
 
 			return $contents;
 		};
-		add_filter( 'mcp_adapter_resource_read_post', $filter );
+		add_filter( 'mcp_adapter_resource_read_result', $filter );
 
 		$handler->read_resource(
 			array(
@@ -200,7 +225,7 @@ final class ResourcesHandlerReadTest extends TestCase {
 
 		$this->assertTrue( $filter_was_called );
 
-		remove_filter( 'mcp_adapter_resource_read_post', $filter );
+		remove_filter( 'mcp_adapter_resource_read_result', $filter );
 	}
 
 	public function test_read_resource_wraps_non_array_result_as_json(): void {

--- a/tests/Unit/Handlers/ResourcesHandlerReadTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerReadTest.php
@@ -155,6 +155,54 @@ final class ResourcesHandlerReadTest extends TestCase {
 		$this->assertSame( 'WordPress://local/resource-plain-string', $contents[0]->getUri() );
 	}
 
+	public function test_read_resource_applies_pre_filter(): void {
+		wp_set_current_user( 1 );
+		$server  = $this->makeServer( array(), array( 'test/resource' ) );
+		$handler = new ResourcesHandler( $server );
+
+		$received_params = null;
+		$filter          = static function ( array $params, string $uri ) use ( &$received_params ): array {
+			$received_params = $params;
+
+			return $params;
+		};
+		add_filter( 'mcp_adapter_resource_read_pre', $filter, 10, 2 );
+
+		$handler->read_resource(
+			array(
+				'params' => array( 'uri' => 'WordPress://local/resource-1' ),
+			)
+		);
+
+		$this->assertIsArray( $received_params );
+
+		remove_filter( 'mcp_adapter_resource_read_pre', $filter );
+	}
+
+	public function test_read_resource_applies_post_filter(): void {
+		wp_set_current_user( 1 );
+		$server  = $this->makeServer( array(), array( 'test/resource' ) );
+		$handler = new ResourcesHandler( $server );
+
+		$filter_was_called = false;
+		$filter            = static function ( $contents ) use ( &$filter_was_called ) {
+			$filter_was_called = true;
+
+			return $contents;
+		};
+		add_filter( 'mcp_adapter_resource_read_post', $filter );
+
+		$handler->read_resource(
+			array(
+				'params' => array( 'uri' => 'WordPress://local/resource-1' ),
+			)
+		);
+
+		$this->assertTrue( $filter_was_called );
+
+		remove_filter( 'mcp_adapter_resource_read_post', $filter );
+	}
+
 	public function test_read_resource_wraps_non_array_result_as_json(): void {
 		wp_set_current_user( 1 );
 

--- a/tests/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerCallTest.php
@@ -169,6 +169,66 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertSame( base64_encode( 'blob-bytes' ), $resource->getBlob() ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
+	public function test_call_tool_applies_pre_filter(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+
+		$received_args = null;
+		$filter        = static function ( array $args, string $tool_name ) use ( &$received_args ): array {
+			$received_args = $args;
+			$args['injected_by_filter'] = true;
+
+			return $args;
+		};
+		add_filter( 'mcp_adapter_tool_call_pre', $filter, 10, 2 );
+
+		$handler->call_tool(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => array( 'key' => 'value' ),
+				),
+			)
+		);
+
+		$this->assertIsArray( $received_args );
+		$this->assertSame( 'value', $received_args['key'] );
+
+		remove_filter( 'mcp_adapter_tool_call_pre', $filter );
+	}
+
+	public function test_call_tool_applies_post_filter(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+
+		$filter = static function ( $result ) {
+			if ( is_array( $result ) ) {
+				$result['filtered'] = true;
+			}
+
+			return $result;
+		};
+		add_filter( 'mcp_adapter_tool_call_post', $filter );
+
+		$result = $handler->call_tool(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => array(),
+				),
+			)
+		);
+
+		// The post filter modifies the raw result before DTO assembly.
+		// Verify the filter was applied by checking structuredContent.
+		$this->assertInstanceOf( CallToolResult::class, $result );
+		$structured = $result->getStructuredContent();
+		$this->assertNotNull( $structured );
+		$this->assertTrue( $structured['filtered'] );
+
+		remove_filter( 'mcp_adapter_tool_call_post', $filter );
+	}
+
 	public function test_tool_call_preserves_meta_in_text_and_structured_content(): void {
 		$server  = $this->makeServer( array( 'test/meta-leak' ) );
 		$handler = new ToolsHandler( $server );

--- a/tests/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerCallTest.php
@@ -169,7 +169,7 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertSame( base64_encode( 'blob-bytes' ), $resource->getBlob() ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
-	public function test_call_tool_applies_pre_filter(): void {
+	public function test_pre_tool_call_filter_can_modify_arguments(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 
@@ -180,7 +180,7 @@ final class ToolsHandlerCallTest extends TestCase {
 
 			return $args;
 		};
-		add_filter( 'mcp_adapter_tool_call_pre', $filter, 10, 2 );
+		add_filter( 'mcp_adapter_pre_tool_call', $filter, 10, 2 );
 
 		$handler->call_tool(
 			array(
@@ -194,21 +194,17 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertIsArray( $received_args );
 		$this->assertSame( 'value', $received_args['key'] );
 
-		remove_filter( 'mcp_adapter_tool_call_pre', $filter );
+		remove_filter( 'mcp_adapter_pre_tool_call', $filter );
 	}
 
-	public function test_call_tool_applies_post_filter(): void {
+	public function test_pre_tool_call_filter_can_short_circuit_with_wp_error(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 
-		$filter = static function ( $result ) {
-			if ( is_array( $result ) ) {
-				$result['filtered'] = true;
-			}
-
-			return $result;
+		$filter = static function () {
+			return new \WP_Error( 'blocked', 'Rate limit exceeded' );
 		};
-		add_filter( 'mcp_adapter_tool_call_post', $filter );
+		add_filter( 'mcp_adapter_pre_tool_call', $filter );
 
 		$result = $handler->call_tool(
 			array(
@@ -219,14 +215,45 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		// The post filter modifies the raw result before DTO assembly.
-		// Verify the filter was applied by checking structuredContent.
+		// Short-circuit returns CallToolResult with isError=true.
+		$this->assertInstanceOf( CallToolResult::class, $result );
+		$this->assertTrue( $result->getIsError() );
+		$content = $result->getContent();
+		$this->assertNotEmpty( $content );
+		$this->assertStringContainsString( 'Rate limit exceeded', $content[0]->getText() );
+
+		remove_filter( 'mcp_adapter_pre_tool_call', $filter );
+	}
+
+	public function test_tool_call_result_filter_can_modify_result(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+
+		$filter = static function ( $result ) {
+			if ( is_array( $result ) ) {
+				$result['filtered'] = true;
+			}
+
+			return $result;
+		};
+		add_filter( 'mcp_adapter_tool_call_result', $filter );
+
+		$result = $handler->call_tool(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => array(),
+				),
+			)
+		);
+
+		// The result filter modifies the raw result before DTO assembly.
 		$this->assertInstanceOf( CallToolResult::class, $result );
 		$structured = $result->getStructuredContent();
 		$this->assertNotNull( $structured );
 		$this->assertTrue( $structured['filtered'] );
 
-		remove_filter( 'mcp_adapter_tool_call_post', $filter );
+		remove_filter( 'mcp_adapter_tool_call_result', $filter );
 	}
 
 	public function test_tool_call_preserves_meta_in_text_and_structured_content(): void {

--- a/tests/Unit/Handlers/ToolsHandlerListTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerListTest.php
@@ -22,6 +22,23 @@ final class ToolsHandlerListTest extends TestCase {
 		$this->assertInstanceOf( ListToolsResult::class, $result );
 	}
 
+	public function test_list_tools_applies_tools_list_filter(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+
+		// Register a filter that removes all tools.
+		$filter = static function (): array {
+			return array();
+		};
+		add_filter( 'mcp_adapter_tools_list', $filter );
+
+		$result = $handler->list_tools();
+		$this->assertInstanceOf( ListToolsResult::class, $result );
+		$this->assertEmpty( $result->getTools() );
+
+		remove_filter( 'mcp_adapter_tools_list', $filter );
+	}
+
 	public function test_list_and_list_all_only_include_json_safe_fields(): void {
 		// Use makeServer helper to properly set up the server with registered abilities.
 		$server = $this->makeServer( array( 'test/always-allowed' ) );

--- a/tests/Unit/Handlers/ToolsHandlerListTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerListTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WP\MCP\Tests\Unit\Handlers;
 
 use WP\MCP\Handlers\Tools\ToolsHandler;
+use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\TestCase;
 use WP\McpSchema\Server\Tools\DTO\ListToolsResult;
 use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
@@ -69,5 +70,30 @@ final class ToolsHandlerListTest extends TestCase {
 		$tool_all       = $all_tools[0];
 		$tool_all_array = $tool_all->toArray();
 		$this->assertArrayHasKey( 'name', $tool_all_array );
+	}
+
+	public function test_list_tools_withFilterReturningNonArray_fallsBackToOriginal(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+
+		$filter = static function (): string {
+			return 'not an array';
+		};
+		add_filter( 'mcp_adapter_tools_list', $filter );
+
+		DummyErrorHandler::reset();
+		$result = $handler->list_tools();
+
+		// Should fall back to the original unfiltered list.
+		$this->assertInstanceOf( ListToolsResult::class, $result );
+		$this->assertNotEmpty( $result->getTools() );
+
+		// Should have logged a warning.
+		$this->assertNotEmpty( DummyErrorHandler::$logs );
+		$last_log = end( DummyErrorHandler::$logs );
+		$this->assertSame( 'warning', $last_log['type'] );
+		$this->assertStringContainsString( 'mcp_adapter_tools_list', $last_log['context']['filter'] );
+
+		remove_filter( 'mcp_adapter_tools_list', $filter );
 	}
 }

--- a/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
+++ b/tests/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
@@ -591,4 +591,42 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 			$this->assertArrayHasKey( 'vendor_info', $arr['_meta'] );
 			$this->assertSame( 'test-value', $arr['_meta']['vendor_info']['custom_data'] );
 		}
+
+	// =========================================================================
+	// mcp_adapter_prompt_name Filter Tests
+	// =========================================================================
+
+	public function test_prompt_name_filter_can_customize_name(): void {
+		$filter_callback = static function ( string $name ): string {
+			return 'custom-prompt-name';
+		};
+		add_filter( 'mcp_adapter_prompt_name', $filter_callback );
+
+		$ability = wp_get_ability( 'test/prompt' );
+		$this->assertNotNull( $ability );
+
+		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
+		$this->assertNotWPError( $prompt );
+
+		$arr = $prompt->toArray();
+		$this->assertSame( 'custom-prompt-name', $arr['name'] );
+
+		remove_filter( 'mcp_adapter_prompt_name', $filter_callback );
+	}
+
+	public function test_prompt_name_filter_with_invalid_result_returns_wp_error(): void {
+		$filter_callback = static function (): string {
+			return 'invalid name with spaces';
+		};
+		add_filter( 'mcp_adapter_prompt_name', $filter_callback );
+
+		$ability = wp_get_ability( 'test/prompt' );
+		$this->assertNotNull( $ability );
+
+		$result = RegisterAbilityAsMcpPrompt::make( $ability );
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_prompt_name_filter_invalid', $result->get_error_code() );
+
+		remove_filter( 'mcp_adapter_prompt_name', $filter_callback );
+	}
 	}


### PR DESCRIPTION
## Summary

11 new `apply_filters` hooks across the MCP handler lifecycle. Covers execution gates, argument/result transformation, list operations, initialization, and component naming.

## Motivation

The plugin had 20 hooks but none in the request/response lifecycle. Once a request entered `RequestRouter`, there were zero extension points until the JSON-RPC response left. No way to modify arguments, filter results, block execution, or dynamically adjust component lists.

## Hooks added

### Pre-execution (can short-circuit with `WP_Error`)

| Hook | Params | Purpose |
|------|--------|---------|
| `mcp_adapter_pre_tool_call` | `(array $args, string $tool_name, McpTool $mcp_tool, McpServer $server) => array\|WP_Error` | Modify tool arguments or return WP_Error to block execution |
| `mcp_adapter_pre_resource_read` | `(array $params, string $uri, McpResource $mcp_resource, McpServer $server) => array\|WP_Error` | Modify resource params or return WP_Error to block execution |
| `mcp_adapter_pre_prompt_get` | `(array $arguments, string $prompt_name, McpPrompt $mcp_prompt, McpServer $server) => array\|WP_Error` | Modify prompt arguments or return WP_Error to block execution |

### Result filters

| Hook | Params | Purpose |
|------|--------|---------|
| `mcp_adapter_tool_call_result` | `(mixed $result, array $args, string $tool_name, McpTool $mcp_tool, McpServer $server) => mixed` | Transform tool result before DTO assembly (PII redaction, audit logging) |
| `mcp_adapter_resource_read_result` | `(mixed $contents, array $params, string $uri, McpResource $mcp_resource, McpServer $server) => mixed` | Transform resource contents before DTO conversion |
| `mcp_adapter_prompt_get_result` | `(mixed $result, array $arguments, string $prompt_name, McpPrompt $mcp_prompt, McpServer $server) => mixed` | Transform prompt result before normalization |

### List filters

| Hook | Params | Purpose |
|------|--------|---------|
| `mcp_adapter_tools_list` | `(array $tools, McpServer $server) => array` | Hide tools per user/role, add dynamic tools, reorder |
| `mcp_adapter_resources_list` | `(array $resources, McpServer $server) => array` | Filter resources by context, add dynamic resources |
| `mcp_adapter_prompts_list` | `(array $prompts, McpServer $server) => array` | Filter prompts, add dynamic prompts |

### Initialize

| Hook | Params | Purpose |
|------|--------|---------|
| `mcp_adapter_initialize_response` | `(InitializeResult $result, McpServer $server) => InitializeResult` | Dynamic capabilities, custom instructions |

### Naming

| Hook | Params | Purpose |
|------|--------|---------|
| `mcp_adapter_prompt_name` | `(string $name, WP_Ability $ability) => string` | Naming parity with existing `mcp_adapter_tool_name` and `mcp_adapter_resource_name` |

## Why the names differ from #130

The names differ from the ones proposed in the #130 investigation. During implementation I found two problems with the `_pre`/`_post` naming from the issue:

1. `_pre` was ambiguous. It could mean "modify arguments" or "gate execution" but couldn't do both. I need to block execution (rate limiting, circuit breakers) from the same hook that modifies arguments, not from a separate one.

2. `_post` didn't say what you're filtering. `_result` is explicit.

I went with the WordPress core `pre_*` short-circuit pattern instead (`pre_delete_post`, `pre_update_option`, `pre_get_shortlink`). The filter returns the modified value to proceed or `WP_Error` to block. This is a pattern WordPress developers already know.

## Test plan

- [ ] All tests pass (`npm run test:php`)
- [ ] PHPCS clean (`npm run lint:php`)
- [ ] PHPStan Level 8 zero errors (`npm run lint:php:stan`)
- [ ] `pre_tool_call` filter can modify arguments
- [ ] `pre_tool_call` filter can block execution with WP_Error
- [ ] `tool_call_result` filter can modify result
- [ ] List filters can remove/add components
- [ ] `initialize_response` filter can modify instructions
- [ ] `prompt_name` filter can customize name
- [ ] MCP Inspector smoke test: `npx @modelcontextprotocol/inspector --cli --config .mcp.json --server mcp-adapter-default-npx --method tools/list`

Ref #130