### PR TITLE
fix: Prevent direct file access on PHP files

### DIFF
--- a/includes/Autoloader.php
+++ b/includes/Autoloader.php
@@ -13,6 +13,9 @@ declare( strict_types=1 );
 
 namespace WP\MCP;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Class - Autoloader
  */

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -20,6 +20,9 @@ use WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler;
 use WP\MCP\Servers\DefaultServerFactory;
 use WP_Error;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
 /**
  * WordPress MCP Registry - Main class for managing multiple MCP servers.
  */

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -13,6 +13,9 @@ namespace WP\MCP;
 
 use WP\MCP\Core\McpAdapter;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Class - Plugin
  */

--- a/includes/Transport/HttpTransport.php
+++ b/includes/Transport/HttpTransport.php
@@ -20,6 +20,9 @@ use WP\MCP\Transport\Infrastructure\HttpRequestHandler;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
 use WP\MCP\Transport\Infrastructure\McpTransportHelperTrait;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
 /**
  * MCP HTTP Transport - Unified transport for both proxy and direct clients
  *

--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -12,6 +12,9 @@ namespace WP\MCP\Transport\Infrastructure;
 use WP\MCP\Core\McpVersionNegotiator;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Handles HTTP request routing and processing for MCP transports.
  *


### PR DESCRIPTION
## What

This PR adds `defined( 'ABSPATH' ) || exit;` to the PHP files that are missing it

## Why

Remediates PCP Issues detected as a result of #187 .

- Part of https://github.com/WordPress/mcp-adapter/issues/178