### PR TITLE
Fix observability gap: isError tool responses and protocol errors lack context

### DIFF
--- a/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/Transport/Infrastructure/RequestRouter.php
@@ -12,6 +12,7 @@ namespace WP\MCP\Transport\Infrastructure;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Infrastructure\Observability\McpObservabilityHelperTrait;
 use WP\McpSchema\Common\AbstractDataTransferObject;
+use WP\McpSchema\Common\Content\DTO\TextContent;
 use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
 use WP\McpSchema\Server\Tools\DTO\CallToolResult;
 
@@ -118,6 +119,13 @@ class RequestRouter {
 				$status = 'success';
 				if ( $handler_result instanceof CallToolResult && true === $handler_result->getIsError() ) {
 					$status = 'error';
+
+					if ( ! isset( $component_tags['failure_reason'] ) ) {
+						$content = $handler_result->getContent();
+						if ( isset( $content[0] ) && $content[0] instanceof TextContent ) {
+							$component_tags['failure_reason'] = $content[0]->getText();
+						}
+					}
 				}
 
 				$tags = array_merge( $common_tags, $component_tags, array( 'status' => $status ) );

--- a/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/Transport/Infrastructure/RequestRouter.php
@@ -95,9 +95,10 @@ class RequestRouter {
 			if ( $handler_result instanceof JSONRPCErrorResponse ) {
 				// Normalize to transport-level shape: only the JSON-RPC error object.
 				// The JSON-RPC envelope is created by the transport boundary.
-				$result             = array( 'error' => $handler_result->getError()->toArray() );
-				$tags               = array_merge( $common_tags, $component_tags, array( 'status' => 'error' ) );
-				$tags['error_code'] = $handler_result->getError()->getCode();
+				$result                 = array( 'error' => $handler_result->getError()->toArray() );
+				$tags                   = array_merge( $common_tags, $component_tags, array( 'status' => 'error' ) );
+				$tags['error_code']     = $handler_result->getError()->getCode();
+				$tags['failure_reason'] = $handler_result->getError()->getMessage();
 				$this->context->observability_handler->record_event( 'mcp.request', $tags, $duration );
 
 				return $result;

--- a/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/Transport/Infrastructure/RequestRouter.php
@@ -13,6 +13,7 @@ use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Infrastructure\Observability\McpObservabilityHelperTrait;
 use WP\McpSchema\Common\AbstractDataTransferObject;
 use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
+use WP\McpSchema\Server\Tools\DTO\CallToolResult;
 
 /**
  * Service for routing MCP requests to appropriate handlers.
@@ -114,7 +115,12 @@ class RequestRouter {
 					$result['_session_id']            = $new_session_id;
 				}
 
-				$tags = array_merge( $common_tags, $component_tags, array( 'status' => 'success' ) );
+				$status = 'success';
+				if ( $handler_result instanceof CallToolResult && true === $handler_result->getIsError() ) {
+					$status = 'error';
+				}
+
+				$tags = array_merge( $common_tags, $component_tags, array( 'status' => $status ) );
 				$this->context->observability_handler->record_event( 'mcp.request', $tags, $duration );
 
 				return $result;

--- a/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -207,6 +207,8 @@ final class RequestRouterTest extends TestCase {
 	}
 
 	public function test_route_request_unknown_method(): void {
+		DummyObservabilityHandler::reset();
+
 		$result = $this->router->route_request( 'unknown/method', array(), 1 );
 
 		$this->assertIsArray( $result );

--- a/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -228,6 +228,11 @@ final class RequestRouterTest extends TestCase {
 			}
 		);
 		$this->assertNotEmpty( $error_event );
+
+		// Verify failure_reason is captured for protocol errors.
+		$error_event_data = array_values( $error_event )[0];
+		$this->assertArrayHasKey( 'failure_reason', $error_event_data['tags'], 'Protocol error should include failure_reason in observability tags.' );
+		$this->assertStringContainsString( 'unknown/method', $error_event_data['tags']['failure_reason'] );
 	}
 
 	public function test_route_request_handles_handler_exceptions(): void {

--- a/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -399,6 +399,12 @@ final class RequestRouterTest extends TestCase {
 			}
 		);
 		$this->assertNotEmpty( $error_event, 'CallToolResult with isError=true should be recorded with status "error".' );
+
+		// Verify failure_reason is captured in observability tags.
+		$error_event_data = array_values( $error_event )[0];
+		$this->assertArrayHasKey( 'failure_reason', $error_event_data['tags'], 'isError response should include failure_reason in observability tags.' );
+		$this->assertIsString( $error_event_data['tags']['failure_reason'] );
+		$this->assertNotEmpty( $error_event_data['tags']['failure_reason'] );
 	}
 
 	public function test_route_request_tools_call_with_is_error_false_records_success_status(): void {

--- a/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -52,7 +52,7 @@ final class RequestRouterTest extends TestCase {
 			array(),
 			DummyErrorHandler::class,
 			DummyObservabilityHandler::class,
-			array( 'test/always-allowed', 'test/meta-leak' ),
+			array( 'test/always-allowed', 'test/meta-leak', 'test/permission-denied' ),
 			array( 'test/resource' ),
 			array( 'test/prompt' )
 		);
@@ -364,6 +364,69 @@ final class RequestRouterTest extends TestCase {
 
 		// Restore user
 		wp_set_current_user( $this->test_user_id );
+	}
+
+	// =========================================================================
+	// CallToolResult isError Observability Tests
+	// =========================================================================
+
+	public function test_route_request_tools_call_with_is_error_true_records_error_status(): void {
+		DummyObservabilityHandler::reset();
+
+		$result = $this->router->route_request(
+			'tools/call',
+			array(
+				'name'      => 'test-permission-denied',
+				'arguments' => array(),
+			),
+			1,
+			'test-transport'
+		);
+
+		$this->assertIsArray( $result );
+		// CallToolResult with isError=true should still have content (not an error key).
+		$this->assertArrayHasKey( 'content', $result );
+		$this->assertArrayHasKey( 'isError', $result );
+		$this->assertTrue( $result['isError'] );
+
+		// Verify observability records status as 'error'.
+		$error_event = array_filter(
+			DummyObservabilityHandler::$events,
+			static function ( $event ) {
+				return 'mcp.request' === $event['event']
+					&& isset( $event['tags']['status'] )
+					&& 'error' === $event['tags']['status'];
+			}
+		);
+		$this->assertNotEmpty( $error_event, 'CallToolResult with isError=true should be recorded with status "error".' );
+	}
+
+	public function test_route_request_tools_call_with_is_error_false_records_success_status(): void {
+		DummyObservabilityHandler::reset();
+
+		$result = $this->router->route_request(
+			'tools/call',
+			array(
+				'name'      => 'test-always-allowed',
+				'arguments' => array(),
+			),
+			1,
+			'test-transport'
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'content', $result );
+
+		// Verify observability records status as 'success'.
+		$success_event = array_filter(
+			DummyObservabilityHandler::$events,
+			static function ( $event ) {
+				return 'mcp.request' === $event['event']
+					&& isset( $event['tags']['status'] )
+					&& 'success' === $event['tags']['status'];
+			}
+		);
+		$this->assertNotEmpty( $success_event, 'CallToolResult with isError=false/null should be recorded with status "success".' );
 	}
 
 	// =========================================================================


### PR DESCRIPTION
## Why

RequestRouter logged all `AbstractDataTransferObject` responses as `status: success`, including `CallToolResult` with `isError: true`. This made application-level tool failures (permission denied, WP_Error, legacy `success:false`) invisible in observability — they looked identical to successful tool calls.

Additionally, neither tool errors nor protocol errors (`JSONRPCErrorResponse`) included a human-readable `failure_reason` in the observability tags. Operators could see *that* something failed but not *why*.

## What

**Status classification** — `CallToolResult` with `getIsError() === true` is now logged as `status: error` instead of `status: success`.

**failure_reason for tool errors** — When `isError` is true and no `failure_reason` already exists in handler metadata, the error message is extracted from the first `TextContent` block in `CallToolResult::getContent()`.

**failure_reason for protocol errors** — `JSONRPCErrorResponse` events now include the error message via `getError()->getMessage()` as `failure_reason`, alongside the existing `error_code`.

| Error scenario | Before | After |
|---|---|---|
| Tool error (permission denied, WP_Error) | `status: success` | `status: error`, `failure_reason: "..."` |
| Tool error with handler metadata | `status: success` | `status: error`, `failure_reason` preserved from metadata |
| Protocol error (tool not found, invalid params) | `status: error`, `error_code` only | `status: error`, `error_code`, `failure_reason: "..."` |

No changes to `McpObservabilityHandlerInterface` or any consumer code.

## Test plan

- [x] PHPStan Level 8 — zero errors
- [x] PHPCS — zero violations
- [x] PHPUnit — 999 tests, 3834 assertions pass
- [x] `CallToolResult` with `isError=true` records `status: error` and `failure_reason`
- [x] `CallToolResult` with `isError=false` still records `status: success`
- [x] `JSONRPCErrorResponse` includes `failure_reason` with error message