### PR TITLE
Revert property visibility changes that broke backward compatibility

### DIFF
--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -29,14 +29,14 @@ class McpServer {
 	 *
 	 * @var \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface
 	 */
-	private McpErrorHandlerInterface $error_handler;
+	public McpErrorHandlerInterface $error_handler;
 
 	/**
 	 * Observability handler instance.
 	 *
 	 * @var \WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface
 	 */
-	private McpObservabilityHandlerInterface $observability_handler;
+	public McpObservabilityHandlerInterface $observability_handler;
 
 	/**
 	 * Server ID.

--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -27,7 +27,7 @@ class HttpRequestHandler {
 	 *
 	 * @var \WP\MCP\Transport\Infrastructure\McpTransportContext
 	 */
-	private McpTransportContext $transport_context;
+	public McpTransportContext $transport_context;
 
 	/**
 	 * Constructor.
@@ -64,7 +64,7 @@ class HttpRequestHandler {
 
 		// Handle GET requests (reserved for SSE streaming; currently not implemented).
 		if ( 'GET' === $context->method ) {
-			return $this->handle_sse_request( $context );
+			return $this->handle_sse_request();
 		}
 
 		// Handle DELETE requests (session termination)
@@ -307,11 +307,9 @@ class HttpRequestHandler {
 	/**
 	 * Handle GET requests (SSE streaming).
 	 *
-	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext $context The HTTP request context.
-	 *
 	 * @return \WP_REST_Response SSE response.
 	 */
-	private function handle_sse_request( HttpRequestContext $context ): \WP_REST_Response {
+	private function handle_sse_request(): \WP_REST_Response {
 		// SSE streaming not yet implemented - return HTTP 405 with no body
 		return new \WP_REST_Response( null, 405 );
 	}


### PR DESCRIPTION
## What

- Reverts `McpServer::$error_handler` and `$observability_handler` from `private` back to `public`
- Reverts `HttpRequestHandler::$transport_context` from `private` back to `protected`
- Removes unused `$context` parameter from `handle_sse_request()` (SSE is not implemented)

## Why

PR #154 changed property visibility as an encapsulation improvement, but this is a breaking change for downstream consumers. Specifically, `WpcomRestTransport` extends `HttpTransport` and accesses `$this->request_handler->transport_context->mcp_server` directly, and handlers access `$server->error_handler` and `$server->observability_handler` as public properties.

The getters added in #154 (`get_error_handler()`, `get_observability_handler()`, `get_transport_context()`) remain available as the preferred access pattern — this revert just restores BC so consumers can migrate at their own pace.