### PR TITLE
feat: add mcp_adapter_server_config filter to McpServer constructor

### DIFF
--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -143,6 +143,56 @@ class McpServer {
 		array $prompts = array(),
 		?callable $transport_permission_callback = null
 	) {
+		/**
+		 * Filters the configuration of any MCP server before it is applied.
+		 *
+		 * Fires for ALL servers during construction — including custom servers created
+		 * via the mcp_adapter_init action. Use $config['server_id'] or the $server_id
+		 * parameter to target a specific server or apply changes to all servers.
+		 *
+		 * @since 0.6.0
+		 *
+		 * @param array  $config {
+		 *     Server configuration array.
+		 *
+		 *     @type string   $server_id              Server identifier.
+		 *     @type string   $server_route_namespace REST API namespace.
+		 *     @type string   $server_route           REST API route.
+		 *     @type string   $server_name            Human-readable server name.
+		 *     @type string   $server_description     Server description.
+		 *     @type string   $server_version         Server version.
+		 *     @type string[] $tools                  Ability names to expose as tools.
+		 *     @type string[] $resources              Ability names to expose as resources.
+		 *     @type string[] $prompts                Ability names to expose as prompts.
+		 * }
+		 * @param string $server_id The server identifier (convenience — same as $config['server_id']).
+		 */
+		$config = apply_filters(
+			'mcp_adapter_server_config',
+			array(
+				'server_id'              => $server_id,
+				'server_route_namespace' => $server_route_namespace,
+				'server_route'           => $server_route,
+				'server_name'            => $server_name,
+				'server_description'     => $server_description,
+				'server_version'         => $server_version,
+				'tools'                  => $tools,
+				'resources'              => $resources,
+				'prompts'                => $prompts,
+			),
+			$server_id
+		);
+
+		$server_id              = isset( $config['server_id'] ) && is_string( $config['server_id'] ) ? $config['server_id'] : $server_id;
+		$server_route_namespace = isset( $config['server_route_namespace'] ) && is_string( $config['server_route_namespace'] ) ? $config['server_route_namespace'] : $server_route_namespace;
+		$server_route           = isset( $config['server_route'] ) && is_string( $config['server_route'] ) ? $config['server_route'] : $server_route;
+		$server_name            = isset( $config['server_name'] ) && is_string( $config['server_name'] ) ? $config['server_name'] : $server_name;
+		$server_description     = isset( $config['server_description'] ) && is_string( $config['server_description'] ) ? $config['server_description'] : $server_description;
+		$server_version         = isset( $config['server_version'] ) && is_string( $config['server_version'] ) ? $config['server_version'] : $server_version;
+		$tools                  = isset( $config['tools'] ) && is_array( $config['tools'] ) ? $config['tools'] : $tools;
+		$resources              = isset( $config['resources'] ) && is_array( $config['resources'] ) ? $config['resources'] : $resources;
+		$prompts                = isset( $config['prompts'] ) && is_array( $config['prompts'] ) ? $config['prompts'] : $prompts;
+
 		// Store server configuration
 		$this->server_id                     = $server_id;
 		$this->server_route_namespace        = $server_route_namespace;

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -84,6 +84,134 @@ final class McpServerTest extends TestCase {
 		$this->assertEmpty( $server_tools );
 	}
 
+	public function test_server_config_filter_can_modify_name_and_description(): void {
+		add_filter(
+			'mcp_adapter_server_config',
+			function ( array $config ) {
+				$config['server_name']        = 'Filtered Name';
+				$config['server_description'] = 'Filtered Description';
+				return $config;
+			}
+		);
+
+		$server = new McpServer(
+			'test-server',
+			'mcp/v1',
+			'/mcp',
+			'Original Name',
+			'Original Description',
+			'0.1.0',
+			array( DummyTransport::class ),
+			NullMcpErrorHandler::class,
+			NullMcpObservabilityHandler::class,
+		);
+
+		$this->assertSame( 'Filtered Name', $server->get_server_name() );
+		$this->assertSame( 'Filtered Description', $server->get_server_description() );
+
+		remove_all_filters( 'mcp_adapter_server_config' );
+	}
+
+	public function test_server_config_filter_receives_server_id_as_second_param(): void {
+		$received_server_id = null;
+
+		add_filter(
+			'mcp_adapter_server_config',
+			function ( array $config, string $server_id ) use ( &$received_server_id ) {
+				$received_server_id = $server_id;
+				return $config;
+			},
+			10,
+			2
+		);
+
+		new McpServer(
+			'my-custom-server',
+			'mcp/v1',
+			'/mcp',
+			'Test',
+			'Test',
+			'0.1.0',
+			array( DummyTransport::class ),
+			NullMcpErrorHandler::class,
+			NullMcpObservabilityHandler::class,
+		);
+
+		$this->assertSame( 'my-custom-server', $received_server_id );
+
+		remove_all_filters( 'mcp_adapter_server_config' );
+	}
+
+	public function test_server_config_filter_can_target_specific_server(): void {
+		add_filter(
+			'mcp_adapter_server_config',
+			function ( array $config, string $server_id ) {
+				if ( 'target-server' === $server_id ) {
+					$config['server_name'] = 'Modified';
+				}
+				return $config;
+			},
+			10,
+			2
+		);
+
+		$target = new McpServer(
+			'target-server',
+			'mcp/v1',
+			'/mcp',
+			'Original',
+			'Desc',
+			'0.1.0',
+			array( DummyTransport::class ),
+			NullMcpErrorHandler::class,
+			NullMcpObservabilityHandler::class,
+		);
+
+		$other = new McpServer(
+			'other-server',
+			'mcp/v1',
+			'/mcp',
+			'Original',
+			'Desc',
+			'0.1.0',
+			array( DummyTransport::class ),
+			NullMcpErrorHandler::class,
+			NullMcpObservabilityHandler::class,
+		);
+
+		$this->assertSame( 'Modified', $target->get_server_name() );
+		$this->assertSame( 'Original', $other->get_server_name() );
+
+		remove_all_filters( 'mcp_adapter_server_config' );
+	}
+
+	public function test_server_config_filter_invalid_types_fall_back_to_original(): void {
+		add_filter(
+			'mcp_adapter_server_config',
+			function ( array $config ) {
+				$config['server_name'] = 12345;   // Invalid — not a string.
+				$config['tools']       = 'bad';   // Invalid — not an array.
+				return $config;
+			}
+		);
+
+		$server = new McpServer(
+			'test-server',
+			'mcp/v1',
+			'/mcp',
+			'Original Name',
+			'Desc',
+			'0.1.0',
+			array( DummyTransport::class ),
+			NullMcpErrorHandler::class,
+			NullMcpObservabilityHandler::class,
+		);
+
+		$this->assertSame( 'Original Name', $server->get_server_name() );
+
+		remove_all_filters( 'mcp_adapter_server_config' );
+	}
+
 	public function test_validation_flag_is_configurable(): void {
 		// Test with validation enabled
 		add_filter( 'mcp_adapter_validation_enabled', '__return_true' );


### PR DESCRIPTION
## Summary

Adds a `mcp_adapter_server_config` filter to `McpServer::__construct()` that fires for **all** MCP servers during construction, allowing modification of server name, route, tools, resources, prompts, and other configuration before it is applied.

Closes #190

## What Changed

**`includes/Core/McpServer.php`**
- Packs all constructor parameters into a `$config` array at the top of `__construct()`
- Applies `mcp_adapter_server_config` filter with `($config, $server_id)`
- Unpacks the filtered config back with type guards (invalid types fall back to original values)
- Properties are then assigned as before — no other logic changes

**`tests/Unit/McpServerTest.php`**
- `test_server_config_filter_can_modify_name_and_description` — basic modification works
- `test_server_config_filter_receives_server_id_as_second_param` — second param is correct
- `test_server_config_filter_can_target_specific_server` — per-server targeting works, other servers unaffected
- `test_server_config_filter_invalid_types_fall_back_to_original` — bad return types do not corrupt server state

## Usage Example

```php
add_filter(
    'mcp_adapter_server_config',
    function ( array $config, string $server_id ) {
        // Remove an ability from all servers.
        $config['tools'] = array_diff( $config['tools'], array( 'core/get-environment-info' ) );

        // Rename a specific server.
        if ( 'mcp-adapter-default-server' === $server_id ) {
            $config['server_name'] = 'My Custom Server Name';
        }

        return $config;
    },
    10,
    2
);
```

## Relationship to `mcp_adapter_default_server_config`

`mcp_adapter_default_server_config` fires inside `DefaultServerFactory` before the default server is constructed — it shapes the config before it reaches `McpServer::__construct()`. The new `mcp_adapter_server_config` fires inside `__construct()` itself, covering all servers regardless of how they were created. The two filters are complementary, not redundant.

## Test plan

- [ ] Existing `McpServerTest` passes
- [ ] Four new test cases pass
- [ ] Filter does not fire for servers that bypass `__construct()` (none currently do)
- [ ] Invalid return types from filter do not break server construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)