### PR TITLE
Docs: Add category to ability registration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/get-posts', [
         'label' => 'Get Posts',
         'description' => 'Retrieve WordPress posts with optional filtering',
+        'category' => 'site',
         'input_schema' => [
             'type' => 'object',
             'properties' => [


### PR DESCRIPTION
Related issues #135 

- This PR adds the category field to the ability registration example in the README, as it is a required parameter.