### PR TITLE
Bump wordpress/php-mcp-schema to v0.1.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "wordpress/php-mcp-schema",
-            "version": "v0.1.0",
+            "version": "v0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-mcp-schema.git",
-                "reference": "b1003dd4d223ef727f19a3163755163461009289"
+                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/b1003dd4d223ef727f19a3163755163461009289",
-                "reference": "b1003dd4d223ef727f19a3163755163461009289",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/e2118ec421ead51a3e17a3d8160f4537727e91b9",
+                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9",
                 "shasum": ""
             },
             "require": {
@@ -53,9 +53,9 @@
             ],
             "support": {
                 "issues": "https://github.com/WordPress/php-mcp-schema/issues",
-                "source": "https://github.com/WordPress/php-mcp-schema/tree/v0.1.0"
+                "source": "https://github.com/WordPress/php-mcp-schema/tree/v0.1.1"
             },
-            "time": "2026-03-02T08:25:49+00:00"
+            "time": "2026-04-10T19:35:16+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Why

WordPress.org plugin submissions bundling `mcp-adapter` may be rejected because `vendor/wordpress/php-mcp-schema` ships executable `.sh` scripts in its `skill/` directory.

## What

Bumps `wordpress/php-mcp-schema` from v0.1.0 to v0.1.1. Upstream v0.1.1 adds `.gitattributes` export-ignore rules that exclude `skill/` and `CLAUDE.md` from Composer dist archives. Lockfile-only change.

## Test plan

- [ ] `composer install` produces a clean `vendor/wordpress/php-mcp-schema/` (no `skill/` directory, no `.sh` files, no `CLAUDE.md`)
- [ ] CI passes