### PR TITLE
Replace @since n.e.x.t placeholders with 0.5.0

### DIFF
--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -327,7 +327,7 @@ class McpServer {
 	/**
 	 * Get the error handler instance.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @return \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface
 	 */

--- a/includes/Core/McpVersionNegotiator.php
+++ b/includes/Core/McpVersionNegotiator.php
@@ -17,7 +17,7 @@ namespace WP\MCP\Core;
  *
  * This is a Core layer class — no WordPress function calls.
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 final class McpVersionNegotiator {
 
@@ -39,7 +39,7 @@ final class McpVersionNegotiator {
 	 * If the client-requested version is in the supported list it is echoed
 	 * back verbatim. Otherwise the latest supported version is returned.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param string $client_version The protocol version requested by the client.
 	 *
@@ -56,7 +56,7 @@ final class McpVersionNegotiator {
 	/**
 	 * Check whether a given version string is supported.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param string $version The protocol version to check.
 	 *

--- a/includes/Domain/Contracts/McpComponentInterface.php
+++ b/includes/Domain/Contracts/McpComponentInterface.php
@@ -23,7 +23,7 @@ use WP\McpSchema\Common\AbstractDataTransferObject;
  *
  * @internal
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 interface McpComponentInterface {
 
@@ -34,7 +34,7 @@ interface McpComponentInterface {
 	 * internal adapter metadata or execution wiring.
 	 *
 	 * @return \WP\McpSchema\Common\AbstractDataTransferObject Protocol-only DTO.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public function get_protocol_dto(): AbstractDataTransferObject;
@@ -49,7 +49,7 @@ interface McpComponentInterface {
 	 * @param mixed $arguments Component arguments (typically an associative array).
 	 *
 	 * @return mixed Execution result.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public function execute( $arguments );
@@ -64,7 +64,7 @@ interface McpComponentInterface {
 	 * @param mixed $arguments Component arguments (typically an associative array).
 	 *
 	 * @return bool|\WP_Error True when permitted, false or WP_Error otherwise.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public function check_permission( $arguments );
@@ -75,7 +75,7 @@ interface McpComponentInterface {
 	 * This metadata MUST NOT be stored on protocol DTOs and MUST NOT be exposed to MCP clients.
 	 *
 	 * @return array<string, mixed> Internal metadata.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public function get_adapter_meta(): array;
@@ -86,7 +86,7 @@ interface McpComponentInterface {
 	 * This replaces legacy approaches that derived observability tags from DTO `_meta`.
 	 *
 	 * @return array<string, mixed> Observability tags (component_type, source, etc.).
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public function get_observability_context(): array;

--- a/includes/Domain/Prompts/McpPrompt.php
+++ b/includes/Domain/Prompts/McpPrompt.php
@@ -52,7 +52,7 @@ use WP_Error;
  * adapter metadata and execution wiring live on this class and are never
  * exposed to MCP clients. Use get_protocol_dto() for protocol responses.
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 final class McpPrompt implements McpComponentInterface {
 

--- a/includes/Domain/Prompts/McpPromptBuilder.php
+++ b/includes/Domain/Prompts/McpPromptBuilder.php
@@ -78,7 +78,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	/**
 	 * The prompt icons for UI display.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @var list<array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}>|null
 	 */
@@ -90,7 +90,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * Use this to attach purpose-specific metadata that MCP clients can consume.
 	 * Keys are passed through unchanged.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @var array<string, mixed>
 	 */
@@ -103,7 +103,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * idempotent behavior. Subclasses should NOT override this constructor;
 	 * instead, implement the configure() method.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 */
 	final public function __construct() {
 		$this->configure();
@@ -215,7 +215,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * Get the prompt icons.
 	 *
 	 * @return list<array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}> The prompt icons.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public function get_icons(): array {
@@ -235,7 +235,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * @param list<array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}> $icons Array of icon definitions.
 	 *
 	 * @return self
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	protected function set_icons( array $icons ): self {
@@ -248,7 +248,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * Get the additional metadata.
 	 *
 	 * @return array<string, mixed> The additional metadata.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public function get_meta(): array {
@@ -263,7 +263,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	 * @param array<string, mixed> $meta Additional metadata key-value pairs.
 	 *
 	 * @return self
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	protected function set_meta( array $meta ): self {

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -49,7 +49,7 @@ use WP_Error;
  *     )
  * );
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 class RegisterAbilityAsMcpPrompt {
 
@@ -63,7 +63,7 @@ class RegisterAbilityAsMcpPrompt {
 	/**
 	 * Tracks whether input_schema was transformed from flattened to object format.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @var bool
 	 */
@@ -72,7 +72,7 @@ class RegisterAbilityAsMcpPrompt {
 	/**
 	 * The wrapper property name used when transforming flattened schemas.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @var string|null
 	 */
@@ -86,7 +86,7 @@ class RegisterAbilityAsMcpPrompt {
 	 * - 'schema': Arguments were auto-converted from ability.input_schema
 	 * - null: No arguments present
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @var string|null
 	 */
@@ -118,7 +118,7 @@ class RegisterAbilityAsMcpPrompt {
 	 * Get the MCP prompt instance.
 	 *
 	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|\WP_Error Prompt DTO or WP_Error if validation fails.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	private function get_prompt() {
@@ -140,7 +140,7 @@ class RegisterAbilityAsMcpPrompt {
 	 * Build Prompt DTO data and adapter metadata.
 	 *
 	 * @return array{prompt_data: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	private function build_prompt_data() {
@@ -210,7 +210,7 @@ class RegisterAbilityAsMcpPrompt {
 	 * This follows the `mcp.*` override pattern used elsewhere (mcp.uri, mcp.icons, mcp.annotations).
 	 *
 	 * @return array<string,mixed>|\WP_Error Prompt data array, or WP_Error if explicit arguments are invalid.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	private function get_data() {
@@ -274,7 +274,7 @@ class RegisterAbilityAsMcpPrompt {
 	 * Get explicit arguments from ability meta.mcp.arguments.
 	 *
 	 * @return list<array<string,mixed>>|null Explicit arguments array or null if not defined.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	private function get_explicit_arguments(): ?array {
@@ -303,7 +303,7 @@ class RegisterAbilityAsMcpPrompt {
 	 * @param list<array<string,mixed>> $explicit_arguments User-defined arguments array.
 	 *
 	 * @return list<\WP\McpSchema\Server\Prompts\DTO\PromptArgument>|\WP_Error PromptArgument DTOs or WP_Error.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	private function convert_explicit_arguments( array $explicit_arguments ) {
@@ -384,7 +384,7 @@ class RegisterAbilityAsMcpPrompt {
 	 * @param array<string,mixed> $input_schema The JSON Schema from ability.
 	 *
 	 * @return list<\WP\McpSchema\Server\Prompts\DTO\PromptArgument> Argument DTO list.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	private function convert_input_schema_to_arguments( array $input_schema ): array {
@@ -439,7 +439,7 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * Sanitizes the ability name to MCP-valid format, applies filter, and validates result.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @return string|\WP_Error Valid prompt name or error.
 	 */
@@ -454,7 +454,7 @@ class RegisterAbilityAsMcpPrompt {
 		/**
 		 * Filters the MCP prompt name derived from an ability.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.5.0
 		 *
 		 * @param string      $name    The sanitized prompt name.
 		 * @param \WP_Ability $ability The source ability instance.
@@ -486,7 +486,7 @@ class RegisterAbilityAsMcpPrompt {
 	 * @param \WP_Ability $ability The ability.
 	 *
 	 * @return array{prompt: \WP\McpSchema\Server\Prompts\DTO\Prompt, adapter_meta: array<string, mixed>}|\WP_Error
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function build( \WP_Ability $ability ) {

--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -43,7 +43,7 @@ use WP_Error;
  * adapter metadata and execution wiring live on this class and are never
  * exposed to MCP clients. Use get_protocol_dto() for protocol responses.
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 final class McpResource implements McpComponentInterface {
 

--- a/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -35,11 +35,11 @@ use WP_Error;
  * - 'mcp.icons' (array): Array of icon objects for UI display
  * - 'mcp._meta' (array): User-provided metadata to pass through
  *
- * Note: Top-level meta keys 'uri', 'mimeType', 'annotations' are deprecated as of n.e.x.t.
+ * Note: Top-level meta keys 'uri', 'mimeType', 'annotations' are deprecated as of 0.5.0.
  * They still work for backward compatibility but will trigger a `_doing_it_wrong` notice.
  * Use 'mcp.uri', 'mcp.mimeType', 'mcp.annotations' instead.
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 class RegisterAbilityAsMcpResource {
 
@@ -126,7 +126,7 @@ class RegisterAbilityAsMcpResource {
 	 * Build Resource DTO data and adapter metadata.
 	 *
 	 * @return array{resource_data: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	private function build_resource_data() {
@@ -262,7 +262,7 @@ class RegisterAbilityAsMcpResource {
 		/**
 		 * Filters the MCP resource URI derived from an ability.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.5.0
 		 *
 		 * @param string $uri The validated resource URI.
 		 * @param \WP_Ability $ability The source ability instance.
@@ -377,7 +377,7 @@ class RegisterAbilityAsMcpResource {
 	 */
 	private function log_deprecation( string $method, string $message, array $context = array() ): void {
 		// WordPress standard deprecation notice (appears as X-WP-DoingItWrong header in REST API).
-		_doing_it_wrong( esc_html( $method ), esc_html( $message ), 'n.e.x.t' );
+		_doing_it_wrong( esc_html( $method ), esc_html( $message ), '0.5.0' );
 
 		// Also log via McpErrorHandler for debug.log visibility.
 		if ( ! $this->error_handler ) {
@@ -409,7 +409,7 @@ class RegisterAbilityAsMcpResource {
 		 *
 		 * Unlike tools, resource names have no charset restrictions.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.5.0
 		 *
 		 * @param string $name The resource name.
 		 * @param \WP_Ability $ability The source ability instance.
@@ -436,7 +436,7 @@ class RegisterAbilityAsMcpResource {
 	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler.
 	 *
 	 * @return array{resource: \WP\McpSchema\Server\Resources\DTO\Resource, adapter_meta: array<string, mixed>}|\WP_Error
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function build( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null ) {

--- a/includes/Domain/Tools/McpTool.php
+++ b/includes/Domain/Tools/McpTool.php
@@ -45,7 +45,7 @@ use WP_Error;
  * adapter metadata and execution wiring live on this class and are never
  * exposed to MCP clients. Use get_protocol_dto() for protocol responses.
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 final class McpTool implements McpComponentInterface {
 

--- a/includes/Domain/Tools/McpToolValidator.php
+++ b/includes/Domain/Tools/McpToolValidator.php
@@ -26,7 +26,7 @@ class McpToolValidator {
 	/**
 	 * Valid task support values for tool execution.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @var array<string>
 	 */

--- a/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -54,7 +54,7 @@ class RegisterAbilityAsMcpTool {
 	 * @param \WP_Ability $ability The ability.
 	 *
 	 * @return array{tool: \WP\McpSchema\Server\Tools\DTO\Tool, adapter_meta: array<string, mixed>}|\WP_Error
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function build( \WP_Ability $ability ) {
@@ -99,7 +99,7 @@ class RegisterAbilityAsMcpTool {
 	 * Build Tool DTO data and adapter metadata.
 	 *
 	 * @return array{tool_data: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	private function build_tool_data() {
@@ -203,7 +203,7 @@ class RegisterAbilityAsMcpTool {
 	 * Sanitizes the ability name to MCP-valid format, applies filter, and validates result.
 	 *
 	 * @return string|\WP_Error Valid tool name or error.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	private function resolve_tool_name() {
@@ -217,7 +217,7 @@ class RegisterAbilityAsMcpTool {
 		/**
 		 * Filters the MCP tool name derived from an ability.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.5.0
 		 *
 		 * @param string $name The sanitized tool name.
 		 * @param \WP_Ability $ability The source ability instance.

--- a/includes/Domain/Utils/AbilityArgumentNormalizer.php
+++ b/includes/Domain/Utils/AbilityArgumentNormalizer.php
@@ -16,7 +16,7 @@ namespace WP\MCP\Domain\Utils;
  * PHP decodes this as [] (empty array).
  * Abilities without input_schema expect null, not empty array.
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 class AbilityArgumentNormalizer {
 
@@ -30,7 +30,7 @@ class AbilityArgumentNormalizer {
 	 * @param mixed $parameters The parameters to normalize.
 	 *
 	 * @return mixed Normalized parameters (null if ability has no schema and params are empty).
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function normalize( \WP_Ability $ability, $parameters ) {

--- a/includes/Domain/Utils/ContentBlockHelper.php
+++ b/includes/Domain/Utils/ContentBlockHelper.php
@@ -29,7 +29,7 @@ use WP\McpSchema\Common\Protocol\Union\ContentBlockInterface;
  * ContentBlockInterface. These DTOs are used in tool call results, prompt messages,
  * and resource contents throughout the MCP protocol.
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 final class ContentBlockHelper {
 

--- a/includes/Domain/Utils/McpNameSanitizer.php
+++ b/includes/Domain/Utils/McpNameSanitizer.php
@@ -21,7 +21,7 @@ use WP_Error;
  * Used for both tools and prompts (same naming rules).
  * NOT used for resources (which use URIs as identifiers).
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 class McpNameSanitizer {
 
@@ -60,7 +60,7 @@ class McpNameSanitizer {
 	 * @param string $name Original name.
 	 *
 	 * @return string|\WP_Error Sanitized name or WP_Error if unsalvageable.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function sanitize_name( string $name ) {

--- a/includes/Domain/Utils/McpValidator.php
+++ b/includes/Domain/Utils/McpValidator.php
@@ -26,7 +26,7 @@ class McpValidator {
 	 * MUST support: image/png, image/jpeg, image/jpg
 	 * SHOULD support: image/svg+xml, image/webp
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @var array<string>
 	 */
@@ -50,7 +50,7 @@ class McpValidator {
 	 * @param int $max_length Maximum allowed length. Default is 128 per MCP spec.
 	 *
 	 * @return bool True if valid, false otherwise.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function validate_name( string $name, int $max_length = 128 ): bool {
@@ -128,7 +128,7 @@ class McpValidator {
 	 * @param bool $log_warnings Whether to log warnings for invalid icons. Default true.
 	 *
 	 * @return array{valid: array, errors: array} Array with 'valid' icons and 'errors' details.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function validate_icons_array( array $icons, bool $log_warnings = true ): array {
@@ -185,7 +185,7 @@ class McpValidator {
 	 * @param array $icon The icon data to validate.
 	 *
 	 * @return array Array of validation errors, empty if valid.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function get_icon_validation_errors( array $icon ): array {
@@ -257,7 +257,7 @@ class McpValidator {
 	 * @param string $src The icon source to validate.
 	 *
 	 * @return bool True if valid, false otherwise.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function validate_icon_src( string $src ): bool {
@@ -291,7 +291,7 @@ class McpValidator {
 	 * @param string $mime_type The MIME type to validate.
 	 *
 	 * @return bool True if valid icon MIME type, false otherwise.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function validate_icon_mime_type( string $mime_type ): bool {
@@ -307,7 +307,7 @@ class McpValidator {
 	 * @param string $size The size string to validate.
 	 *
 	 * @return bool True if valid, false otherwise.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function validate_icon_size( string $size ): bool {
@@ -335,7 +335,7 @@ class McpValidator {
 	 * @param string $theme The theme to validate.
 	 *
 	 * @return bool True if valid, false otherwise.
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 */
 	public static function validate_icon_theme( string $theme ): bool {

--- a/includes/Handlers/HandlerHelperTrait.php
+++ b/includes/Handlers/HandlerHelperTrait.php
@@ -36,7 +36,7 @@ trait HandlerHelperTrait {
 	 * and falls back to the original unfiltered array to prevent
 	 * downstream type errors.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param mixed                    $filtered    The value returned by apply_filters.
 	 * @param array                    $original    The original unfiltered array.

--- a/includes/Handlers/Initialize/InitializeHandler.php
+++ b/includes/Handlers/Initialize/InitializeHandler.php
@@ -42,7 +42,7 @@ class InitializeHandler {
 	 * If the client requests a supported version, that version is used. Otherwise
 	 * the server falls back to the latest supported version.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param string $client_protocol_version The protocol version requested by the client.
 	 *
@@ -90,7 +90,7 @@ class InitializeHandler {
 		 * `$result->toArray()`, change the data, and return
 		 * `InitializeResult::fromArray( $modified_data )`.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.5.0
 		 *
 		 * @param \WP\McpSchema\Common\Protocol\DTO\InitializeResult $result The initialize result DTO.
 		 * @param \WP\MCP\Core\McpServer                             $server The MCP server instance.

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -20,7 +20,7 @@ use WP\McpSchema\Server\Prompts\DTO\PromptMessage;
 /**
  * Handles prompts-related MCP methods.
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 class PromptsHandler {
 	use HandlerHelperTrait;
@@ -76,7 +76,7 @@ class PromptsHandler {
 		 * Use this filter to filter prompts by context, add dynamic prompts,
 		 * or reorder the prompts list.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.5.0
 		 *
 		 * @param array<\WP\McpSchema\Server\Prompts\DTO\Prompt> $prompts Array of Prompt DTOs.
 		 * @param \WP\MCP\Core\McpServer                         $server  The MCP server instance.
@@ -147,7 +147,7 @@ class PromptsHandler {
 			 * Return the (optionally modified) arguments array to proceed with execution,
 			 * or return a WP_Error to block execution and return an error to the client.
 			 *
-			 * @since n.e.x.t
+			 * @since 0.5.0
 			 *
 			 * @param array                              $arguments   The prompt arguments.
 			 * @param string                             $prompt_name The prompt name being retrieved.
@@ -169,7 +169,7 @@ class PromptsHandler {
 			 * Use this filter for message transformation, context injection,
 			 * content enrichment, or audit logging.
 			 *
-			 * @since n.e.x.t
+			 * @since 0.5.0
 			 *
 			 * @param mixed|\WP_Error                    $result      The raw execution result (may be WP_Error).
 			 * @param array                              $arguments   The prompt arguments used.
@@ -221,7 +221,7 @@ class PromptsHandler {
 	 * - Tier 4: Multi-text with 'texts' array
 	 * - Tier 5: Fallback JSON encoding for arbitrary data
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param array                                 $result      Raw result from prompt execution.
 	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt      The prompt DTO for description fallback.
@@ -261,7 +261,7 @@ class PromptsHandler {
 	/**
 	 * Tier 1: Full MCP-compliant format with 'messages' array.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param array                                 $result      Raw result with 'messages' key.
 	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt      The prompt DTO.
@@ -319,7 +319,7 @@ class PromptsHandler {
 	 *
 	 * Creates a single user message with text content.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param array                                 $result Raw result with 'text' key.
 	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The prompt DTO.
@@ -355,7 +355,7 @@ class PromptsHandler {
 	/**
 	 * Tier 3: Single message with 'role' and 'content'.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param array                                 $result      Raw result with 'role' and 'content' keys.
 	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt      The prompt DTO.
@@ -383,7 +383,7 @@ class PromptsHandler {
 	 *
 	 * Creates multiple messages with the same role.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param array                                 $result Raw result with 'texts' key.
 	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The prompt DTO.
@@ -436,7 +436,7 @@ class PromptsHandler {
 	 *
 	 * Used when no other tier matches. Logs an observability event.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param array                                 $result      Raw result (arbitrary structure).
 	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt      The prompt DTO.
@@ -490,7 +490,7 @@ class PromptsHandler {
 	 *
 	 * Validates role and content type, applying defaults where needed.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param array  $message     Raw message array.
 	 * @param string $prompt_name Prompt name for logging.
@@ -524,7 +524,7 @@ class PromptsHandler {
 	/**
 	 * Validate content type against ContentBlockFactory registry.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param array  $content     Content array with 'type' key.
 	 * @param string $prompt_name Prompt name for logging.
@@ -583,7 +583,7 @@ class PromptsHandler {
 	/**
 	 * Validate role value and apply default if invalid.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param string $role        Role value to validate.
 	 * @param string $prompt_name Prompt name for logging (empty to skip logging).

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -57,7 +57,7 @@ class ResourcesHandler {
 		 * Use this filter to filter resources by context, add dynamic resources,
 		 * or reorder the resources list.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.5.0
 		 *
 		 * @param array<\WP\McpSchema\Server\Resources\DTO\Resource> $resources Array of Resource DTOs.
 		 * @param \WP\MCP\Core\McpServer                             $server    The MCP server instance.
@@ -128,7 +128,7 @@ class ResourcesHandler {
 			 * Return the (optionally modified) parameters array to proceed with execution,
 			 * or return a WP_Error to block execution and return an error to the client.
 			 *
-			 * @since n.e.x.t
+			 * @since 0.5.0
 			 *
 			 * @param array                                $params       The request parameters.
 			 * @param string                               $uri          The resource URI.
@@ -150,7 +150,7 @@ class ResourcesHandler {
 			 * Use this filter for content transformation, caching storage,
 			 * PII redaction, or audit logging.
 			 *
-			 * @since n.e.x.t
+			 * @since 0.5.0
 			 *
 			 * @param mixed|\WP_Error                      $contents     The raw resource contents (may be WP_Error).
 			 * @param array                                $params       The request parameters used.

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -79,7 +79,7 @@ class ToolsHandler {
 		 * Use this filter to hide tools per user/role, add dynamic tools,
 		 * or reorder the tools list.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.5.0
 		 *
 		 * @param array<\WP\McpSchema\Server\Tools\DTO\Tool> $tools  Array of Tool DTOs.
 		 * @param \WP\MCP\Core\McpServer                     $server The MCP server instance.
@@ -172,7 +172,7 @@ class ToolsHandler {
 			 * Return the (optionally modified) arguments array to proceed with execution,
 			 * or return a WP_Error to block execution and return an error to the client.
 			 *
-			 * @since n.e.x.t
+			 * @since 0.5.0
 			 *
 			 * @param array                        $args      The tool arguments.
 			 * @param string                       $tool_name The tool name being called.
@@ -194,7 +194,7 @@ class ToolsHandler {
 			 * Use this filter for result transformation, PII redaction,
 			 * audit logging, or content enrichment.
 			 *
-			 * @since n.e.x.t
+			 * @since 0.5.0
 			 *
 			 * @param mixed|\WP_Error              $result    The raw execution result (may be WP_Error).
 			 * @param array                        $args      The tool arguments used.
@@ -324,7 +324,7 @@ class ToolsHandler {
 	/**
 	 * Create an error CallToolResult from a message string.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param string $message The error message.
 	 *

--- a/includes/Infrastructure/Observability/FailureReason.php
+++ b/includes/Infrastructure/Observability/FailureReason.php
@@ -7,7 +7,7 @@
  * consistent categorization across all MCP adapter components.
  *
  * @package McpAdapter
- * @since   n.e.x.t
+ * @since   0.5.0
  */
 
 declare( strict_types=1 );
@@ -22,7 +22,7 @@ namespace WP\MCP\Infrastructure\Observability;
  * - Permission failures: Occur when permission checks fail at execution time
  * - Execution failures: Occur during component execution
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 final class FailureReason {
 

--- a/includes/Servers/DefaultServerFactory.php
+++ b/includes/Servers/DefaultServerFactory.php
@@ -123,7 +123,7 @@ class DefaultServerFactory {
 				esc_html( $result->get_error_message() ),
 				esc_html( (string) $result->get_error_code() )
 			),
-			'n.e.x.t'
+			'0.5.0'
 		);
 	}
 

--- a/includes/Transport/Infrastructure/HttpRequestContext.php
+++ b/includes/Transport/Infrastructure/HttpRequestContext.php
@@ -46,7 +46,7 @@ class HttpRequestContext {
 	/**
 	 * The MCP-Protocol-Version header from the request.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @var string|null
 	 */

--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -41,7 +41,7 @@ class HttpRequestHandler {
 	/**
 	 * Get the transport context.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @return \WP\MCP\Transport\Infrastructure\McpTransportContext
 	 */
@@ -246,7 +246,7 @@ class HttpRequestHandler {
 	 * version is also accepted. An unsupported version returns a JSON-RPC
 	 * invalid-request error payload.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 *
 	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext $context The HTTP request context.
 	 *

--- a/includes/Transport/Infrastructure/McpTransportContext.php
+++ b/includes/Transport/Infrastructure/McpTransportContext.php
@@ -145,7 +145,7 @@ class McpTransportContext {
 	 *
 	 * @throws \InvalidArgumentException If required keys are missing or unknown keys are present.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 */
 	public function __construct( array $properties ) {
 		$this->validate_properties( $properties );
@@ -175,7 +175,7 @@ class McpTransportContext {
 	 *
 	 * @throws \InvalidArgumentException If required keys are missing or unknown keys are present.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.5.0
 	 */
 	private function validate_properties( array $properties ): void {
 		$provided_keys = array_keys( $properties );

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -197,7 +197,7 @@ final class SessionManager {
 		 * `last_activity` if at least this many seconds have elapsed since
 		 * the last write.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.5.0
 		 *
 		 * @param int $interval Minimum seconds between writes. Default 60.
 		 */

--- a/tests/Unit/Core/McpVersionNegotiatorTest.php
+++ b/tests/Unit/Core/McpVersionNegotiatorTest.php
@@ -14,7 +14,7 @@ use WP\MCP\Tests\TestCase;
 use WP\McpSchema\Common\McpConstants;
 
 /**
- * @since n.e.x.t.
+ * @since 0.5.0
  */
 final class McpVersionNegotiatorTest extends TestCase {
 

--- a/tests/Unit/Transport/Infrastructure/McpTransportContextTest.php
+++ b/tests/Unit/Transport/Infrastructure/McpTransportContextTest.php
@@ -25,7 +25,7 @@ use WP\MCP\Transport\Infrastructure\RequestRouter;
 /**
  * Test McpTransportContext constructor validation.
  *
- * @since n.e.x.t
+ * @since 0.5.0
  */
 final class McpTransportContextTest extends TestCase {
 


### PR DESCRIPTION
## Summary

- Replace all `@since n.e.x.t` version placeholders with `@since 0.5.0` across 28 PHP files before tagging the v0.5.0 release
- Covers PHPDoc `@since` tags (~88 occurrences), 2 runtime `_doing_it_wrong()` version parameters, and 1 deprecation prose note
- Pure find-and-replace — no logic changes

## Test plan

- [x] Zero `n.e.x.t` matches remaining in `includes/` and `tests/` directories
- [x] Runtime usages in `DefaultServerFactory.php` and `RegisterAbilityAsMcpResource.php` verified
- [x] PHPStan Level 8: 0 errors
- [x] PHPCS: 0 violations