### PR TITLE
Security hardening: input validation and fail-closed permissions

### DIFF
--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -114,6 +114,10 @@ class PromptsHandler {
 		$prompt_name = (string) $request_params['name'];
 		$prompt_name = trim( $prompt_name );
 
+		if ( isset( $request_params['arguments'] ) && ! is_array( $request_params['arguments'] ) ) {
+			return McpErrorFactory::invalid_params( $request_id, 'arguments must be an object' );
+		}
+
 		$mcp_prompt = $this->mcp->get_mcp_prompt( $prompt_name );
 
 		if ( ! $mcp_prompt ) {
@@ -154,7 +158,7 @@ class PromptsHandler {
 
 			// Allow pre-filter to short-circuit execution by returning WP_Error.
 			if ( is_wp_error( $arguments ) ) {
-				return McpErrorFactory::permission_denied( $request_id, $arguments->get_error_message() );
+				return McpErrorFactory::internal_error( $request_id, $arguments->get_error_message() );
 			}
 
 			$result = $mcp_prompt->execute( $arguments );

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -124,6 +124,10 @@ class ToolsHandler {
 			return McpErrorFactory::missing_parameter( $request_id, 'tool name' );
 		}
 
+		if ( isset( $request_params['arguments'] ) && ! is_array( $request_params['arguments'] ) ) {
+			return McpErrorFactory::invalid_params( $request_id, 'arguments must be an object' );
+		}
+
 		try {
 			$tool_name = trim( (string) $request_params['name'] );
 			$args      = $request_params['arguments'] ?? array();

--- a/includes/Transport/HttpTransport.php
+++ b/includes/Transport/HttpTransport.php
@@ -90,15 +90,18 @@ class HttpTransport implements McpRestTransportInterface {
 					return $result;
 				}
 
-				// Log the error and fall back to default permission
+				// Log the error and deny access (fail-closed)
 				$this->request_handler->transport_context->error_handler->log(
 					'Permission callback returned WP_Error: ' . $result->get_error_message(),
 					array( 'HttpTransport::check_permission' )
 				);
-				// Fall through to default permission check
+
+				return false;
 			} catch ( \Throwable $e ) {
-				// Log the error using the error handler, and fall back to default permission
+				// Log the error and deny access (fail-closed)
 				$this->request_handler->transport_context->error_handler->log( 'Error in transport permission callback: ' . $e->getMessage(), array( 'HttpTransport::check_permission' ) );
+
+				return false;
 			}
 		}
 
@@ -106,8 +109,7 @@ class HttpTransport implements McpRestTransportInterface {
 		 * Filters the default user capability required for MCP transport access.
 		 *
 		 * This filter is only applied when no custom transport permission callback
-		 * is provided or when the custom callback fails. The capability is checked
-		 * using current_user_can().
+		 * is provided. The capability is checked using current_user_can().
 		 *
 		 * @since 0.3.0
 		 *

--- a/includes/Transport/HttpTransport.php
+++ b/includes/Transport/HttpTransport.php
@@ -86,8 +86,8 @@ class HttpTransport implements McpRestTransportInterface {
 
 				// Handle WP_Error returns
 				if ( ! is_wp_error( $result ) ) {
-					// Return boolean result directly
-					return $result;
+					// Cast to bool to match return type while preserving truthy/falsy semantics.
+					return (bool) $result;
 				}
 
 				// Log the error and deny access (fail-closed)

--- a/tests/Integration/HttpTransportTest.php
+++ b/tests/Integration/HttpTransportTest.php
@@ -594,6 +594,18 @@ final class HttpTransportTest extends TestCase {
 	}
 
 	public function test_permission_callback_returning_wp_error(): void {
+		// Create a mock error handler that captures log messages
+		$mock_error_handler = $this->getMockBuilder( DummyErrorHandler::class )
+			->onlyMethods( array( 'log' ) )
+			->getMock();
+
+		$mock_error_handler->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->stringContains( 'Permission callback returned WP_Error: Custom permission error' ),
+				$this->equalTo( array( 'HttpTransport::check_permission' ) )
+			);
+
 		// Test with custom permission callback that returns WP_Error
 		$context_with_permission = new McpTransportContext(
 			array(
@@ -605,7 +617,7 @@ final class HttpTransportTest extends TestCase {
 				'system_handler'                => $this->context->system_handler,
 				'observability_handler'         => $this->context->observability_handler,
 				'request_router'                => $this->context->request_router,
-				'error_handler'                 => new DummyErrorHandler(), // Add error_handler
+				'error_handler'                 => $mock_error_handler,
 				'transport_permission_callback' => static function () {
 					return new WP_Error( 'permission_denied', 'Custom permission error' );
 				},
@@ -623,11 +635,10 @@ final class HttpTransportTest extends TestCase {
 			)
 		);
 
-		// Should fall back to default permission check when WP_Error is returned
+		// Should deny access (fail-closed) when WP_Error is returned
+		wp_set_current_user( 1 );
 		$permission_result = $transport_with_permission->check_permission( $request );
-
-		// Since we're user ID 1 (admin), default permission check should pass
-		$this->assertTrue( $permission_result );
+		$this->assertFalse( $permission_result, 'Should deny access when callback returns WP_Error' );
 	}
 
 	public function test_permission_with_different_user_capabilities(): void {
@@ -796,10 +807,10 @@ final class HttpTransportTest extends TestCase {
 			)
 		);
 
-		// Should fall back to default permission check when exception is thrown
+		// Should deny access (fail-closed) when exception is thrown
 		wp_set_current_user( 1 );
 		$permission_result = $transport_with_permission->check_permission( $request );
-		$this->assertTrue( $permission_result, 'Should fall back to default permission check' );
+		$this->assertFalse( $permission_result, 'Should deny access when callback throws exception' );
 	}
 
 	public function test_permission_denied_logging(): void {

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -950,6 +950,7 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
 		$error = $result->getError();
 		$this->assertNotNull( $error );
+		$this->assertSame( -32602, $error->getCode() );
 		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
 	}
 
@@ -969,6 +970,7 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
 		$error = $result->getError();
 		$this->assertNotNull( $error );
+		$this->assertSame( -32602, $error->getCode() );
 		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
 	}
 

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -934,7 +934,7 @@ final class PromptsHandlerTest extends TestCase {
 		wp_unregister_ability( 'test/invalid-content-prompt' );
 	}
 
-	public function test_get_prompt_withStringArguments_returnsInvalidParamsError(): void {
+	public function test_get_prompt_with_string_arguments_returns_invalid_params_error(): void {
 		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
 		$handler = new PromptsHandler( $server );
 		$result  = $handler->get_prompt(
@@ -953,7 +953,7 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
 	}
 
-	public function test_get_prompt_withIntegerArguments_returnsInvalidParamsError(): void {
+	public function test_get_prompt_with_integer_arguments_returns_invalid_params_error(): void {
 		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
 		$handler = new PromptsHandler( $server );
 		$result  = $handler->get_prompt(
@@ -972,7 +972,7 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
 	}
 
-	public function test_get_prompt_withNullArguments_succeeds(): void {
+	public function test_get_prompt_with_null_arguments_succeeds(): void {
 		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
 		$handler = new PromptsHandler( $server );
 		$result  = $handler->get_prompt(
@@ -988,7 +988,7 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertInstanceOf( GetPromptResult::class, $result );
 	}
 
-	public function test_get_prompt_withMissingArguments_succeeds(): void {
+	public function test_get_prompt_with_missing_arguments_succeeds(): void {
 		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
 		$handler = new PromptsHandler( $server );
 		$result  = $handler->get_prompt(
@@ -1003,7 +1003,7 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertInstanceOf( GetPromptResult::class, $result );
 	}
 
-	public function test_list_prompts_withFilterReturningNonArray_fallsBackToOriginal(): void {
+	public function test_list_prompts_with_filter_returning_non_array_falls_back_to_original(): void {
 		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
 		$handler = new PromptsHandler( $server );
 

--- a/tests/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/Unit/Handlers/PromptsHandlerTest.php
@@ -290,10 +290,11 @@ final class PromptsHandlerTest extends TestCase {
 			)
 		);
 
-		// Short-circuit returns JSONRPCErrorResponse.
+		// Short-circuit returns JSONRPCErrorResponse with internal_error code.
 		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
 		$error = $result->getError();
 		$this->assertNotNull( $error );
+		$this->assertSame( -32603, $error->getCode() );
 		$this->assertStringContainsString( 'Prompt access blocked', $error->getMessage() );
 
 		remove_filter( 'mcp_adapter_pre_prompt_get', $filter );
@@ -931,6 +932,75 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertEquals( 'some value', $decoded['value'] );
 
 		wp_unregister_ability( 'test/invalid-content-prompt' );
+	}
+
+	public function test_get_prompt_withStringArguments_returnsInvalidParamsError(): void {
+		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
+		$handler = new PromptsHandler( $server );
+		$result  = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => 'invalid',
+				),
+			),
+			1
+		);
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$error = $result->getError();
+		$this->assertNotNull( $error );
+		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
+	}
+
+	public function test_get_prompt_withIntegerArguments_returnsInvalidParamsError(): void {
+		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
+		$handler = new PromptsHandler( $server );
+		$result  = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => 42,
+				),
+			),
+			1
+		);
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$error = $result->getError();
+		$this->assertNotNull( $error );
+		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
+	}
+
+	public function test_get_prompt_withNullArguments_succeeds(): void {
+		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
+		$handler = new PromptsHandler( $server );
+		$result  = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => null,
+				),
+			)
+		);
+
+		// null arguments should default to empty array and succeed.
+		$this->assertInstanceOf( GetPromptResult::class, $result );
+	}
+
+	public function test_get_prompt_withMissingArguments_succeeds(): void {
+		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
+		$handler = new PromptsHandler( $server );
+		$result  = $handler->get_prompt(
+			array(
+				'params' => array(
+					'name' => 'test-always-allowed',
+				),
+			)
+		);
+
+		// Missing arguments should default to empty array and succeed.
+		$this->assertInstanceOf( GetPromptResult::class, $result );
 	}
 
 	public function test_list_prompts_withFilterReturningNonArray_fallsBackToOriginal(): void {

--- a/tests/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerCallTest.php
@@ -310,6 +310,7 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
 		$error = $result->getError();
 		$this->assertNotNull( $error );
+		$this->assertSame( -32602, $error->getCode() );
 		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
 	}
 
@@ -329,6 +330,7 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
 		$error = $result->getError();
 		$this->assertNotNull( $error );
+		$this->assertSame( -32602, $error->getCode() );
 		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
 	}
 

--- a/tests/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerCallTest.php
@@ -294,7 +294,7 @@ final class ToolsHandlerCallTest extends TestCase {
 			$this->assertArrayHasKey( 'mcp_adapter', $structured['nested']['_meta'] );
 		}
 
-	public function test_call_tool_withStringArguments_returnsInvalidParamsError(): void {
+	public function test_call_tool_with_string_arguments_returns_invalid_params_error(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->call_tool(
@@ -313,7 +313,7 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
 	}
 
-	public function test_call_tool_withIntegerArguments_returnsInvalidParamsError(): void {
+	public function test_call_tool_with_integer_arguments_returns_invalid_params_error(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->call_tool(
@@ -332,7 +332,7 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
 	}
 
-	public function test_call_tool_withNullArguments_succeeds(): void {
+	public function test_call_tool_with_null_arguments_succeeds(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->call_tool(
@@ -350,7 +350,7 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertFalse( (bool) $result->getIsError() );
 	}
 
-	public function test_call_tool_withMissingArguments_succeeds(): void {
+	public function test_call_tool_with_missing_arguments_succeeds(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->call_tool(

--- a/tests/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/Unit/Handlers/ToolsHandlerCallTest.php
@@ -293,4 +293,77 @@ final class ToolsHandlerCallTest extends TestCase {
 			$this->assertArrayHasKey( 'mcp_adapter', $structured['_meta'] );
 			$this->assertArrayHasKey( 'mcp_adapter', $structured['nested']['_meta'] );
 		}
+
+	public function test_call_tool_withStringArguments_returnsInvalidParamsError(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+		$result  = $handler->call_tool(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => 'invalid',
+				),
+			),
+			1
+		);
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$error = $result->getError();
+		$this->assertNotNull( $error );
+		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
+	}
+
+	public function test_call_tool_withIntegerArguments_returnsInvalidParamsError(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+		$result  = $handler->call_tool(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => 42,
+				),
+			),
+			1
+		);
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$error = $result->getError();
+		$this->assertNotNull( $error );
+		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
+	}
+
+	public function test_call_tool_withNullArguments_succeeds(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+		$result  = $handler->call_tool(
+			array(
+				'params' => array(
+					'name'      => 'test-always-allowed',
+					'arguments' => null,
+				),
+			),
+			1
+		);
+
+		// null arguments should default to empty array and succeed.
+		$this->assertInstanceOf( CallToolResult::class, $result );
+		$this->assertFalse( (bool) $result->getIsError() );
+	}
+
+	public function test_call_tool_withMissingArguments_succeeds(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+		$result  = $handler->call_tool(
+			array(
+				'params' => array(
+					'name' => 'test-always-allowed',
+				),
+			),
+			1
+		);
+
+		// Missing arguments should default to empty array and succeed.
+		$this->assertInstanceOf( CallToolResult::class, $result );
+		$this->assertFalse( (bool) $result->getIsError() );
+	}
 }


### PR DESCRIPTION
## Why

Three gaps flagged during the v0.5.0 code review and PR #151 review:

1. **`arguments` parameter not type-checked.** `tools/call` and `prompts/get` accept whatever the client sends as `arguments` — a string, integer, or boolean passes silently into the execution layer. The MCP spec requires `arguments` to be an object (associative array in PHP).

2. **Permission callback failures fail open.** When a custom `transport_permission_callback` returns `WP_Error` or throws an exception, `HttpTransport::check_permission()` falls through to the weaker default capability check instead of denying access. A broken permission callback should not silently degrade security.

3. **Inconsistent pre-filter error types.** The `mcp_adapter_pre_prompt_get` filter returns `permission_denied` (-32008) on `WP_Error` short-circuit, while `mcp_adapter_pre_resource_read` returns `internal_error` (-32603). Pre-filter short-circuits represent generic blocks (rate limiting, maintenance mode, content policy), not permission failures. Fixes #152.

## What

**Input validation** (`ToolsHandler`, `PromptsHandler`):
- Added `is_array()` check on `arguments` before use in both `call_tool()` and `get_prompt()`
- Non-array arguments return `invalid_params` (-32602) with message `"arguments must be an object"`
- Null and missing arguments continue to default to `[]` — no behavior change on the happy path

**Fail-closed permissions** (`HttpTransport`):
- `check_permission()` now returns `false` when the custom callback returns `WP_Error` or throws
- Errors are still logged via the error handler
- Updated filter PHPDoc to remove the "or when the custom callback fails" clause since it no longer falls through

**Pre-filter error normalization** (`PromptsHandler`):
- Changed `mcp_adapter_pre_prompt_get` WP_Error handling from `permission_denied()` to `internal_error()`
- Now consistent with `mcp_adapter_pre_resource_read`

## Test plan

- [ ] 8 new unit tests covering string/integer arguments and null/missing arguments for both handlers
- [ ] Updated integration tests for `WP_Error` and exception permission callback scenarios
- [ ] Updated prompt handler test to verify `-32603` error code on pre-filter short-circuit
- [ ] Full suite: 983 tests, 3792 assertions, 0 failures
- [ ] PHPStan Level 8: 0 errors
- [ ] PHPCS: 0 violations