### PR TITLE
fix: pin tag_name so release zip attaches to the correct release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,5 +60,6 @@ jobs:
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           files: mcp-adapter.zip
+          tag_name: ${{ github.event.release.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What?

Pass `${{ github.event.release.tag_name }}` to `softprops/action-gh-release` when uploading `mcp-adapter.zip`.

The change only affects release targeting. Build, packaging, permissions, and plugin runtime behavior are unchanged.

## Why?

The v0.5.0 release workflow completed successfully, but uploaded the ZIP to a new release named `untagged-b3a070d0ed339be9df3d` instead of v0.5.0.

[Run 24473552183](https://github.com/WordPress/mcp-adapter/actions/runs/24473552183) shows:

```text
Creating new GitHub release for tag untagged-b3a070d0ed339be9df3d...
Uploaded mcp-adapter.zip
Release ready at .../releases/tag/untagged-b3a070d0ed339be9df3d
```

The release event ran with that synthetic `untagged-*` ref. When `tag_name` is omitted, `softprops/action-gh-release` defaults to the current ref, so it selected the wrong release tag.

The documented installation URL depends on the release asset:

```text
https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip
```

The v0.5.0 asset has since been uploaded manually. This PR prevents the same problem on future releases.

## How?

Use the tag from the release event payload as the source of truth:

```yaml
tag_name: ${{ github.event.release.tag_name }}
```

Both the v2.3.2 action used by this PR and the v3.0.2 action on current `trunk` support this input and use it before falling back to the workflow ref. If the release already exists, the action updates it with the uploaded asset.

## Testing

- Confirmed the original failure in run `24473552183`.
- All GitHub checks on the PR head pass.
- A synthetic merge with current `trunk` was conflict-free and passed:
  - Prettier
  - PHPCS, 61/61 files
  - PHPStan, 61/61 files
  - PHPUnit, 1,009 tests and 3,896 assertions with one documented skip
  - `npm run plugin-zip`
- A live release has not been published with this change yet. On the next release, or with a disposable fork release, confirm that:
  - `mcp-adapter.zip` is attached to the triggering release.
  - No new `untagged-*` release is created.
  - Rerunning the workflow updates the same release.

## Changelog Entry

> Fixed - Upload `mcp-adapter.zip` to the release that triggered the release workflow.
