### PR TITLE
Guard DefaultServerFactory against cross-dispatch from other vendored copies

### DIFF
--- a/includes/Servers/DefaultServerFactory.php
+++ b/includes/Servers/DefaultServerFactory.php
@@ -31,9 +31,32 @@ class DefaultServerFactory {
 	 * WordPress filters for customization, making it perfect for use within
 	 * the McpAdapter.
 	 *
+	 * When hooked to the `mcp_adapter_init` action, WordPress passes the dispatching
+	 * adapter instance as the first argument. If that instance is not this copy's
+	 * singleton, the call bails out. This prevents duplicate server registration
+	 * when multiple copies of this library are active in the same request (e.g.
+	 * two plugins that each vendor `wordpress/mcp-adapter`, with or without
+	 * namespace prefixing) and each copy's dispatch fires every copy's callbacks.
+	 *
+	 * The parameter is intentionally untyped: in a multi-copy setup the dispatching
+	 * adapter may be a different class (different namespace) than this factory's
+	 * own `McpAdapter` import, so a strict type hint would raise a TypeError before
+	 * the guard could run.
+	 *
+	 * @since n.e.x.t Added optional `$dispatching_adapter` parameter and cross-dispatch guard.
+	 *
+	 * @param mixed $dispatching_adapter The dispatching adapter instance passed by WordPress.
+	 *                                   Null when invoked directly (not via the action).
+	 *
 	 * @return void
 	 */
-	public static function create(): void {
+	public static function create( $dispatching_adapter = null ): void {
+
+		// Bail when the dispatching adapter isn't this copy's singleton.
+		// See the docblock for why the parameter is untyped.
+		if ( null !== $dispatching_adapter && McpAdapter::instance() !== $dispatching_adapter ) {
+			return;
+		}
 
 		// Auto-discover resources and prompts from abilities
 		$auto_discovered_resources = self::discover_abilities_by_type( 'resource' );

--- a/tests/phpunit/Unit/Servers/DefaultServerFactoryTest.php
+++ b/tests/phpunit/Unit/Servers/DefaultServerFactoryTest.php
@@ -251,4 +251,34 @@ final class DefaultServerFactoryTest extends TestCase {
 		$this->assertNotNull( $server );
 		$this->assertInstanceOf( NullMcpObservabilityHandler::class, $server->get_observability_handler() );
 	}
+
+	public function test_create_with_matching_adapter_registers_server(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'mcp_adapter_init';
+
+		DefaultServerFactory::create( McpAdapter::instance() );
+
+		array_pop( $wp_current_filter );
+
+		$this->assertNotNull( $this->adapter->get_server( 'mcp-adapter-default-server' ) );
+	}
+
+	public function test_create_with_foreign_adapter_bails_out(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'mcp_adapter_init';
+
+		// Simulate a second adapter instance — the kind that would be dispatched
+		// by another vendored copy of this library in the same request.
+		$foreign = ( new \ReflectionClass( McpAdapter::class ) )->newInstanceWithoutConstructor();
+		$this->assertNotSame( McpAdapter::instance(), $foreign );
+
+		DefaultServerFactory::create( $foreign );
+
+		array_pop( $wp_current_filter );
+
+		$this->assertNull(
+			$this->adapter->get_server( 'mcp-adapter-default-server' ),
+			'Default server must not be registered on our singleton when a foreign adapter dispatched.'
+		);
+	}
 }


### PR DESCRIPTION
## Problem

Fixes #172.

When two or more active plugins each vendor `wordpress/mcp-adapter`, they collide on the shared `mcp_adapter_init` action. Every copy's dispatch runs every copy's callbacks, so each copy's `DefaultServerFactory::create` re-enters `create_server` on its own singleton, producing `duplicate_server_id` errors and a `_doing_it_wrong` notice on every REST request.

## Fix

`DefaultServerFactory::create` now accepts the dispatching adapter (passed by WordPress as the first argument to the `mcp_adapter_init` callback) and bails when it is not this copy's singleton. The parameter is intentionally untyped: in a multi-copy setup the dispatching adapter may be a different class (different namespace) than this factory's own `McpAdapter` import, so a strict type hint would raise a `TypeError` before the guard could run.

The change is backwards compatible: the parameter is optional, the `mcp_adapter_init` hook name is unchanged, and direct calls to `create()` (with no argument) behave exactly as before.

## Scope

This PR is intentionally limited to the factory guard, which fixes the crash on its own. The `McpAdapter::on_init()` consumer helper that was previously part of this PR has been split out into a separate PR so the new public API can be discussed and documented on its own.

## Tests

Two new unit tests cover the matching-adapter (registers the default server) and foreign-adapter (bails out) paths. Full unit suite passes locally (963 tests).