### PR TITLE
Encapsulation and type safety improvements

### DIFF
--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -29,14 +29,14 @@ class McpServer {
 	 *
 	 * @var \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface
 	 */
-	public McpErrorHandlerInterface $error_handler;
+	private McpErrorHandlerInterface $error_handler;
 
 	/**
 	 * Observability handler instance.
 	 *
 	 * @var \WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface
 	 */
-	public McpObservabilityHandlerInterface $observability_handler;
+	private McpObservabilityHandlerInterface $observability_handler;
 
 	/**
 	 * Server ID.

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -6,6 +6,8 @@
  * @package McpAdapter
  */
 
+declare( strict_types=1 );
+
 namespace WP\MCP\Domain\Prompts;
 
 use WP\MCP\Domain\Utils\McpNameSanitizer;

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -30,21 +30,21 @@ class PromptsHandler {
 	 *
 	 * @var list<string>
 	 */
-	private static $valid_content_types = array( 'text', 'image', 'audio', 'resource_link', 'resource' );
+	private static array $valid_content_types = array( 'text', 'image', 'audio', 'resource_link', 'resource' );
 
 	/**
 	 * Valid role values for PromptMessage.
 	 *
 	 * @var list<string>
 	 */
-	private static $valid_roles = array( 'user', 'assistant' );
+	private static array $valid_roles = array( 'user', 'assistant' );
 
 	/**
 	 * Default role for messages when not specified.
 	 *
 	 * @var string
 	 */
-	private static $default_role = 'user';
+	private static string $default_role = 'user';
 
 	/**
 	 * The WordPress MCP instance.
@@ -85,7 +85,7 @@ class PromptsHandler {
 			apply_filters( 'mcp_adapter_prompts_list', $prompts, $this->mcp ),
 			$prompts,
 			'mcp_adapter_prompts_list',
-			$this->mcp->error_handler
+			$this->mcp->get_error_handler()
 		);
 
 		return ListPromptsResult::fromArray(
@@ -180,7 +180,7 @@ class PromptsHandler {
 			$result = apply_filters( 'mcp_adapter_prompt_get_result', $result, $arguments, $prompt_name, $mcp_prompt, $this->mcp );
 
 			if ( is_wp_error( $result ) ) {
-				$this->mcp->error_handler->log(
+				$this->mcp->get_error_handler()->log(
 					'Prompt execution returned WP_Error',
 					array(
 						'prompt_name'   => $prompt_name,
@@ -194,7 +194,7 @@ class PromptsHandler {
 
 			return $this->normalize_result_to_dto( $result, $prompt, $prompt_name );
 		} catch ( \Throwable $e ) {
-			$this->mcp->error_handler->log(
+			$this->mcp->get_error_handler()->log(
 				'Prompt execution failed',
 				array(
 					'prompt_name' => $prompt_name,
@@ -278,7 +278,7 @@ class PromptsHandler {
 
 		foreach ( $result['messages'] as $index => $message ) {
 			if ( ! is_array( $message ) ) {
-				$this->mcp->error_handler->log(
+				$this->mcp->get_error_handler()->log(
 					'Invalid message structure in prompt result, skipping',
 					array(
 						'prompt_name'   => $prompt_name,
@@ -450,7 +450,7 @@ class PromptsHandler {
 		string $prompt_name
 	): GetPromptResult {
 		// Log observability event for fallback normalization.
-		$this->mcp->observability_handler->record_event(
+		$this->mcp->get_observability_handler()->record_event(
 			'prompt_result_fallback_normalization',
 			array(
 				'prompt_name' => $prompt_name,
@@ -536,7 +536,7 @@ class PromptsHandler {
 
 		// Check if type is missing.
 		if ( null === $type || '' === $type ) {
-			$this->mcp->error_handler->log(
+			$this->mcp->get_error_handler()->log(
 				'Missing content type in prompt result, defaulting to text',
 				array(
 					'prompt_name' => $prompt_name,
@@ -554,7 +554,7 @@ class PromptsHandler {
 
 		// Check if type is valid.
 		if ( ! in_array( $type, self::$valid_content_types, true ) ) {
-			$this->mcp->error_handler->log(
+			$this->mcp->get_error_handler()->log(
 				'Invalid content type in prompt result, converting to text',
 				array(
 					'prompt_name'  => $prompt_name,
@@ -596,7 +596,7 @@ class PromptsHandler {
 		}
 
 		if ( '' !== $prompt_name ) {
-			$this->mcp->error_handler->log(
+			$this->mcp->get_error_handler()->log(
 				'Invalid role in prompt message, defaulting to user',
 				array(
 					'prompt_name'  => $prompt_name,

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -66,7 +66,7 @@ class ResourcesHandler {
 			apply_filters( 'mcp_adapter_resources_list', $resources, $this->mcp ),
 			$resources,
 			'mcp_adapter_resources_list',
-			$this->mcp->error_handler
+			$this->mcp->get_error_handler()
 		);
 
 		return ListResourcesResult::fromArray(
@@ -162,7 +162,7 @@ class ResourcesHandler {
 
 			// Handle WP_Error objects returned by McpResource execution.
 			if ( is_wp_error( $contents ) ) {
-				$this->mcp->error_handler->log(
+				$this->mcp->get_error_handler()->log(
 					'Resource execution returned WP_Error object',
 					array(
 						'uri'           => $uri,
@@ -186,7 +186,7 @@ class ResourcesHandler {
 				)
 			);
 		} catch ( \Throwable $exception ) {
-			$this->mcp->error_handler->log(
+			$this->mcp->get_error_handler()->log(
 				'Error reading resource',
 				array(
 					'uri'       => $uri,

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -88,7 +88,7 @@ class ToolsHandler {
 			apply_filters( 'mcp_adapter_tools_list', $tools, $this->mcp ),
 			$tools,
 			'mcp_adapter_tools_list',
-			$this->mcp->error_handler
+			$this->mcp->get_error_handler()
 		);
 
 		return ListToolsResult::fromArray(
@@ -134,7 +134,7 @@ class ToolsHandler {
 
 			$mcp_tool = $this->mcp->get_mcp_tool( $tool_name );
 			if ( ! $mcp_tool ) {
-				$this->mcp->error_handler->log(
+				$this->mcp->get_error_handler()->log(
 					'Tool not found',
 					array(
 						'tool_name' => $tool_name,
@@ -151,7 +151,7 @@ class ToolsHandler {
 				if ( is_wp_error( $permission ) ) {
 					$error_message = $permission->get_error_message();
 
-					$this->mcp->error_handler->log(
+					$this->mcp->get_error_handler()->log(
 						'Tool permission check failed',
 						array(
 							'tool_name'      => $tool_name,
@@ -205,7 +205,7 @@ class ToolsHandler {
 			$result = apply_filters( 'mcp_adapter_tool_call_result', $result, $args, $tool_name, $mcp_tool, $this->mcp );
 
 			if ( is_wp_error( $result ) ) {
-				$this->mcp->error_handler->log(
+				$this->mcp->get_error_handler()->log(
 					'Tool execution returned WP_Error',
 					array(
 						'tool_name'     => $tool_name,
@@ -309,7 +309,7 @@ class ToolsHandler {
 				)
 			);
 		} catch ( \Throwable $exception ) {
-			$this->mcp->error_handler->log(
+			$this->mcp->get_error_handler()->log(
 				'Error calling tool',
 				array(
 					'tool'      => $request_params['name'],

--- a/includes/Transport/HttpTransport.php
+++ b/includes/Transport/HttpTransport.php
@@ -52,7 +52,7 @@ class HttpTransport implements McpRestTransportInterface {
 	 */
 	public function register_routes(): void {
 		// Get server info from request handler's transport context
-		$server = $this->request_handler->transport_context->mcp_server;
+		$server = $this->request_handler->get_transport_context()->mcp_server;
 
 		// Single endpoint for MCP communication (POST, GET reserved for SSE, DELETE for session termination).
 		// Do not remove GET: it is part of the MCP HTTP transport shape and will be implemented (SSE) in a future iteration.
@@ -78,7 +78,7 @@ class HttpTransport implements McpRestTransportInterface {
 		$context = new HttpRequestContext( $request );
 
 		// Check permission using callback or default
-		$transport_context = $this->request_handler->transport_context;
+		$transport_context = $this->request_handler->get_transport_context();
 
 		if ( null !== $transport_context->transport_permission_callback ) {
 			try {
@@ -91,7 +91,7 @@ class HttpTransport implements McpRestTransportInterface {
 				}
 
 				// Log the error and deny access (fail-closed)
-				$this->request_handler->transport_context->error_handler->log(
+				$this->request_handler->get_transport_context()->error_handler->log(
 					'Permission callback returned WP_Error: ' . $result->get_error_message(),
 					array( 'HttpTransport::check_permission' )
 				);
@@ -99,7 +99,7 @@ class HttpTransport implements McpRestTransportInterface {
 				return false;
 			} catch ( \Throwable $e ) {
 				// Log the error and deny access (fail-closed)
-				$this->request_handler->transport_context->error_handler->log( 'Error in transport permission callback: ' . $e->getMessage(), array( 'HttpTransport::check_permission' ) );
+				$this->request_handler->get_transport_context()->error_handler->log( 'Error in transport permission callback: ' . $e->getMessage(), array( 'HttpTransport::check_permission' ) );
 
 				return false;
 			}
@@ -127,7 +127,7 @@ class HttpTransport implements McpRestTransportInterface {
 
 		if ( ! $user_has_capability ) {
 			$user_id = get_current_user_id();
-			$this->request_handler->transport_context->error_handler->log(
+			$this->request_handler->get_transport_context()->error_handler->log(
 				sprintf( 'Permission denied for MCP API access. User ID %d does not have capability "%s"', $user_id, $user_capability ),
 				array( 'HttpTransport::check_permission' )
 			);

--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -27,7 +27,7 @@ class HttpRequestHandler {
 	 *
 	 * @var \WP\MCP\Transport\Infrastructure\McpTransportContext
 	 */
-	public McpTransportContext $transport_context;
+	private McpTransportContext $transport_context;
 
 	/**
 	 * Constructor.
@@ -36,6 +36,17 @@ class HttpRequestHandler {
 	 */
 	public function __construct( McpTransportContext $transport_context ) {
 		$this->transport_context = $transport_context;
+	}
+
+	/**
+	 * Get the transport context.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return \WP\MCP\Transport\Infrastructure\McpTransportContext
+	 */
+	public function get_transport_context(): McpTransportContext {
+		return $this->transport_context;
 	}
 
 	/**
@@ -88,7 +99,7 @@ class HttpRequestHandler {
 
 			return $this->process_mcp_messages( $context );
 		} catch ( \Throwable $exception ) {
-			$this->transport_context->mcp_server->error_handler->log(
+			$this->transport_context->mcp_server->get_error_handler()->log(
 				'Unexpected error in handle_mcp_request',
 				array(
 					'transport' => static::class,

--- a/includes/Transport/Infrastructure/McpTransportContext.php
+++ b/includes/Transport/Infrastructure/McpTransportContext.php
@@ -159,10 +159,8 @@ class McpTransportContext {
 		$this->system_handler        = $properties['system_handler'];
 		$this->observability_handler = $properties['observability_handler'];
 
-		// Assign optional properties.
-		if ( isset( $properties['error_handler'] ) ) {
-			$this->error_handler = $properties['error_handler'];
-		}
+		// Assign optional properties (error_handler defaults to the server's handler).
+		$this->error_handler = $properties['error_handler'] ?? $properties['mcp_server']->get_error_handler();
 
 		$this->transport_permission_callback = $properties['transport_permission_callback'] ?? null;
 
@@ -188,7 +186,6 @@ class McpTransportContext {
 		if ( ! empty( $unknown_keys ) ) {
 			throw new \InvalidArgumentException(
 				sprintf(
-					/* translators: 1: comma-separated list of unknown property names, 2: comma-separated list of allowed property names */
 					'Unknown properties provided to McpTransportContext: %1$s. Allowed properties: %2$s.',
 					esc_html( implode( ', ', $unknown_keys ) ),
 					esc_html( implode( ', ', $allowed_keys ) )
@@ -201,7 +198,6 @@ class McpTransportContext {
 		if ( ! empty( $missing_keys ) ) {
 			throw new \InvalidArgumentException(
 				sprintf(
-					/* translators: %s: comma-separated list of missing required property names */
 					'Missing required properties for McpTransportContext: %s.',
 					esc_html( implode( ', ', $missing_keys ) )
 				)

--- a/includes/Transport/Infrastructure/McpTransportContext.php
+++ b/includes/Transport/Infrastructure/McpTransportContext.php
@@ -31,18 +31,32 @@ use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterfa
 class McpTransportContext {
 
 	/**
-	 * Initialize the transport context.
+	 * Required property keys for the constructor array.
 	 *
-	 * @param \WP\MCP\Core\McpServer $mcp_server The MCP server instance.
-	 * @param \WP\MCP\Handlers\Initialize\InitializeHandler $initialize_handler The initialize handler.
-	 * @param \WP\MCP\Handlers\Tools\ToolsHandler $tools_handler The tools handler.
-	 * @param \WP\MCP\Handlers\Resources\ResourcesHandler $resources_handler The resources handler.
-	 * @param \WP\MCP\Handlers\Prompts\PromptsHandler $prompts_handler The prompts handler.
-	 * @param \WP\MCP\Handlers\System\SystemHandler $system_handler The system handler.
-	 * @param string $observability_handler The observability handler class name.
-	 * @param \WP\MCP\Transport\Infrastructure\RequestRouter|null $request_router The request router service.
-	 * @param callable|null $transport_permission_callback Optional custom permission callback for transport-level authentication.
+	 * @var list<string>
 	 */
+	// phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- False positive: sniff mistakes array() commas for multi-const commas (only handles short syntax).
+	private const REQUIRED_KEYS = array(
+		'mcp_server',
+		'initialize_handler',
+		'tools_handler',
+		'resources_handler',
+		'prompts_handler',
+		'system_handler',
+		'observability_handler',
+	);
+
+	/**
+	 * Optional property keys for the constructor array.
+	 *
+	 * @var list<string>
+	 */
+	// phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- False positive: sniff mistakes array() commas for multi-const commas (only handles short syntax).
+	private const OPTIONAL_KEYS = array(
+		'request_router',
+		'transport_permission_callback',
+		'error_handler',
+	);
 
 	/**
 	 * The MCP server instance.
@@ -128,18 +142,70 @@ class McpTransportContext {
 	 *   error_handler?: \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface
 	 * } $properties Properties to set on the context.
 	 * Note: request_router is optional and will be auto-created if not provided.
+	 *
+	 * @throws \InvalidArgumentException If required keys are missing or unknown keys are present.
+	 *
+	 * @since n.e.x.t
 	 */
 	public function __construct( array $properties ) {
-		foreach ( $properties as $name => $value ) {
-			$this->$name = $value;
+		$this->validate_properties( $properties );
+
+		// Assign required properties.
+		$this->mcp_server            = $properties['mcp_server'];
+		$this->initialize_handler    = $properties['initialize_handler'];
+		$this->tools_handler         = $properties['tools_handler'];
+		$this->resources_handler     = $properties['resources_handler'];
+		$this->prompts_handler       = $properties['prompts_handler'];
+		$this->system_handler        = $properties['system_handler'];
+		$this->observability_handler = $properties['observability_handler'];
+
+		// Assign optional properties.
+		if ( isset( $properties['error_handler'] ) ) {
+			$this->error_handler = $properties['error_handler'];
 		}
 
-		// If request_router is provided, we're done
-		if ( isset( $properties['request_router'] ) ) {
-			return;
+		$this->transport_permission_callback = $properties['transport_permission_callback'] ?? null;
+
+		// Create request_router if not provided.
+		$this->request_router = $properties['request_router'] ?? new RequestRouter( $this );
+	}
+
+	/**
+	 * Validate that the properties array contains all required keys and no unknown keys.
+	 *
+	 * @param array<string, mixed> $properties Properties to validate.
+	 *
+	 * @throws \InvalidArgumentException If required keys are missing or unknown keys are present.
+	 *
+	 * @since n.e.x.t
+	 */
+	private function validate_properties( array $properties ): void {
+		$provided_keys = array_keys( $properties );
+		$allowed_keys  = array_merge( self::REQUIRED_KEYS, self::OPTIONAL_KEYS );
+
+		// Check for unknown keys.
+		$unknown_keys = array_diff( $provided_keys, $allowed_keys );
+		if ( ! empty( $unknown_keys ) ) {
+			throw new \InvalidArgumentException(
+				sprintf(
+					/* translators: 1: comma-separated list of unknown property names, 2: comma-separated list of allowed property names */
+					'Unknown properties provided to McpTransportContext: %1$s. Allowed properties: %2$s.',
+					esc_html( implode( ', ', $unknown_keys ) ),
+					esc_html( implode( ', ', $allowed_keys ) )
+				)
+			);
 		}
 
-		// Create request_router if not provided
-		$this->request_router = new RequestRouter( $this );
+		// Check for missing required keys.
+		$missing_keys = array_diff( self::REQUIRED_KEYS, $provided_keys );
+		if ( ! empty( $missing_keys ) ) {
+			throw new \InvalidArgumentException(
+				sprintf(
+					/* translators: %s: comma-separated list of missing required property names */
+					'Missing required properties for McpTransportContext: %s.',
+					esc_html( implode( ', ', $missing_keys ) )
+				)
+			);
+		}
 	}
 }

--- a/tests/Integration/ErrorHandlingIntegrationTest.php
+++ b/tests/Integration/ErrorHandlingIntegrationTest.php
@@ -80,8 +80,8 @@ final class ErrorHandlingIntegrationTest extends TestCase {
 			DummyObservabilityHandler::class,
 		);
 
-		$this->assertInstanceOf( McpErrorHandlerInterface::class, $server->error_handler );
-		$this->assertInstanceOf( DummyErrorHandler::class, $server->error_handler );
+		$this->assertInstanceOf( McpErrorHandlerInterface::class, $server->get_error_handler() );
+		$this->assertInstanceOf( DummyErrorHandler::class, $server->get_error_handler() );
 	}
 
 	public function test_handlers_return_consistent_error_format(): void {

--- a/tests/Unit/Handlers/ResourcesHandlerReadTest.php
+++ b/tests/Unit/Handlers/ResourcesHandlerReadTest.php
@@ -277,4 +277,26 @@ final class ResourcesHandlerReadTest extends TestCase {
 		// Clean up.
 		wp_unregister_ability( 'test/resource-object-result' );
 	}
+
+	public function test_read_resource_with_throwing_result_filter_triggers_catch_block(): void {
+		wp_set_current_user( 1 );
+		$server  = $this->makeServer( array(), array( 'test/resource' ) );
+		$handler = new ResourcesHandler( $server );
+
+		$filter = static function () {
+			throw new \RuntimeException( 'Filter exploded' );
+		};
+		add_filter( 'mcp_adapter_resource_read_result', $filter );
+
+		$result = $handler->read_resource(
+			array(
+				'params' => array( 'uri' => 'WordPress://local/resource-1' ),
+			)
+		);
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$this->assertStringContainsString( 'Failed to read resource', $result->getError()->getMessage() );
+
+		remove_filter( 'mcp_adapter_resource_read_result', $filter );
+	}
 }

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -46,8 +46,8 @@ final class McpServerTest extends TestCase {
 			NullMcpObservabilityHandler::class,
 		);
 
-		$this->assertInstanceOf( \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface::class, $server->error_handler );
-		$this->assertInstanceOf( \WP\MCP\Tests\Fixtures\DummyErrorHandler::class, $server->error_handler );
+		$this->assertInstanceOf( \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface::class, $server->get_error_handler() );
+		$this->assertInstanceOf( \WP\MCP\Tests\Fixtures\DummyErrorHandler::class, $server->get_error_handler() );
 	}
 
 	public function test_constructor_falls_back_to_null_error_handler(): void {
@@ -63,7 +63,7 @@ final class McpServerTest extends TestCase {
 			NullMcpObservabilityHandler::class,
 		);
 
-		$this->assertInstanceOf( NullMcpErrorHandler::class, $server->error_handler );
+		$this->assertInstanceOf( NullMcpErrorHandler::class, $server->get_error_handler() );
 	}
 
 	public function test_constructor_without_tools_does_not_register_system_tools(): void {

--- a/tests/Unit/Servers/DefaultServerFactoryTest.php
+++ b/tests/Unit/Servers/DefaultServerFactoryTest.php
@@ -234,7 +234,7 @@ final class DefaultServerFactoryTest extends TestCase {
 
 		$server = $this->adapter->get_server( 'mcp-adapter-default-server' );
 		$this->assertNotNull( $server );
-		$this->assertInstanceOf( ErrorLogMcpErrorHandler::class, $server->error_handler );
+		$this->assertInstanceOf( ErrorLogMcpErrorHandler::class, $server->get_error_handler() );
 	}
 
 	public function test_create_uses_default_observability_handler(): void {
@@ -249,7 +249,7 @@ final class DefaultServerFactoryTest extends TestCase {
 
 		$server = $this->adapter->get_server( 'mcp-adapter-default-server' );
 		$this->assertNotNull( $server );
-		$this->assertInstanceOf( NullMcpObservabilityHandler::class, $server->observability_handler );
+		$this->assertInstanceOf( NullMcpObservabilityHandler::class, $server->get_observability_handler() );
 	}
 }
 

--- a/tests/Unit/Transport/Infrastructure/McpTransportContextTest.php
+++ b/tests/Unit/Transport/Infrastructure/McpTransportContextTest.php
@@ -49,7 +49,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that providing all required keys creates a valid context.
 	 */
-	public function test_construct_withAllRequiredKeys_createsContext(): void {
+	public function test_construct_with_all_required_keys_creates_context(): void {
 		$properties = $this->build_required_properties();
 
 		$context = new McpTransportContext( $properties );
@@ -67,7 +67,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that request_router is auto-created when not provided.
 	 */
-	public function test_construct_withoutRequestRouter_createsRouterAutomatically(): void {
+	public function test_construct_without_request_router_creates_router_automatically(): void {
 		$properties = $this->build_required_properties();
 
 		$context = new McpTransportContext( $properties );
@@ -78,7 +78,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that request_router is used when explicitly provided.
 	 */
-	public function test_construct_withRequestRouter_usesProvidedRouter(): void {
+	public function test_construct_with_request_router_uses_provided_router(): void {
 		$properties = $this->build_required_properties();
 		// Create a context first to get a RequestRouter instance.
 		$temp_context               = new McpTransportContext( $properties );
@@ -93,7 +93,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that transport_permission_callback defaults to null when not provided.
 	 */
-	public function test_construct_withoutPermissionCallback_defaultsToNull(): void {
+	public function test_construct_without_permission_callback_defaults_to_null(): void {
 		$properties = $this->build_required_properties();
 
 		$context = new McpTransportContext( $properties );
@@ -104,7 +104,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that transport_permission_callback is assigned when provided.
 	 */
-	public function test_construct_withPermissionCallback_assignsCallback(): void {
+	public function test_construct_with_permission_callback_assigns_callback(): void {
 		$properties = $this->build_required_properties();
 		$callback   = static function () {
 			return true;
@@ -119,7 +119,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that error_handler is assigned when provided.
 	 */
-	public function test_construct_withErrorHandler_assignsHandler(): void {
+	public function test_construct_with_error_handler_assigns_handler(): void {
 		$properties                   = $this->build_required_properties();
 		$error_handler                = new DummyErrorHandler();
 		$properties['error_handler']  = $error_handler;
@@ -132,7 +132,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that error_handler defaults to the server's error handler when omitted.
 	 */
-	public function test_construct_withoutErrorHandler_defaultsToServerErrorHandler(): void {
+	public function test_construct_without_error_handler_defaults_to_server_error_handler(): void {
 		$properties = $this->build_required_properties();
 
 		$context = new McpTransportContext( $properties );
@@ -143,7 +143,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that missing a single required key throws InvalidArgumentException.
 	 */
-	public function test_construct_withMissingRequiredKey_throwsException(): void {
+	public function test_construct_with_missing_required_key_throws_exception(): void {
 		$properties = $this->build_required_properties();
 		unset( $properties['tools_handler'] );
 
@@ -156,7 +156,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that missing multiple required keys lists all missing keys.
 	 */
-	public function test_construct_withMultipleMissingRequiredKeys_listsAllMissing(): void {
+	public function test_construct_with_multiple_missing_required_keys_lists_all_missing(): void {
 		$properties = $this->build_required_properties();
 		unset( $properties['mcp_server'], $properties['system_handler'] );
 
@@ -169,7 +169,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that providing an unknown key throws InvalidArgumentException.
 	 */
-	public function test_construct_withUnknownKey_throwsException(): void {
+	public function test_construct_with_unknown_key_throws_exception(): void {
 		$properties                = $this->build_required_properties();
 		$properties['typo_server'] = 'some_value';
 
@@ -182,7 +182,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that providing multiple unknown keys lists all unknown keys.
 	 */
-	public function test_construct_withMultipleUnknownKeys_listsAllUnknown(): void {
+	public function test_construct_with_multiple_unknown_keys_lists_all_unknown(): void {
 		$properties            = $this->build_required_properties();
 		$properties['foo']     = 'bar';
 		$properties['baz_qux'] = 'quux';
@@ -196,7 +196,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that an empty array throws InvalidArgumentException for missing required keys.
 	 */
-	public function test_construct_withEmptyArray_throwsException(): void {
+	public function test_construct_with_empty_array_throws_exception(): void {
 		$this->expectException( InvalidArgumentException::class );
 		$this->expectExceptionMessage( 'Missing required properties for McpTransportContext' );
 
@@ -206,7 +206,7 @@ final class McpTransportContextTest extends TestCase {
 	/**
 	 * Test that all optional keys can be provided alongside required keys.
 	 */
-	public function test_construct_withAllKeys_createsContext(): void {
+	public function test_construct_with_all_keys_creates_context(): void {
 		$properties                                  = $this->build_required_properties();
 		$properties['error_handler']                 = new DummyErrorHandler();
 		$properties['transport_permission_callback'] = static function () {

--- a/tests/Unit/Transport/Infrastructure/McpTransportContextTest.php
+++ b/tests/Unit/Transport/Infrastructure/McpTransportContextTest.php
@@ -130,14 +130,14 @@ final class McpTransportContextTest extends TestCase {
 	}
 
 	/**
-	 * Test that error_handler can be omitted without error.
+	 * Test that error_handler defaults to the server's error handler when omitted.
 	 */
-	public function test_construct_withoutErrorHandler_doesNotThrow(): void {
+	public function test_construct_withoutErrorHandler_defaultsToServerErrorHandler(): void {
 		$properties = $this->build_required_properties();
 
 		$context = new McpTransportContext( $properties );
 
-		$this->assertInstanceOf( McpTransportContext::class, $context );
+		$this->assertSame( $this->server->get_error_handler(), $context->error_handler );
 	}
 
 	/**

--- a/tests/Unit/Transport/Infrastructure/McpTransportContextTest.php
+++ b/tests/Unit/Transport/Infrastructure/McpTransportContextTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Tests for McpTransportContext constructor validation.
+ *
+ * @package WP\MCP\Tests\Unit\Transport\Infrastructure
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Transport\Infrastructure;
+
+use InvalidArgumentException;
+use WP\MCP\Core\McpServer;
+use WP\MCP\Handlers\Initialize\InitializeHandler;
+use WP\MCP\Handlers\Prompts\PromptsHandler;
+use WP\MCP\Handlers\Resources\ResourcesHandler;
+use WP\MCP\Handlers\System\SystemHandler;
+use WP\MCP\Handlers\Tools\ToolsHandler;
+use WP\MCP\Tests\Fixtures\DummyErrorHandler;
+use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
+use WP\MCP\Tests\TestCase;
+use WP\MCP\Transport\Infrastructure\McpTransportContext;
+use WP\MCP\Transport\Infrastructure\RequestRouter;
+
+/**
+ * Test McpTransportContext constructor validation.
+ *
+ * @since n.e.x.t
+ */
+final class McpTransportContextTest extends TestCase {
+
+	/**
+	 * The MCP server instance used across tests.
+	 *
+	 * @var \WP\MCP\Core\McpServer
+	 */
+	private McpServer $server;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->server = $this->makeServer(
+			array( 'test-dummy/echo-tool' ),
+		);
+	}
+
+	/**
+	 * Test that providing all required keys creates a valid context.
+	 */
+	public function test_construct_withAllRequiredKeys_createsContext(): void {
+		$properties = $this->build_required_properties();
+
+		$context = new McpTransportContext( $properties );
+
+		$this->assertInstanceOf( McpTransportContext::class, $context );
+		$this->assertSame( $properties['mcp_server'], $context->mcp_server );
+		$this->assertSame( $properties['initialize_handler'], $context->initialize_handler );
+		$this->assertSame( $properties['tools_handler'], $context->tools_handler );
+		$this->assertSame( $properties['resources_handler'], $context->resources_handler );
+		$this->assertSame( $properties['prompts_handler'], $context->prompts_handler );
+		$this->assertSame( $properties['system_handler'], $context->system_handler );
+		$this->assertSame( $properties['observability_handler'], $context->observability_handler );
+	}
+
+	/**
+	 * Test that request_router is auto-created when not provided.
+	 */
+	public function test_construct_withoutRequestRouter_createsRouterAutomatically(): void {
+		$properties = $this->build_required_properties();
+
+		$context = new McpTransportContext( $properties );
+
+		$this->assertInstanceOf( RequestRouter::class, $context->request_router );
+	}
+
+	/**
+	 * Test that request_router is used when explicitly provided.
+	 */
+	public function test_construct_withRequestRouter_usesProvidedRouter(): void {
+		$properties = $this->build_required_properties();
+		// Create a context first to get a RequestRouter instance.
+		$temp_context               = new McpTransportContext( $properties );
+		$router                     = $temp_context->request_router;
+		$properties['request_router'] = $router;
+
+		$context = new McpTransportContext( $properties );
+
+		$this->assertSame( $router, $context->request_router );
+	}
+
+	/**
+	 * Test that transport_permission_callback defaults to null when not provided.
+	 */
+	public function test_construct_withoutPermissionCallback_defaultsToNull(): void {
+		$properties = $this->build_required_properties();
+
+		$context = new McpTransportContext( $properties );
+
+		$this->assertNull( $context->transport_permission_callback );
+	}
+
+	/**
+	 * Test that transport_permission_callback is assigned when provided.
+	 */
+	public function test_construct_withPermissionCallback_assignsCallback(): void {
+		$properties = $this->build_required_properties();
+		$callback   = static function () {
+			return true;
+		};
+		$properties['transport_permission_callback'] = $callback;
+
+		$context = new McpTransportContext( $properties );
+
+		$this->assertSame( $callback, $context->transport_permission_callback );
+	}
+
+	/**
+	 * Test that error_handler is assigned when provided.
+	 */
+	public function test_construct_withErrorHandler_assignsHandler(): void {
+		$properties                   = $this->build_required_properties();
+		$error_handler                = new DummyErrorHandler();
+		$properties['error_handler']  = $error_handler;
+
+		$context = new McpTransportContext( $properties );
+
+		$this->assertSame( $error_handler, $context->error_handler );
+	}
+
+	/**
+	 * Test that error_handler can be omitted without error.
+	 */
+	public function test_construct_withoutErrorHandler_doesNotThrow(): void {
+		$properties = $this->build_required_properties();
+
+		$context = new McpTransportContext( $properties );
+
+		$this->assertInstanceOf( McpTransportContext::class, $context );
+	}
+
+	/**
+	 * Test that missing a single required key throws InvalidArgumentException.
+	 */
+	public function test_construct_withMissingRequiredKey_throwsException(): void {
+		$properties = $this->build_required_properties();
+		unset( $properties['tools_handler'] );
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Missing required properties for McpTransportContext: tools_handler' );
+
+		new McpTransportContext( $properties );
+	}
+
+	/**
+	 * Test that missing multiple required keys lists all missing keys.
+	 */
+	public function test_construct_withMultipleMissingRequiredKeys_listsAllMissing(): void {
+		$properties = $this->build_required_properties();
+		unset( $properties['mcp_server'], $properties['system_handler'] );
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Missing required properties for McpTransportContext: mcp_server, system_handler' );
+
+		new McpTransportContext( $properties );
+	}
+
+	/**
+	 * Test that providing an unknown key throws InvalidArgumentException.
+	 */
+	public function test_construct_withUnknownKey_throwsException(): void {
+		$properties                = $this->build_required_properties();
+		$properties['typo_server'] = 'some_value';
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Unknown properties provided to McpTransportContext: typo_server' );
+
+		new McpTransportContext( $properties );
+	}
+
+	/**
+	 * Test that providing multiple unknown keys lists all unknown keys.
+	 */
+	public function test_construct_withMultipleUnknownKeys_listsAllUnknown(): void {
+		$properties            = $this->build_required_properties();
+		$properties['foo']     = 'bar';
+		$properties['baz_qux'] = 'quux';
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Unknown properties provided to McpTransportContext: foo, baz_qux' );
+
+		new McpTransportContext( $properties );
+	}
+
+	/**
+	 * Test that an empty array throws InvalidArgumentException for missing required keys.
+	 */
+	public function test_construct_withEmptyArray_throwsException(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Missing required properties for McpTransportContext' );
+
+		new McpTransportContext( array() );
+	}
+
+	/**
+	 * Test that all optional keys can be provided alongside required keys.
+	 */
+	public function test_construct_withAllKeys_createsContext(): void {
+		$properties                                  = $this->build_required_properties();
+		$properties['error_handler']                 = new DummyErrorHandler();
+		$properties['transport_permission_callback'] = static function () {
+			return true;
+		};
+
+		// Create context to get a router, then rebuild with it.
+		$temp_context                 = new McpTransportContext( $properties );
+		$properties['request_router'] = $temp_context->request_router;
+
+		$context = new McpTransportContext( $properties );
+
+		$this->assertInstanceOf( McpTransportContext::class, $context );
+		$this->assertSame( $properties['request_router'], $context->request_router );
+		$this->assertSame( $properties['error_handler'], $context->error_handler );
+		$this->assertSame( $properties['transport_permission_callback'], $context->transport_permission_callback );
+	}
+
+	/**
+	 * Build the minimal set of required properties for McpTransportContext.
+	 *
+	 * @return array<string, mixed> Properties array with all required keys.
+	 */
+	private function build_required_properties(): array {
+		return array(
+			'mcp_server'            => $this->server,
+			'initialize_handler'    => new InitializeHandler( $this->server ),
+			'tools_handler'         => new ToolsHandler( $this->server ),
+			'resources_handler'     => new ResourcesHandler( $this->server ),
+			'prompts_handler'       => new PromptsHandler( $this->server ),
+			'system_handler'        => new SystemHandler(),
+			'observability_handler' => new DummyObservabilityHandler(),
+		);
+	}
+}


### PR DESCRIPTION
## Why

The v0.5.0 code review identified five internal structure issues that weaken type safety and encapsulation without serving any API purpose:

1. **`RegisterAbilityAsMcpPrompt.php` is the only file missing `declare(strict_types=1)`**, allowing silent type coercion in a domain layer class.

2. **`McpTransportContext` uses dynamic property assignment** (`$this->$name = $value` in a foreach loop), which silently accepts typos, creates dynamic properties on PHP 8.2+, and bypasses the type system entirely.

3. **`McpServer::$error_handler` and `::$observability_handler` are public** despite having getter methods. The properties are not part of the frozen public API (the getters are), but ~15 internal call sites access them directly — inconsistent and mutable from outside.

4. **`HttpRequestHandler::$transport_context` is public** with no getter, forcing `HttpTransport` to reach into the handler's internals via `$this->request_handler->transport_context`.

5. **`PromptsHandler` static properties lack typed declarations**, relying on PHPDoc `@var` annotations instead of PHP's native type system.

None of these touch the frozen public API surface. All changes are internal to the plugin.

## What

**Type safety** (`RegisterAbilityAsMcpPrompt`, `PromptsHandler`):
- Added `declare(strict_types=1)` to the only file missing it
- Added explicit `array` and `string` type declarations to `PromptsHandler` static properties

**Encapsulation** (`McpServer`, `HttpRequestHandler`):
- Made `McpServer::$error_handler` and `::$observability_handler` private
- Updated ~15 internal call sites across handlers, transport, and tests to use `get_error_handler()` / `get_observability_handler()`
- Made `HttpRequestHandler::$transport_context` private and added `get_transport_context()` getter
- Updated 5 call sites in `HttpTransport`

**Constructor validation** (`McpTransportContext`):
- Replaced unsafe dynamic `foreach` assignment with explicit key validation
- Required keys (7) must be present — throws `InvalidArgumentException` listing missing keys
- Unknown keys are rejected — throws `InvalidArgumentException` listing offending keys
- 13 new tests covering valid construction, missing keys, unknown keys, and optional key handling

## Test plan

- [ ] 13 new unit tests for `McpTransportContext` key validation
- [ ] All existing tests updated to use getter methods instead of direct property access
- [ ] Full suite: 988 tests, 3800 assertions, 0 failures
- [ ] PHPStan Level 8: 0 errors
- [ ] PHPCS: 0 violations