### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,7 @@ jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     permissions:
       contents: read # Required to clone the repo.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,5 +1,9 @@
 name: 'Copilot Setup Steps'
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 # Automatically run the setup steps when they are changed to allow for easy validation, and
 # allow manual testing through the repository's "Actions" tab
 on:
@@ -17,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -50,9 +50,8 @@ jobs:
     name: Generate a list of props
     runs-on: ubuntu-24.04
     permissions:
-      # The action needs permission `write` permission for PRs in order to add a comment.
-      pull-requests: write
-      contents: read
+      pull-requests: write # Required by props-bot-action to comment on the PR.
+      contents: read       # Required by props-bot-action to read repository contents.
     timeout-minutes: 20
     # The job will run when pull requests are open, ready for review and:
     #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
   tag:
     name: Upload New Release
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: write # Required to clone the repo and to upload the release asset.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Upload Package on Release
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
@@ -15,6 +19,8 @@ jobs:
   tag:
     name: Upload New Release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # Required to clone the repo and to upload the release asset.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,6 +177,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read # Required to clone the repo.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 on:
   workflow_dispatch:
   push:
@@ -33,7 +37,7 @@ jobs:
     name: Run PHPCS coding standards checks
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: read # Required to clone the repo.
     timeout-minutes: 20
 
     steps:
@@ -92,7 +96,7 @@ jobs:
     name: Run PHP static analysis
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: read # Required to clone the repo.
     timeout-minutes: 20
 
     steps:
@@ -171,6 +175,8 @@ jobs:
   phpunit:
     name: Test PHP ${{ matrix.php }} WP ${{ matrix.wp }}${{ matrix.coverage && ' with coverage' || '' }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # Required to clone the repo.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/mcp-adapter/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Claude Code was used to create the initial changes. All permissions and timeouts changes were reviewed and adjusted by me where necessary.
