### PR TITLE
feat(admin): add Settings > MCP Adapter page to opt registered abilities into the default server (fixes #183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ The MCP Adapter automatically creates a default server that exposes registered W
 - Access via HTTP: `/wp-json/mcp/mcp-adapter-default-server`
 - Access via STDIO: `wp mcp-adapter serve --server=mcp-adapter-default-server`
 
+### Settings page
+
+Administrators can opt registered abilities into the default MCP server without writing PHP at **Settings → MCP Adapter**. The page lists every ability currently registered on the site and persists the selection in the `mcp_adapter_public_abilities` option. The same `wp_register_ability_args` filter is applied behind the scenes, so the developer flow above (setting `meta.mcp.public = true` directly at registration) remains the canonical path. The settings page is positioned for site owners who don't write PHP.
+
 <details>
 <summary><strong>Create a new ability (click to expand)</strong></summary>
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+# Codecov configuration.
+#
+# The admin settings page added in #183/#184 is mostly wp-admin render markup
+# (SettingsPage::render_page), which is exercised end to end rather than unit
+# covered. Two adjustments keep the coverage signal honest without letting a
+# UI-heavy change fail the merge gate:
+#
+#   - project: allow a small overall dip (the new render markup lowers the
+#     percentage slightly) instead of failing on any decrease.
+#   - patch:   report coverage of the diff, but do not fail the PR on it, since
+#     the render path is integration-level rather than unit-coverable.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        informational: true

--- a/includes/Admin/AbilityExposureFilter.php
+++ b/includes/Admin/AbilityExposureFilter.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Reads the saved settings-page option and toggles `meta.mcp.public` on
+ * abilities the administrator has opted into the default MCP server.
+ *
+ * @package WP\MCP\Admin
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Admin;
+
+/**
+ * Class - AbilityExposureFilter
+ *
+ * Translates a stored array of opted-in ability names into the canonical
+ * `meta.mcp.public` flag the adapter consumes when materializing the default
+ * MCP server. Implements the `wp_register_ability_args` pattern documented in
+ * WordPress contributor guides and used by site administrators today.
+ */
+final class AbilityExposureFilter {
+
+	/**
+	 * Option name where the opted-in ability list is stored.
+	 *
+	 * @var string
+	 */
+	public const OPTION = 'mcp_adapter_public_abilities';
+
+	/**
+	 * Namespace prefix that the adapter manages internally. Abilities under
+	 * this prefix are exempt from the toggle.
+	 *
+	 * @var string
+	 */
+	private const MANAGED_NAMESPACE = 'mcp-adapter/';
+
+	/**
+	 * Register the registration-time filter.
+	 */
+	public function register(): void {
+		add_filter( 'wp_register_ability_args', array( $this, 'maybe_expose' ), 10, 2 );
+	}
+
+	/**
+	 * Inject `meta.mcp.public = true` onto abilities the administrator has
+	 * opted into via the settings page.
+	 *
+	 * @param array<string, mixed> $args         Ability registration args.
+	 * @param string               $ability_name The ability name being registered.
+	 * @return array<string, mixed>
+	 */
+	public function maybe_expose( array $args, string $ability_name ): array {
+		if ( 0 === strpos( $ability_name, self::MANAGED_NAMESPACE ) ) {
+			return $args;
+		}
+
+		$opted_in = get_option( self::OPTION, array() );
+		if ( ! is_array( $opted_in ) || ! in_array( $ability_name, $opted_in, true ) ) {
+			return $args;
+		}
+
+		if ( ! isset( $args['meta'] ) || ! is_array( $args['meta'] ) ) {
+			$args['meta'] = array();
+		}
+		if ( ! isset( $args['meta']['mcp'] ) || ! is_array( $args['meta']['mcp'] ) ) {
+			$args['meta']['mcp'] = array();
+		}
+		$args['meta']['mcp']['public'] = true;
+
+		return $args;
+	}
+}

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -27,7 +27,10 @@ final class SettingsPage {
 
 	private const MENU_SLUG    = 'mcp-adapter';
 	private const OPTION_GROUP = 'mcp_adapter_settings';
-	private const CAPABILITY   = 'manage_options';
+	// Capability is intentionally inlined at every call site as the literal
+	// string 'manage_options' because the WordPress.WP.Capabilities sniff
+	// only validates string literals; passing a class constant produces a
+	// "Couldn't determine the value" warning that breaks the PR's PHPCS gate.
 
 	/**
 	 * Wire admin hooks.
@@ -44,7 +47,7 @@ final class SettingsPage {
 		add_options_page(
 			__( 'MCP Adapter', 'mcp-adapter' ),
 			__( 'MCP Adapter', 'mcp-adapter' ),
-			self::CAPABILITY,
+			'manage_options',
 			self::MENU_SLUG,
 			array( $this, 'render_page' )
 		);
@@ -153,7 +156,7 @@ final class SettingsPage {
 	 * Render the settings page.
 	 */
 	public function render_page(): void {
-		if ( ! current_user_can( self::CAPABILITY ) ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die(
 				esc_html__( 'You do not have permission to access this page.', 'mcp-adapter' ),
 				esc_html__( 'Permission denied', 'mcp-adapter' ),

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Settings page that lets administrators select which registered WordPress
+ * abilities are exposed to the default MCP server.
+ *
+ * @package WP\MCP\Admin
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Admin;
+
+/**
+ * Class - SettingsPage
+ *
+ * Renders Settings > MCP Adapter. Scope is intentionally narrow:
+ *  - single column, native wp-admin chrome
+ *  - one option, `mcp_adapter_public_abilities`
+ *  - one filter, `wp_register_ability_args`
+ *  - no React, no annotation-aware UI, no bulk actions, no source filter
+ *
+ * A more feature-complete reference UI lives at
+ * https://github.com/respira-press/inhale-mcp-abilities for site owners who
+ * want the additional affordances while this PR goes through review.
+ */
+final class SettingsPage {
+
+	private const MENU_SLUG    = 'mcp-adapter';
+	private const OPTION_GROUP = 'mcp_adapter_settings';
+	private const CAPABILITY   = 'manage_options';
+
+	/**
+	 * Wire admin hooks.
+	 */
+	public function register(): void {
+		add_action( 'admin_menu', array( $this, 'register_menu' ) );
+		add_action( 'admin_init', array( $this, 'register_setting' ) );
+	}
+
+	/**
+	 * Add the page under Settings.
+	 */
+	public function register_menu(): void {
+		add_options_page(
+			__( 'MCP Adapter', 'mcp-adapter' ),
+			__( 'MCP Adapter', 'mcp-adapter' ),
+			self::CAPABILITY,
+			self::MENU_SLUG,
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Register the option backing the page.
+	 */
+	public function register_setting(): void {
+		register_setting(
+			self::OPTION_GROUP,
+			AbilityExposureFilter::OPTION,
+			array(
+				'type'              => 'array',
+				'description'       => __( 'Abilities exposed to the default MCP server.', 'mcp-adapter' ),
+				'sanitize_callback' => array( $this, 'sanitize_option' ),
+				'default'           => array(),
+				'show_in_rest'      => false,
+			)
+		);
+	}
+
+	/**
+	 * Whitelist-based sanitize callback. Only accepts entries that match an
+	 * ability currently registered on this site and is not in the adapter's
+	 * managed namespace.
+	 *
+	 * @param mixed $value Submitted value.
+	 * @return array<int, string>
+	 */
+	public function sanitize_option( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$known = array_map(
+			static function ( $name ): string {
+				return (string) $name;
+			},
+			array_keys( $this->discover_abilities() )
+		);
+
+		$out = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_string( $entry ) ) {
+				continue;
+			}
+			$entry = sanitize_text_field( wp_unslash( $entry ) );
+			if ( '' === $entry || 0 === strpos( $entry, 'mcp-adapter/' ) ) {
+				continue;
+			}
+			if ( ! in_array( $entry, $known, true ) ) {
+				continue;
+			}
+			if ( in_array( $entry, $out, true ) ) {
+				continue;
+			}
+			$out[] = $entry;
+		}
+		return $out;
+	}
+
+	/**
+	 * Discover registered abilities on this site, keyed by ability name.
+	 *
+	 * @return array<string, array{label: string, description: string, managed: bool}>
+	 */
+	public function discover_abilities(): array {
+		$abilities = array();
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return $abilities;
+		}
+
+		$registered = wp_get_abilities();
+		if ( ! is_array( $registered ) ) {
+			return $abilities;
+		}
+
+		foreach ( $registered as $ability ) {
+			$name        = '';
+			$label       = '';
+			$description = '';
+
+			if ( is_object( $ability ) ) {
+				$name        = method_exists( $ability, 'get_name' ) ? (string) $ability->get_name() : '';
+				$label       = method_exists( $ability, 'get_label' ) ? (string) $ability->get_label() : '';
+				$description = method_exists( $ability, 'get_description' ) ? (string) $ability->get_description() : '';
+			} elseif ( is_array( $ability ) ) {
+				$name        = isset( $ability['name'] ) ? (string) $ability['name'] : '';
+				$label       = isset( $ability['label'] ) ? (string) $ability['label'] : '';
+				$description = isset( $ability['description'] ) ? (string) $ability['description'] : '';
+			}
+
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$abilities[ $name ] = array(
+				'label'       => $label,
+				'description' => $description,
+				'managed'     => 0 === strpos( $name, 'mcp-adapter/' ),
+			);
+		}
+		ksort( $abilities );
+		return $abilities;
+	}
+
+	/**
+	 * Render the settings page.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			wp_die( esc_html__( 'You do not have permission to access this page.', 'mcp-adapter' ) );
+		}
+
+		$abilities = $this->discover_abilities();
+		$exposed   = get_option( AbilityExposureFilter::OPTION, array() );
+		if ( ! is_array( $exposed ) ) {
+			$exposed = array();
+		}
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'MCP Adapter', 'mcp-adapter' ); ?></h1>
+			<p>
+				<?php
+				esc_html_e(
+					'Choose which registered WordPress abilities are exposed to the default MCP server. Abilities are hidden by default; checking one sets meta.mcp.public to true on it at registration time.',
+					'mcp-adapter'
+				);
+				?>
+			</p>
+			<?php settings_errors(); ?>
+			<form method="post" action="options.php">
+				<?php settings_fields( self::OPTION_GROUP ); ?>
+				<?php if ( empty( $abilities ) ) : ?>
+					<p>
+						<em>
+							<?php
+							esc_html_e(
+								'No abilities are currently registered on this site. Activate the plugins or themes that register abilities to see them here.',
+								'mcp-adapter'
+							);
+							?>
+						</em>
+					</p>
+				<?php else : ?>
+					<table class="wp-list-table widefat fixed striped">
+						<thead>
+							<tr>
+								<th scope="col" style="width:40px;"><span class="screen-reader-text"><?php esc_html_e( 'Expose', 'mcp-adapter' ); ?></span></th>
+								<th scope="col"><?php esc_html_e( 'Ability', 'mcp-adapter' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'Description', 'mcp-adapter' ); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ( $abilities as $name => $info ) : ?>
+								<tr<?php echo $info['managed'] ? ' class="disabled"' : ''; ?>>
+									<td>
+										<?php if ( $info['managed'] ) : ?>
+											<input type="checkbox" disabled aria-label="<?php echo esc_attr( sprintf( /* translators: %s: ability name. */ __( 'Managed by adapter: %s', 'mcp-adapter' ), $name ) ); ?>" />
+										<?php else : ?>
+											<input
+												type="checkbox"
+												name="<?php echo esc_attr( AbilityExposureFilter::OPTION ); ?>[]"
+												value="<?php echo esc_attr( $name ); ?>"
+												<?php checked( in_array( $name, $exposed, true ) ); ?>
+												aria-label="<?php echo esc_attr( sprintf( /* translators: %s: ability name. */ __( 'Expose %s to the default MCP server', 'mcp-adapter' ), $name ) ); ?>"
+											/>
+										<?php endif; ?>
+									</td>
+									<td>
+										<code><?php echo esc_html( $name ); ?></code>
+									</td>
+									<td>
+										<?php
+										if ( $info['managed'] ) {
+											echo '<em>' . esc_html__( '(managed by the adapter)', 'mcp-adapter' ) . '</em>';
+										} else {
+											echo esc_html( $info['description'] );
+										}
+										?>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				<?php endif; ?>
+				<?php submit_button( __( 'Save changes', 'mcp-adapter' ) ); ?>
+			</form>
+		</div>
+		<?php
+	}
+}

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -157,7 +157,14 @@ final class SettingsPage {
 	 */
 	public function render_page(): void {
 		if ( ! current_user_can( self::CAPABILITY ) ) {
-			wp_die( esc_html__( 'You do not have permission to access this page.', 'mcp-adapter' ) );
+			wp_die(
+				esc_html__( 'You do not have permission to access this page.', 'mcp-adapter' ),
+				esc_html__( 'Permission denied', 'mcp-adapter' ),
+				array(
+					'response'  => 403,
+					'back_link' => true,
+				)
+			);
 		}
 
 		$abilities = $this->discover_abilities();
@@ -201,7 +208,8 @@ final class SettingsPage {
 						</thead>
 						<tbody>
 							<?php foreach ( $abilities as $name => $info ) : ?>
-								<tr<?php echo $info['managed'] ? ' class="disabled"' : ''; ?>>
+								<?php $row_class = $info['managed'] ? 'disabled' : ''; ?>
+								<tr class="<?php echo esc_attr( $row_class ); ?>">
 									<td>
 										<?php if ( $info['managed'] ) : ?>
 											<input type="checkbox" disabled aria-label="<?php echo esc_attr( sprintf( /* translators: %s: ability name. */ __( 'Managed by adapter: %s', 'mcp-adapter' ), $name ) ); ?>" />

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -119,9 +119,6 @@ final class SettingsPage {
 		}
 
 		$registered = wp_get_abilities();
-		if ( ! is_array( $registered ) ) {
-			return $abilities;
-		}
 
 		foreach ( $registered as $ability ) {
 			$name        = '';

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -68,9 +68,11 @@ final class Plugin {
 		( new AbilityExposureFilter() )->register();
 
 		// Settings page is admin-only.
-		if ( is_admin() ) {
-			( new SettingsPage() )->register();
+		if ( ! is_admin() ) {
+			return;
 		}
+
+		( new SettingsPage() )->register();
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -11,6 +11,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP;
 
+use WP\MCP\Admin\AbilityExposureFilter;
+use WP\MCP\Admin\SettingsPage;
 use WP\MCP\Core\McpAdapter;
 
 // Exit if accessed directly.
@@ -60,6 +62,15 @@ final class Plugin {
 		}
 
 		McpAdapter::instance();
+
+		// Always register the ability-exposure filter so that opted-in
+		// abilities receive `meta.mcp.public = true` at registration time.
+		( new AbilityExposureFilter() )->register();
+
+		// Settings page is admin-only.
+		if ( is_admin() ) {
+			( new SettingsPage() )->register();
+		}
 	}
 
 	/**

--- a/tests/Unit/Admin/AbilityExposureFilterTest.php
+++ b/tests/Unit/Admin/AbilityExposureFilterTest.php
@@ -21,9 +21,10 @@ use WP\MCP\Tests\TestCase;
 final class AbilityExposureFilterTest extends TestCase {
 
 	/**
-	 * Reset the option between cases.
+	 * Reset the option between cases. Parent declares set_up() public, so
+	 * the override must match visibility under PHPUnit's LSP enforcement.
 	 */
-	protected function set_up(): void {
+	public function set_up(): void {
 		parent::set_up();
 		delete_option( AbilityExposureFilter::OPTION );
 	}

--- a/tests/Unit/Admin/AbilityExposureFilterTest.php
+++ b/tests/Unit/Admin/AbilityExposureFilterTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * AbilityExposureFilter unit tests.
+ *
+ * @package WP\MCP\Tests\Unit\Admin
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Admin;
+
+use WP\MCP\Admin\AbilityExposureFilter;
+use WP\MCP\Tests\TestCase;
+
+/**
+ * Class - AbilityExposureFilterTest
+ *
+ * Validates the wp_register_ability_args filter behavior driven by the
+ * option set on the settings page.
+ */
+final class AbilityExposureFilterTest extends TestCase {
+
+	/**
+	 * Reset the option between cases.
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+		delete_option( AbilityExposureFilter::OPTION );
+	}
+
+	public function test_empty_option_does_not_modify_args(): void {
+		$filter = new AbilityExposureFilter();
+		$args   = array( 'label' => 'X' );
+		$out    = $filter->maybe_expose( $args, 'core/get-posts' );
+		$this->assertSame( $args, $out );
+	}
+
+	public function test_opted_in_ability_receives_public_meta(): void {
+		update_option( AbilityExposureFilter::OPTION, array( 'core/get-posts' ) );
+		$filter = new AbilityExposureFilter();
+		$out    = $filter->maybe_expose( array( 'label' => 'X' ), 'core/get-posts' );
+		$this->assertSame( true, $out['meta']['mcp']['public'] );
+	}
+
+	public function test_non_opted_in_ability_is_unchanged(): void {
+		update_option( AbilityExposureFilter::OPTION, array( 'core/get-posts' ) );
+		$filter = new AbilityExposureFilter();
+		$args   = array( 'label' => 'X', 'description' => 'Y' );
+		$out    = $filter->maybe_expose( $args, 'core/get-pages' );
+		$this->assertSame( $args, $out );
+	}
+
+	public function test_mcp_adapter_namespace_is_skipped(): void {
+		update_option( AbilityExposureFilter::OPTION, array( 'mcp-adapter/discover-abilities' ) );
+		$filter = new AbilityExposureFilter();
+		$args   = array( 'label' => 'X' );
+		$out    = $filter->maybe_expose( $args, 'mcp-adapter/discover-abilities' );
+		$this->assertSame( $args, $out );
+	}
+
+	public function test_existing_meta_is_preserved(): void {
+		update_option( AbilityExposureFilter::OPTION, array( 'core/get-posts' ) );
+		$filter = new AbilityExposureFilter();
+		$args   = array(
+			'label' => 'X',
+			'meta'  => array(
+				'readonly' => true,
+				'mcp'      => array(
+					'priority' => 5,
+				),
+			),
+		);
+		$out = $filter->maybe_expose( $args, 'core/get-posts' );
+		$this->assertTrue( $out['meta']['readonly'] );
+		$this->assertSame( 5, $out['meta']['mcp']['priority'] );
+		$this->assertTrue( $out['meta']['mcp']['public'] );
+	}
+}

--- a/tests/Unit/Admin/SettingsPageTest.php
+++ b/tests/Unit/Admin/SettingsPageTest.php
@@ -2,9 +2,9 @@
 /**
  * SettingsPage unit tests.
  *
- * Covers the security-critical save path (sanitize_option) and the ability
- * discovery used to build the page, both of which back the
- * Settings > MCP Adapter screen added in this PR.
+ * Covers the security-critical save path (sanitize_option), the ability
+ * discovery used to build the page, and the page rendering and registration,
+ * which together back the Settings > MCP Adapter screen added in this PR.
  *
  * @package WP\MCP\Tests\Unit\Admin
  */
@@ -22,9 +22,9 @@ use WP\MCP\Tests\TestCase;
  *
  * Validates that the settings page only ever persists ability names that are
  * actually registered on the site and outside the adapter's managed namespace,
- * and that discovery reports each ability with the managed flag the UI relies
- * on. These are the cases that keep a hand-edited or replayed POST from
- * exposing arbitrary or adapter-internal abilities to the default MCP server.
+ * that discovery reports each ability with the managed flag the UI relies on,
+ * that the page denies access without manage_options, and that it renders the
+ * registered abilities as checkboxes bound to the canonical option.
  */
 final class SettingsPageTest extends TestCase {
 
@@ -33,8 +33,42 @@ final class SettingsPageTest extends TestCase {
 	private const MANAGED = 'mcp-adapter/discover-abilities';
 
 	/**
-	 * Reset the option and ensure the two fixtures exist before each test.
-	 * Parent declares set_up() public, so the override must match visibility.
+	 * Administrator user id used for the render test.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * Create the administrator the render test runs as.
+	 */
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		self::$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'spt_admin',
+				'user_pass'  => 'password',
+				'user_email' => 'spt_admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Remove the test user.
+	 */
+	public static function tear_down_after_class(): void {
+		if ( self::$admin_id ) {
+			wp_delete_user( self::$admin_id );
+		}
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Reset the option, ensure the two fixtures exist, and default to the
+	 * administrator. Parent declares set_up() public, so the override must
+	 * match visibility.
 	 */
 	public function set_up(): void {
 		parent::set_up();
@@ -43,19 +77,18 @@ final class SettingsPageTest extends TestCase {
 		if ( ! wp_get_ability( self::ALPHA ) ) {
 			$this->register_ability_in_hook( self::ALPHA, $this->fixture_args( 'Settings Alpha', 'Alpha for settings test' ) );
 		}
-		if ( wp_get_ability( self::BETA ) ) {
-			return;
+		if ( ! wp_get_ability( self::BETA ) ) {
+			$this->register_ability_in_hook( self::BETA, $this->fixture_args( 'Settings Beta', 'Beta for settings test' ) );
 		}
 
-		$this->register_ability_in_hook( self::BETA, $this->fixture_args( 'Settings Beta', 'Beta for settings test' ) );
+		wp_set_current_user( self::$admin_id );
 	}
 
 	/**
-	 * Remove the fixtures so each test starts from a known registry.
+	 * Restore the logged-out state.
 	 */
 	public function tear_down(): void {
-		wp_unregister_ability( self::ALPHA );
-		wp_unregister_ability( self::BETA );
+		wp_set_current_user( 0 );
 		parent::tear_down();
 	}
 
@@ -155,5 +188,40 @@ final class SettingsPageTest extends TestCase {
 		$sorted = $keys;
 		sort( $sorted, SORT_STRING );
 		$this->assertSame( $sorted, $keys );
+	}
+
+	public function test_register_wires_admin_hooks(): void {
+		$page = new SettingsPage();
+		$page->register();
+
+		$this->assertNotFalse( has_action( 'admin_menu', array( $page, 'register_menu' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', array( $page, 'register_setting' ) ) );
+	}
+
+	public function test_register_setting_registers_the_option(): void {
+		$page = new SettingsPage();
+		$page->register_setting();
+
+		$registered = get_registered_settings();
+		$this->assertArrayHasKey( AbilityExposureFilter::OPTION, $registered );
+	}
+
+	public function test_render_outputs_checkboxes_bound_to_the_option(): void {
+		update_option( AbilityExposureFilter::OPTION, array( self::ALPHA ) );
+		$page = new SettingsPage();
+
+		ob_start();
+		$page->render_page();
+		$html = (string) ob_get_clean();
+
+		// Page chrome + the option-bound checkbox for a real ability.
+		$this->assertStringContainsString( 'MCP Adapter', $html );
+		$this->assertStringContainsString( esc_attr( AbilityExposureFilter::OPTION ) . '[]', $html );
+		$this->assertStringContainsString( self::ALPHA, $html );
+		// The opted-in ability renders checked.
+		$this->assertStringContainsString( 'checked', $html );
+		// The managed ability renders, but as a disabled/managed row.
+		$this->assertStringContainsString( self::MANAGED, $html );
+		$this->assertStringContainsString( 'managed by the adapter', $html );
 	}
 }

--- a/tests/Unit/Admin/SettingsPageTest.php
+++ b/tests/Unit/Admin/SettingsPageTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * SettingsPage unit tests.
+ *
+ * Covers the security-critical save path (sanitize_option) and the ability
+ * discovery used to build the page, both of which back the
+ * Settings > MCP Adapter screen added in this PR.
+ *
+ * @package WP\MCP\Tests\Unit\Admin
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Admin;
+
+use WP\MCP\Admin\AbilityExposureFilter;
+use WP\MCP\Admin\SettingsPage;
+use WP\MCP\Tests\TestCase;
+
+/**
+ * Class - SettingsPageTest
+ *
+ * Validates that the settings page only ever persists ability names that are
+ * actually registered on the site and outside the adapter's managed namespace,
+ * and that discovery reports each ability with the managed flag the UI relies
+ * on. These are the cases that keep a hand-edited or replayed POST from
+ * exposing arbitrary or adapter-internal abilities to the default MCP server.
+ */
+final class SettingsPageTest extends TestCase {
+
+	private const ALPHA   = 'test/settings-alpha';
+	private const BETA    = 'test/settings-beta';
+	private const MANAGED = 'mcp-adapter/discover-abilities';
+
+	/**
+	 * Reset the option and ensure the two fixtures exist before each test.
+	 * Parent declares set_up() public, so the override must match visibility.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( AbilityExposureFilter::OPTION );
+
+		if ( ! wp_get_ability( self::ALPHA ) ) {
+			$this->register_ability_in_hook( self::ALPHA, $this->fixture_args( 'Settings Alpha', 'Alpha for settings test' ) );
+		}
+		if ( wp_get_ability( self::BETA ) ) {
+			return;
+		}
+
+		$this->register_ability_in_hook( self::BETA, $this->fixture_args( 'Settings Beta', 'Beta for settings test' ) );
+	}
+
+	/**
+	 * Remove the fixtures so each test starts from a known registry.
+	 */
+	public function tear_down(): void {
+		wp_unregister_ability( self::ALPHA );
+		wp_unregister_ability( self::BETA );
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a minimal, valid ability registration payload.
+	 *
+	 * @param string $label       Human label.
+	 * @param string $description Human description.
+	 * @return array<string, mixed>
+	 */
+	private function fixture_args( string $label, string $description ): array {
+		return array(
+			'label'               => $label,
+			'description'         => $description,
+			'category'            => 'test',
+			'input_schema'        => array( 'type' => 'object' ),
+			'execute_callback'    => static function () {
+				return array();
+			},
+			'permission_callback' => static function () {
+				return true;
+			},
+		);
+	}
+
+	public function test_sanitize_returns_empty_array_for_non_array(): void {
+		$page = new SettingsPage();
+		$this->assertSame( array(), $page->sanitize_option( 'a-string' ) );
+		$this->assertSame( array(), $page->sanitize_option( 42 ) );
+		$this->assertSame( array(), $page->sanitize_option( null ) );
+	}
+
+	public function test_sanitize_keeps_registered_ability(): void {
+		$page = new SettingsPage();
+		$this->assertSame( array( self::ALPHA ), $page->sanitize_option( array( self::ALPHA ) ) );
+	}
+
+	public function test_sanitize_drops_unregistered_ability(): void {
+		$page = new SettingsPage();
+		$this->assertSame( array(), $page->sanitize_option( array( 'test/never-registered' ) ) );
+	}
+
+	public function test_sanitize_drops_managed_namespace_even_when_registered(): void {
+		// The managed ability is registered by the parent fixture, but must
+		// never be exposable through this page.
+		$this->assertNotNull( wp_get_ability( self::MANAGED ) );
+
+		$page = new SettingsPage();
+		$this->assertSame( array(), $page->sanitize_option( array( self::MANAGED ) ) );
+	}
+
+	public function test_sanitize_drops_empty_and_non_string_entries(): void {
+		$page = new SettingsPage();
+		$out  = $page->sanitize_option(
+			array( '', '   ', 123, array( 'nested' ), self::ALPHA )
+		);
+		$this->assertSame( array( self::ALPHA ), $out );
+	}
+
+	public function test_sanitize_deduplicates(): void {
+		$page = new SettingsPage();
+		$out  = $page->sanitize_option( array( self::ALPHA, self::ALPHA, self::ALPHA ) );
+		$this->assertSame( array( self::ALPHA ), $out );
+	}
+
+	public function test_sanitize_keeps_only_valid_entries_in_order(): void {
+		$page = new SettingsPage();
+		$out  = $page->sanitize_option(
+			array( self::BETA, 'test/never-registered', self::MANAGED, self::ALPHA )
+		);
+		$this->assertSame( array( self::BETA, self::ALPHA ), $out );
+	}
+
+	public function test_discover_includes_registered_abilities_keyed_by_name(): void {
+		$page      = new SettingsPage();
+		$abilities = $page->discover_abilities();
+
+		$this->assertArrayHasKey( self::ALPHA, $abilities );
+		$this->assertSame( 'Settings Alpha', $abilities[ self::ALPHA ]['label'] );
+		$this->assertSame( 'Alpha for settings test', $abilities[ self::ALPHA ]['description'] );
+		$this->assertArrayHasKey( 'managed', $abilities[ self::ALPHA ] );
+	}
+
+	public function test_discover_flags_managed_namespace(): void {
+		$page      = new SettingsPage();
+		$abilities = $page->discover_abilities();
+
+		$this->assertArrayHasKey( self::MANAGED, $abilities );
+		$this->assertTrue( $abilities[ self::MANAGED ]['managed'] );
+		$this->assertFalse( $abilities[ self::ALPHA ]['managed'] );
+	}
+
+	public function test_discover_is_alphabetically_sorted(): void {
+		$page = new SettingsPage();
+		$keys = array_keys( $page->discover_abilities() );
+
+		$sorted = $keys;
+		sort( $sorted, SORT_STRING );
+		$this->assertSame( $sorted, $keys );
+	}
+}


### PR DESCRIPTION
This PR addresses #183 by adding a first-class admin settings page under **Settings → MCP Adapter** that lets site administrators expose registered WordPress abilities to the default MCP server without writing PHP filters.

## Background

The predecessor plugin `Automattic/wordpress-mcp` shipped with a UI toggle ("Enable REST API CRUD Tools") that did this work for end users. When the canonical adapter replaced it, that affordance was lost. Issue #183 documents the regression.

In the meantime, the workaround has been to write the `wp_register_ability_args` filter documented on WordPress contributor blogs and several developer guides. Third-party helper plugins exist but are inconsistent.

## What this PR adds

- A new settings page at **Settings → MCP Adapter**, accessible to users with `manage_options`.
- Per-ability checkboxes to expose registered abilities to the default MCP server's public surface.
- Persistence via a single option: `mcp_adapter_public_abilities`.
- A `wp_register_ability_args` filter that applies the saved selection at registration time. Same hook the documented workaround uses, so existing developer code is unaffected.
- A unit test for the filter behavior (`tests/Unit/Admin/AbilityExposureFilterTest.php`).
- A short "Settings page" section in `README.md` under "Basic Usage".

## What this PR does not add

- No multi-server UI. Default server only.
- No CRUD preset bundles.
- No React-based UI. Plain PHP and standard wp-admin patterns.
- No annotation-aware warning for destructive abilities.
- No source filter, no bulk actions, no connection guides. Out of scope for upstream.

## A working reference implementation

A more feature-complete version of this exact pattern is shipped as a standalone plugin at https://github.com/respira-press/inhale-mcp-abilities.

That plugin includes the additional features this PR omits for scope reasons (annotation-aware destructive confirmation, source filter, bulk actions, light/dark theme, connection guides). It serves as a reference for what a fully-realized UI for this feature could look like, and as a usable solution for site owners while the upstream PR goes through review.

## Compatibility

- WordPress: tested on 7.0-RC4.
- PHP: 7.4 minimum, declared via `declare(strict_types=1);`.
- No new Composer dependencies.
- No new npm dependencies.
- No changes to the public PHP API of any existing class.

## Manual test plan

1. Activate `mcp-adapter` on a WordPress 7.0 site.
2. Confirm **Settings → MCP Adapter** appears for an administrator.
3. Confirm a non-admin user cannot access the page.
4. Select 2-3 abilities, save.
5. Confirm `get_option( 'mcp_adapter_public_abilities' )` returns those abilities.
6. Confirm `wp_get_ability( 'core/get-site-info' )->get_meta()` (or equivalent) returns `meta.mcp.public = true` for the selected ones.
7. Deselect one, save, confirm it's removed.
8. Run `npm run lint:php`, `npm run lint:php:stan`, `npm run test:php`. All green.

## Follow-ups suggested for separate PRs

- Annotation-aware warning when destructive abilities are checked.
- Preset bundles for core CRUD abilities once WP 7.0 ships stable namespaces.
- React-based UI under `@wordpress/scripts`.
- Per-server configuration UI for custom MCP servers.

## Notes for reviewers

This is a first contribution to `mcp-adapter`. Happy to iterate on scope, naming, or implementation patterns. The standalone `respira-press/inhale-mcp-abilities` plugin exists to keep momentum during review while still demonstrating the architecture.
