### PR TITLE
Fix: WP_CLI::line() in serve command corrupts JSON-RPC stdout stream

### DIFF
--- a/includes/Cli/McpCommand.php
+++ b/includes/Cli/McpCommand.php
@@ -75,7 +75,7 @@ class McpCommand extends \WP_CLI_Command { // phpcs:ignore
 			// Use the first available server
 			$server    = array_values( $servers )[0];
 			$server_id = $server->get_server_id();
-			\WP_CLI::line( sprintf( 'Using server: %s', $server_id ) );
+			\WP_CLI::debug( sprintf( 'Using server: %s', $server_id ) );
 		}
 
 		// Set user context if specified


### PR DESCRIPTION
## Problem

When `wp mcp-adapter serve` is called without a `--server` flag, it falls back to the first registered server and calls `WP_CLI::line()` to report the selection:

```php
\WP_CLI::line( sprintf( 'Using server: %s', $server_id ) );
```

`WP_CLI::line()` writes to **stdout**. The `serve` command communicates with MCP clients over STDIO using the JSON-RPC 2.0 protocol, so anything written to stdout before the first `{` is treated as part of the protocol stream. This causes the client's JSON parser to fail immediately.

**Real-world impact:** Any MCP client using STDIO transport (Claude Code, VS Code Copilot, Cursor, etc.) that omits `--server` will fail to connect. Workarounds require piping output through `grep '^{'` to strip the non-JSON line.

## Fix

Change `WP_CLI::line()` to `WP_CLI::debug()`. Debug output goes to **stderr** and is suppressed by default, so:
- Normal usage is unaffected
- The message is still visible when running with `--debug`
- The JSON-RPC stream on stdout is clean

## Change

`includes/Cli/McpCommand.php` line 78:

```diff
- \WP_CLI::line( sprintf( 'Using server: %s', $server_id ) );
+ \WP_CLI::debug( sprintf( 'Using server: %s', $server_id ) );
```