### PR TITLE
Fix: Add placeholder property for parameterless ability schemas

### DIFF
--- a/includes/Domain/Utils/SchemaTransformer.php
+++ b/includes/Domain/Utils/SchemaTransformer.php
@@ -19,6 +19,13 @@ namespace WP\MCP\Domain\Utils;
  */
 class SchemaTransformer {
 	/**
+	 * No-op property placeholder for tools without input fields.
+	 *
+	 * @var string
+	 */
+	private const NOOP_PROPERTY = '_mcp_noop';
+
+	/**
 	 * Transform a schema to MCP-compatible object format.
 	 *
 	 * If the schema is already an object type, it is returned unchanged.
@@ -39,8 +46,10 @@ class SchemaTransformer {
 		// Handle null or empty schema - return minimal valid MCP object schema.
 		if ( empty( $schema ) ) {
 			return array(
-				'schema'           => array(
-					'type' => 'object',
+				'schema'           => self::ensure_object_properties(
+					array(
+						'type' => 'object',
+					)
 				),
 				'was_transformed'  => false,
 				'wrapper_property' => null,
@@ -52,7 +61,7 @@ class SchemaTransformer {
 			$schema['type'] = 'object';
 
 			return array(
-				'schema'           => $schema,
+				'schema'           => self::ensure_object_properties( $schema ),
 				'was_transformed'  => false,
 				'wrapper_property' => null,
 			);
@@ -61,7 +70,7 @@ class SchemaTransformer {
 		// If already an object type, return as-is
 		if ( 'object' === $schema['type'] ) {
 			return array(
-				'schema'           => $schema,
+				'schema'           => self::ensure_object_properties( $schema ),
 				'was_transformed'  => false,
 				'wrapper_property' => null,
 			);
@@ -73,6 +82,34 @@ class SchemaTransformer {
 			'was_transformed'  => true,
 			'wrapper_property' => $wrapper_key,
 		);
+	}
+
+	/**
+	 * Ensure an object schema has properties.
+	 *
+	 * If the schema already has non-empty properties, it is returned unchanged.
+	 * Otherwise, it injects a no-op placeholder property to ensure the schema
+	 * is a valid JSON object with at least one property.
+	 *
+	 * @param array<string,mixed> $schema The object schema.
+	 *
+	 * @return array<string,mixed> The schema with properties ensured.
+	 */
+	private static function ensure_object_properties( array $schema ): array {
+		if ( ! isset( $schema['properties'] ) || ! is_array( $schema['properties'] ) || empty( $schema['properties'] ) ) {
+			$schema['properties'] = array(
+				self::NOOP_PROPERTY => array(
+					'type'        => 'string',
+					'description' => 'Optional no-op placeholder for parameterless tools.',
+				),
+			);
+		}
+
+		if ( ! isset( $schema['required'] ) || ! is_array( $schema['required'] ) ) {
+			$schema['required'] = array();
+		}
+
+		return $schema;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR updates `SchemaTransformer` to make parameterless ability schemas compatible with stricter MCP clients (notably Anthropic integrations) that reject `type: object` schemas when `properties` is missing.

## Changes

### 1. Added a placeholder property constant
- Introduced `private const NOOP_PROPERTY = '_mcp_noop';`
- Used as an optional, no-op placeholder key for tools that otherwise have no input fields

### 2. Normalized empty/object schemas to always include properties
Changed all object-schema return paths in `transform_to_object_schema()` to go through a new helper:
- Empty schema case (`empty($schema)`)
- No explicit type case (default to `type: object`)
- Already object schema case (`type === 'object'`)

All now call: `self::ensure_object_properties($schema)`

### 3. Added `ensure_object_properties()` helper
New private method with the following behavior:
- If schema already has non-empty `properties` (array), it is returned unchanged
- Otherwise, injects:
  - `properties._mcp_noop` with:
    - `type: string`
    - `description: "Optional no-op placeholder for parameterless tools."`
- Ensures `required` exists and is an array
- Does **not** require `_mcp_noop` (so no real behavioral change for callers)

### 4. Why this approach (instead of `stdClass` in schema)
A previous approach used `new \stdClass()` for empty properties, which helps JSON encoding but can be risky in internal DTO/validation paths expecting arrays.

This patch keeps everything array-based and client-safe:
- `inputSchema.properties` is always present
- DTO and validator flow remains consistent
- No-op property is optional, so tool execution semantics are unchanged

## Compatibility Impact
✅ Fixes clients that require object schemas to include `properties`  
✅ Keeps existing tools with real input schemas untouched  
✅ Parameterless tools now expose one optional placeholder input key, which is harmless and ignored unless explicitly sent

## Rationale
This improves interoperability with strict MCP client schema validation while preserving adapter internals and tool behavior. It specifically addresses cases where parameterless WordPress abilities were transformed into `{ type: "object" }` without properties, causing client-side tool registration failures.