### PR TITLE
fix: handle non-UTF-8 bytes in tool results to prevent transport close

### DIFF
--- a/includes/Cli/StdioServerBridge.php
+++ b/includes/Cli/StdioServerBridge.php
@@ -289,10 +289,7 @@ class StdioServerBridge {
 	 */
 	private function encode_response( array $response ): string {
 		// See ToolsHandler::call_tool for the parallel fix on the HTTP transport (issue #195).
-		$encode_flags = JSON_UNESCAPED_SLASHES
-			| JSON_UNESCAPED_UNICODE
-			| JSON_INVALID_UTF8_SUBSTITUTE
-			| JSON_PARTIAL_OUTPUT_ON_ERROR;
+		$encode_flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
 		$json         = wp_json_encode( $response, $encode_flags );
 
 		if ( false === $json ) {
@@ -311,10 +308,6 @@ class StdioServerBridge {
 				McpErrorFactory::INTERNAL_ERROR,
 				$id_json
 			);
-		}
-
-		if ( JSON_ERROR_NONE !== json_last_error() ) {
-			$this->log_to_stderr( sprintf( 'Response JSON-encoded with substitution: %s', json_last_error_msg() ) );
 		}
 
 		return $json;

--- a/includes/Cli/StdioServerBridge.php
+++ b/includes/Cli/StdioServerBridge.php
@@ -288,13 +288,29 @@ class StdioServerBridge {
 	 * @return string JSON-encoded response string.
 	 */
 	private function encode_response( array $response ): string {
-		$json = wp_json_encode( $response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		// JSON_INVALID_UTF8_SUBSTITUTE + JSON_PARTIAL_OUTPUT_ON_ERROR ensure a single bad byte
+		// in the payload does not cause an empty stdout line and a "Connection closed" symptom
+		// at the client. See ToolsHandler::call_tool for the parallel fix on the HTTP transport.
+		$json = wp_json_encode(
+			$response,
+			JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR
+		);
 
 		if ( false === $json ) {
-			// Fallback when JSON encoding fails - use constant for consistency.
+			$this->log_to_stderr( sprintf( 'Response could not be JSON-encoded: %s', json_last_error_msg() ) );
+
+			// Preserve the original request id so client-side JSON-RPC correlation still works.
+			$id_json = isset( $response['id'] )
+				? wp_json_encode( $response['id'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR )
+				: 'null';
+			if ( false === $id_json || null === $id_json ) {
+				$id_json = 'null';
+			}
+
 			return sprintf(
-				'{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"},"id":null}',
-				McpErrorFactory::INTERNAL_ERROR
+				'{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error: response could not be encoded"},"id":%s}',
+				McpErrorFactory::INTERNAL_ERROR,
+				$id_json
 			);
 		}
 

--- a/includes/Cli/StdioServerBridge.php
+++ b/includes/Cli/StdioServerBridge.php
@@ -288,22 +288,21 @@ class StdioServerBridge {
 	 * @return string JSON-encoded response string.
 	 */
 	private function encode_response( array $response ): string {
-		// JSON_INVALID_UTF8_SUBSTITUTE + JSON_PARTIAL_OUTPUT_ON_ERROR ensure a single bad byte
-		// in the payload does not cause an empty stdout line and a "Connection closed" symptom
-		// at the client. See ToolsHandler::call_tool for the parallel fix on the HTTP transport.
-		$json = wp_json_encode(
-			$response,
-			JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR
-		);
+		// See ToolsHandler::call_tool for the parallel fix on the HTTP transport (issue #195).
+		$encode_flags = JSON_UNESCAPED_SLASHES
+			| JSON_UNESCAPED_UNICODE
+			| JSON_INVALID_UTF8_SUBSTITUTE
+			| JSON_PARTIAL_OUTPUT_ON_ERROR;
+		$json         = wp_json_encode( $response, $encode_flags );
 
 		if ( false === $json ) {
 			$this->log_to_stderr( sprintf( 'Response could not be JSON-encoded: %s', json_last_error_msg() ) );
 
 			// Preserve the original request id so client-side JSON-RPC correlation still works.
 			$id_json = isset( $response['id'] )
-				? wp_json_encode( $response['id'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR )
+				? wp_json_encode( $response['id'], $encode_flags )
 				: 'null';
-			if ( false === $id_json || null === $id_json ) {
+			if ( false === $id_json ) {
 				$id_json = 'null';
 			}
 
@@ -312,6 +311,10 @@ class StdioServerBridge {
 				McpErrorFactory::INTERNAL_ERROR,
 				$id_json
 			);
+		}
+
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			$this->log_to_stderr( sprintf( 'Response JSON-encoded with substitution: %s', json_last_error_msg() ) );
 		}
 
 		return $json;

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -321,13 +321,10 @@ class ToolsHandler {
 
 			// Re-derive structuredContent from the sanitized text so the outer WP REST envelope
 			// (default flags) cannot trip on bytes that the inner encode tolerated.
-			$decoded    = json_decode( $json_text, true );
-			$structured = null === $decoded && 'null' !== $json_text ? $result : $decoded;
-
 			return CallToolResult::fromArray(
 				array(
 					'content'           => array( ContentBlockHelper::text( $json_text ) ),
-					'structuredContent' => $structured,
+					'structuredContent' => json_decode( $json_text, true ),
 					'isError'           => false,
 				)
 			);

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -295,10 +295,9 @@ class ToolsHandler {
 				);
 			}
 
-			// Standard result - JSON-encode for text content, include as structuredContent.
-			// Use UTF-8-tolerant flags so a single bad byte (e.g. from a copy-pasted smart quote
-			// or a binary blob in a custom field) does not cause an empty response body and the
-			// "MCP error -32000: Connection closed" downstream symptom.
+			// JSON_INVALID_UTF8_SUBSTITUTE keeps a single bad byte from emptying the response
+			// (see issue #195). JSON_PARTIAL_OUTPUT_ON_ERROR keeps depth/recursion errors from
+			// the same fate but can still flag json_last_error() on success.
 			$encode_flags = JSON_UNESCAPED_SLASHES
 				| JSON_UNESCAPED_UNICODE
 				| JSON_INVALID_UTF8_SUBSTITUTE
@@ -307,26 +306,47 @@ class ToolsHandler {
 
 			if ( false === $json_text ) {
 				$this->mcp->get_error_handler()->log(
-					'Tool result could not be JSON-encoded',
+					'Tool result could not be JSON-encoded; emitting empty payload',
 					array(
 						'tool'       => $request_params['name'] ?? 'unknown',
 						'json_error' => json_last_error_msg(),
 					)
 				);
 
-				return $this->create_error_result(
-					sprintf(
-						/* translators: %s: JSON error message */
-						__( 'Tool result could not be serialized: %s', 'mcp-adapter' ),
-						json_last_error_msg()
+				return CallToolResult::fromArray(
+					array(
+						'content'           => array( ContentBlockHelper::text( '{}' ) ),
+						'structuredContent' => null,
+						'isError'           => false,
 					)
+				);
+			}
+
+			// Snapshot before json_decode below overwrites json_last_error().
+			$encode_error_code = json_last_error();
+			$encode_error_msg  = json_last_error_msg();
+
+			// Re-derive structuredContent from the sanitized text so the outer WP REST envelope
+			// (default flags) cannot trip on bytes that the inner encode tolerated. UTF-8
+			// substitution is silent in json_last_error(), so we cannot gate this on the error.
+			$decoded    = json_decode( $json_text, true );
+			$structured = null === $decoded && 'null' !== $json_text ? $result : $decoded;
+
+			if ( JSON_ERROR_NONE !== $encode_error_code ) {
+				$this->mcp->get_error_handler()->log(
+					'Tool result JSON-encoded with substitution',
+					array(
+						'tool'       => $request_params['name'] ?? 'unknown',
+						'json_error' => $encode_error_msg,
+					),
+					'warning'
 				);
 			}
 
 			return CallToolResult::fromArray(
 				array(
 					'content'           => array( ContentBlockHelper::text( $json_text ) ),
-					'structuredContent' => $result,
+					'structuredContent' => $structured,
 					'isError'           => false,
 				)
 			);

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -296,12 +296,9 @@ class ToolsHandler {
 			}
 
 			// JSON_INVALID_UTF8_SUBSTITUTE keeps a single bad byte from emptying the response
-			// (see issue #195). JSON_PARTIAL_OUTPUT_ON_ERROR keeps depth/recursion errors from
-			// the same fate but can still flag json_last_error() on success.
-			$encode_flags = JSON_UNESCAPED_SLASHES
-				| JSON_UNESCAPED_UNICODE
-				| JSON_INVALID_UTF8_SUBSTITUTE
-				| JSON_PARTIAL_OUTPUT_ON_ERROR;
+			// (see issue #195). Other failure modes (depth, recursion, NAN, resources) fall
+			// through to the false-branch below instead of being silently substituted.
+			$encode_flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
 			$json_text    = wp_json_encode( $result, $encode_flags );
 
 			if ( false === $json_text ) {
@@ -322,26 +319,10 @@ class ToolsHandler {
 				);
 			}
 
-			// Snapshot before json_decode below overwrites json_last_error().
-			$encode_error_code = json_last_error();
-			$encode_error_msg  = json_last_error_msg();
-
 			// Re-derive structuredContent from the sanitized text so the outer WP REST envelope
-			// (default flags) cannot trip on bytes that the inner encode tolerated. UTF-8
-			// substitution is silent in json_last_error(), so we cannot gate this on the error.
+			// (default flags) cannot trip on bytes that the inner encode tolerated.
 			$decoded    = json_decode( $json_text, true );
 			$structured = null === $decoded && 'null' !== $json_text ? $result : $decoded;
-
-			if ( JSON_ERROR_NONE !== $encode_error_code ) {
-				$this->mcp->get_error_handler()->log(
-					'Tool result JSON-encoded with substitution',
-					array(
-						'tool'       => $request_params['name'] ?? 'unknown',
-						'json_error' => $encode_error_msg,
-					),
-					'warning'
-				);
-			}
 
 			return CallToolResult::fromArray(
 				array(

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -296,9 +296,31 @@ class ToolsHandler {
 			}
 
 			// Standard result - JSON-encode for text content, include as structuredContent.
-			$json_text = wp_json_encode( $result );
+			// Use UTF-8-tolerant flags so a single bad byte (e.g. from a copy-pasted smart quote
+			// or a binary blob in a custom field) does not cause an empty response body and the
+			// "MCP error -32000: Connection closed" downstream symptom.
+			$encode_flags = JSON_UNESCAPED_SLASHES
+				| JSON_UNESCAPED_UNICODE
+				| JSON_INVALID_UTF8_SUBSTITUTE
+				| JSON_PARTIAL_OUTPUT_ON_ERROR;
+			$json_text    = wp_json_encode( $result, $encode_flags );
+
 			if ( false === $json_text ) {
-				$json_text = '{}';
+				$this->mcp->get_error_handler()->log(
+					'Tool result could not be JSON-encoded',
+					array(
+						'tool'       => $request_params['name'] ?? 'unknown',
+						'json_error' => json_last_error_msg(),
+					)
+				);
+
+				return $this->create_error_result(
+					sprintf(
+						/* translators: %s: JSON error message */
+						__( 'Tool result could not be serialized: %s', 'mcp-adapter' ),
+						json_last_error_msg()
+					)
+				);
 			}
 
 			return CallToolResult::fromArray(

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -298,8 +298,7 @@ class ToolsHandler {
 			// JSON_INVALID_UTF8_SUBSTITUTE keeps a single bad byte from emptying the response
 			// (see issue #195). Other failure modes (depth, recursion, NAN, resources) fall
 			// through to the false-branch below instead of being silently substituted.
-			$encode_flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
-			$json_text    = wp_json_encode( $result, $encode_flags );
+			$json_text = wp_json_encode( $result, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE );
 
 			if ( false === $json_text ) {
 				$this->mcp->get_error_handler()->log(

--- a/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
+++ b/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
@@ -673,6 +673,50 @@ final class StdioServerBridgeTest extends TestCase {
 		$this->assertEquals( -32601, $response['error']['code'] ); // Method not found
 	}
 
+	/**
+	 * Regression: previously wp_json_encode() in encode_response() ran with only
+	 * UNESCAPED_SLASHES|UNESCAPED_UNICODE, so a single non-UTF-8 byte returned
+	 * false and the fallback dropped the request id, breaking JSON-RPC
+	 * correlation on the client. With the fix the byte is substituted and the
+	 * normal encoded response (with id preserved) is emitted.
+	 *
+	 * @see https://github.com/WordPress/mcp-adapter/issues/195
+	 */
+	public function test_encode_response_tolerates_non_utf8_bytes_in_payload(): void {
+		$reflection             = new \ReflectionClass( $this->bridge );
+		$encode_response_method = $reflection->getMethod( 'encode_response' );
+		$encode_response_method->setAccessible( true );
+
+		$response = array(
+			'jsonrpc' => '2.0',
+			'id'      => 7,
+			'result'  => array(
+				'content' => array(
+					array(
+						'type' => 'text',
+						// 0x80 is not a valid leading byte for any UTF-8 sequence.
+						'text' => "before \x80 after",
+					),
+				),
+			),
+		);
+
+		$encoded = $encode_response_method->invoke( $this->bridge, $response );
+
+		$this->assertIsString( $encoded );
+		$this->assertStringNotContainsString(
+			'response could not be encoded',
+			$encoded,
+			'Bad byte should be substituted, not trigger the encode-failure fallback.'
+		);
+
+		$decoded = json_decode( $encoded, true );
+		$this->assertIsArray( $decoded );
+		$this->assertSame( '2.0', $decoded['jsonrpc'] );
+		$this->assertSame( 7, $decoded['id'], 'Request id must round-trip even when the payload contained bad bytes.' );
+		$this->assertArrayHasKey( 'result', $decoded );
+	}
+
 	public function test_handle_request_with_missing_params(): void {
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );

--- a/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
+++ b/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
@@ -673,15 +673,7 @@ final class StdioServerBridgeTest extends TestCase {
 		$this->assertEquals( -32601, $response['error']['code'] ); // Method not found
 	}
 
-	/**
-	 * Regression: previously wp_json_encode() in encode_response() ran with only
-	 * UNESCAPED_SLASHES|UNESCAPED_UNICODE, so a single non-UTF-8 byte returned
-	 * false and the fallback dropped the request id, breaking JSON-RPC
-	 * correlation on the client. With the fix the byte is substituted and the
-	 * normal encoded response (with id preserved) is emitted.
-	 *
-	 * @see https://github.com/WordPress/mcp-adapter/issues/195
-	 */
+	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
 	public function test_encode_response_tolerates_non_utf8_bytes_in_payload(): void {
 		$reflection             = new \ReflectionClass( $this->bridge );
 		$encode_response_method = $reflection->getMethod( 'encode_response' );
@@ -694,7 +686,6 @@ final class StdioServerBridgeTest extends TestCase {
 				'content' => array(
 					array(
 						'type' => 'text',
-						// 0x80 is not a valid leading byte for any UTF-8 sequence.
 						'text' => "before \x80 after",
 					),
 				),
@@ -704,17 +695,44 @@ final class StdioServerBridgeTest extends TestCase {
 		$encoded = $encode_response_method->invoke( $this->bridge, $response );
 
 		$this->assertIsString( $encoded );
-		$this->assertStringNotContainsString(
-			'response could not be encoded',
-			$encoded,
-			'Bad byte should be substituted, not trigger the encode-failure fallback.'
-		);
+		$this->assertStringNotContainsString( 'response could not be encoded', $encoded );
 
 		$decoded = json_decode( $encoded, true );
 		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'jsonrpc', $decoded );
 		$this->assertSame( '2.0', $decoded['jsonrpc'] );
-		$this->assertSame( 7, $decoded['id'], 'Request id must round-trip even when the payload contained bad bytes.' );
+		$this->assertArrayHasKey( 'id', $decoded );
+		$this->assertSame( 7, $decoded['id'] );
 		$this->assertArrayHasKey( 'result', $decoded );
+	}
+
+	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
+	public function test_encode_response_preserves_id_on_partial_output_substitution(): void {
+		$reflection             = new \ReflectionClass( $this->bridge );
+		$encode_response_method = $reflection->getMethod( 'encode_response' );
+		$encode_response_method->setAccessible( true );
+
+		// Depth >512 flags JSON_ERROR_DEPTH on a PARTIAL_OUTPUT_ON_ERROR encode — the call
+		// succeeds with substitution but should still round-trip the request id.
+		$deep = 'leaf';
+		for ( $i = 0; $i < 600; $i++ ) {
+			$deep = array( $deep );
+		}
+
+		$response = array(
+			'jsonrpc' => '2.0',
+			'id'      => 'req-42',
+			'result'  => array( 'nested' => $deep ),
+		);
+
+		$encoded = $encode_response_method->invoke( $this->bridge, $response );
+
+		$this->assertIsString( $encoded );
+		$this->assertStringNotContainsString( 'response could not be encoded', $encoded );
+		// json_decode default depth (512) can't read the 600-deep output, so assert on the
+		// raw string instead — we only care that jsonrpc + id round-tripped, not the payload.
+		$this->assertStringContainsString( '"jsonrpc":"2.0"', $encoded );
+		$this->assertStringContainsString( '"id":"req-42"', $encoded );
 	}
 
 	public function test_handle_request_with_missing_params(): void {

--- a/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
+++ b/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
@@ -707,13 +707,13 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
-	public function test_encode_response_preserves_id_on_partial_output_substitution(): void {
+	public function test_encode_response_fallback_preserves_id_when_payload_unencodable(): void {
 		$reflection             = new \ReflectionClass( $this->bridge );
 		$encode_response_method = $reflection->getMethod( 'encode_response' );
 		$encode_response_method->setAccessible( true );
 
-		// Depth >512 flags JSON_ERROR_DEPTH on a PARTIAL_OUTPUT_ON_ERROR encode — the call
-		// succeeds with substitution but should still round-trip the request id.
+		// Depth >512 triggers JSON_ERROR_DEPTH; without PARTIAL_OUTPUT_ON_ERROR
+		// wp_json_encode returns false, hitting the fallback path.
 		$deep = 'leaf';
 		for ( $i = 0; $i < 600; $i++ ) {
 			$deep = array( $deep );
@@ -728,11 +728,15 @@ final class StdioServerBridgeTest extends TestCase {
 		$encoded = $encode_response_method->invoke( $this->bridge, $response );
 
 		$this->assertIsString( $encoded );
-		$this->assertStringNotContainsString( 'response could not be encoded', $encoded );
-		// json_decode default depth (512) can't read the 600-deep output, so assert on the
-		// raw string instead — we only care that jsonrpc + id round-tripped, not the payload.
-		$this->assertStringContainsString( '"jsonrpc":"2.0"', $encoded );
-		$this->assertStringContainsString( '"id":"req-42"', $encoded );
+		$this->assertStringContainsString( 'response could not be encoded', $encoded );
+
+		$decoded = json_decode( $encoded, true );
+		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'jsonrpc', $decoded );
+		$this->assertSame( '2.0', $decoded['jsonrpc'] );
+		$this->assertArrayHasKey( 'id', $decoded );
+		$this->assertSame( 'req-42', $decoded['id'] );
+		$this->assertArrayHasKey( 'error', $decoded );
 	}
 
 	public function test_handle_request_with_missing_params(): void {

--- a/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
+++ b/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
@@ -712,17 +712,12 @@ final class StdioServerBridgeTest extends TestCase {
 		$encode_response_method = $reflection->getMethod( 'encode_response' );
 		$encode_response_method->setAccessible( true );
 
-		// Depth >512 triggers JSON_ERROR_DEPTH; without PARTIAL_OUTPUT_ON_ERROR
+		// NAN triggers JSON_ERROR_INF_OR_NAN; without PARTIAL_OUTPUT_ON_ERROR
 		// wp_json_encode returns false, hitting the fallback path.
-		$deep = 'leaf';
-		for ( $i = 0; $i < 600; $i++ ) {
-			$deep = array( $deep );
-		}
-
 		$response = array(
 			'jsonrpc' => '2.0',
 			'id'      => 'req-42',
-			'result'  => array( 'nested' => $deep ),
+			'result'  => array( 'value' => NAN ),
 		);
 
 		$encoded = $encode_response_method->invoke( $this->bridge, $response );
@@ -745,15 +740,10 @@ final class StdioServerBridgeTest extends TestCase {
 		$encode_response_method = $reflection->getMethod( 'encode_response' );
 		$encode_response_method->setAccessible( true );
 
-		$deep = 'leaf';
-		for ( $i = 0; $i < 600; $i++ ) {
-			$deep = array( $deep );
-		}
-
 		// No 'id' key — exercises the ': "null"' branch of the fallback ternary.
 		$response = array(
 			'jsonrpc' => '2.0',
-			'result'  => array( 'nested' => $deep ),
+			'result'  => array( 'value' => NAN ),
 		);
 
 		$encoded = $encode_response_method->invoke( $this->bridge, $response );

--- a/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
+++ b/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
@@ -739,6 +739,59 @@ final class StdioServerBridgeTest extends TestCase {
 		$this->assertArrayHasKey( 'error', $decoded );
 	}
 
+	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
+	public function test_encode_response_fallback_emits_null_id_when_response_has_no_id(): void {
+		$reflection             = new \ReflectionClass( $this->bridge );
+		$encode_response_method = $reflection->getMethod( 'encode_response' );
+		$encode_response_method->setAccessible( true );
+
+		$deep = 'leaf';
+		for ( $i = 0; $i < 600; $i++ ) {
+			$deep = array( $deep );
+		}
+
+		// No 'id' key — exercises the ': "null"' branch of the fallback ternary.
+		$response = array(
+			'jsonrpc' => '2.0',
+			'result'  => array( 'nested' => $deep ),
+		);
+
+		$encoded = $encode_response_method->invoke( $this->bridge, $response );
+
+		$this->assertIsString( $encoded );
+		$this->assertStringContainsString( 'response could not be encoded', $encoded );
+
+		$decoded = json_decode( $encoded, true );
+		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'id', $decoded );
+		$this->assertNull( $decoded['id'] );
+	}
+
+	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
+	public function test_encode_response_fallback_recovers_when_id_itself_unencodable(): void {
+		$reflection             = new \ReflectionClass( $this->bridge );
+		$encode_response_method = $reflection->getMethod( 'encode_response' );
+		$encode_response_method->setAccessible( true );
+
+		// NAN can't be encoded without PARTIAL_OUTPUT_ON_ERROR, so the outer encode
+		// fails AND the inner id encode fails — exercises the recovery assignment.
+		$response = array(
+			'jsonrpc' => '2.0',
+			'id'      => NAN,
+			'result'  => array(),
+		);
+
+		$encoded = $encode_response_method->invoke( $this->bridge, $response );
+
+		$this->assertIsString( $encoded );
+		$this->assertStringContainsString( 'response could not be encoded', $encoded );
+
+		$decoded = json_decode( $encoded, true );
+		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'id', $decoded );
+		$this->assertNull( $decoded['id'] );
+	}
+
 	public function test_handle_request_with_missing_params(): void {
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );

--- a/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
+++ b/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
@@ -734,6 +734,44 @@ final class StdioServerBridgeTest extends TestCase {
 		$this->assertArrayHasKey( 'error', $decoded );
 	}
 
+	public function test_handle_request_catches_unexpected_throwable_from_router(): void {
+		$reflection            = new \ReflectionClass( $this->bridge );
+		$handle_request_method = $reflection->getMethod( 'handle_request' );
+		$handle_request_method->setAccessible( true );
+		$router_property       = $reflection->getProperty( 'request_router' );
+		$router_property->setAccessible( true );
+
+		$original_router = $router_property->getValue( $this->bridge );
+		$mock_router     = $this->createMock( \WP\MCP\Transport\Infrastructure\RequestRouter::class );
+		$mock_router->method( 'route_request' )->willThrowException( new \RuntimeException( 'router blew up' ) );
+		$router_property->setValue( $this->bridge, $mock_router );
+
+		try {
+			$result = $handle_request_method->invoke(
+				$this->bridge,
+				wp_json_encode(
+					array(
+						'jsonrpc' => '2.0',
+						'id'      => 1,
+						'method'  => 'tools/list',
+						'params'  => array(),
+					)
+				)
+			);
+		} finally {
+			$router_property->setValue( $this->bridge, $original_router );
+		}
+
+		$this->assertIsString( $result );
+		$decoded = json_decode( $result, true );
+		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'error', $decoded );
+		$this->assertSame( -32603, $decoded['error']['code'] );
+		$this->assertSame( 'Internal error', $decoded['error']['message'] );
+		$this->assertArrayHasKey( 'data', $decoded['error'] );
+		$this->assertStringContainsString( 'router blew up', $decoded['error']['data'] );
+	}
+
 	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
 	public function test_encode_response_fallback_emits_null_id_when_response_has_no_id(): void {
 		$reflection             = new \ReflectionClass( $this->bridge );

--- a/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
@@ -421,20 +421,91 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertStringNotContainsString( "\x80", $structured['body'] );
 	}
 
+	public function test_embedded_resource_nested_shape_is_unwrapped(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+
+		// Inject the nested EmbeddedResource shape (resource keyed under 'resource').
+		$filter = static function () {
+			return array(
+				'type'     => 'resource',
+				'resource' => array(
+					'uri'      => 'WordPress://local/nested-resource',
+					'text'     => 'nested payload',
+					'mimeType' => 'text/plain',
+				),
+			);
+		};
+		add_filter( 'mcp_adapter_tool_call_result', $filter );
+
+		try {
+			$result = $handler->call_tool(
+				array(
+					'params' => array(
+						'name'      => 'test-always-allowed',
+						'arguments' => array(),
+					),
+				),
+				1
+			);
+		} finally {
+			remove_filter( 'mcp_adapter_tool_call_result', $filter );
+		}
+
+		$this->assertInstanceOf( CallToolResult::class, $result );
+		$content = $result->getContent();
+		$this->assertInstanceOf( EmbeddedResource::class, $content[0] );
+		$resource = $content[0]->getResource();
+		$this->assertInstanceOf( TextResourceContents::class, $resource );
+		$this->assertSame( 'WordPress://local/nested-resource', $resource->getUri() );
+		$this->assertSame( 'nested payload', $resource->getText() );
+	}
+
+	public function test_throwable_from_filter_triggers_outer_catch(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+
+		// Throwing from a filter inside the try escapes McpTool::execute's own catch
+		// and hits the outer try/catch in ToolsHandler::call_tool. Use the pre_tool_call
+		// hook (not tool_call_result) so a callback exception leaving WP_Hook in a
+		// half-iterated state cannot leak into other tests that use tool_call_result.
+		$filter = static function () {
+			throw new \RuntimeException( 'filter blew up' );
+		};
+		add_filter( 'mcp_adapter_pre_tool_call', $filter );
+
+		try {
+			$result = $handler->call_tool(
+				array(
+					'params' => array(
+						'name'      => 'test-always-allowed',
+						'arguments' => array(),
+					),
+				),
+				1
+			);
+		} finally {
+			remove_filter( 'mcp_adapter_pre_tool_call', $filter );
+		}
+
+		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
+		$error = $result->getError();
+		$this->assertNotNull( $error );
+		$this->assertSame( -32603, $error->getCode() );
+
+		$messages = array_column( DummyErrorHandler::$logs, 'message' );
+		$this->assertContains( 'Error calling tool', $messages );
+	}
+
 	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
 	public function test_unencodable_result_emits_empty_payload_and_logs(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 
-		// Depth >512 triggers JSON_ERROR_DEPTH and wp_json_encode returns false (we no longer
-		// pass PARTIAL_OUTPUT_ON_ERROR, so depth/recursion/NAN/resources fall through here).
-		$deep = 'leaf';
-		for ( $i = 0; $i < 600; $i++ ) {
-			$deep = array( $deep );
-		}
-
-		$filter = static function () use ( $deep ) {
-			return array( 'nested' => $deep );
+		// NAN triggers JSON_ERROR_INF_OR_NAN; without PARTIAL_OUTPUT_ON_ERROR
+		// wp_json_encode returns false and we hit the empty-payload fallback.
+		$filter = static function () {
+			return array( 'value' => NAN );
 		};
 		add_filter( 'mcp_adapter_tool_call_result', $filter );
 

--- a/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
@@ -369,22 +369,12 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertFalse( (bool) $result->getIsError() );
 	}
 
-	/**
-	 * Regression: a non-UTF-8 byte anywhere in a tool result used to cause
-	 * wp_json_encode() to return false. The handler then substituted '{}' for
-	 * the text content but still passed the unencodable payload into
-	 * structuredContent, which made WP REST envelope serialization fail and
-	 * surfaced to clients as "MCP error -32000: Connection closed". With the
-	 * fix the bad byte is substituted (U+FFFD) and the response is well-formed.
-	 *
-	 * @see https://github.com/WordPress/mcp-adapter/issues/195
-	 */
+	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
 	public function test_non_utf8_byte_in_result_does_not_break_response(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 
 		$filter = static function () {
-			// 0x80 is not a valid leading byte for any UTF-8 sequence.
 			return array(
 				'ok'   => true,
 				'body' => "leading text \x80 trailing text",
@@ -414,11 +404,68 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertInstanceOf( TextContent::class, $content[0] );
 
 		$text = $content[0]->getText();
-		$this->assertNotSame( '{}', $text, 'Pre-fix behavior substituted {} for unencodable results; should now be substituted JSON.' );
+		$this->assertNotSame( '{}', $text );
 
 		$decoded = json_decode( $text, true );
-		$this->assertIsArray( $decoded, 'Encoded text content must be valid JSON after substitution.' );
+		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'ok', $decoded );
 		$this->assertTrue( $decoded['ok'] );
 		$this->assertArrayHasKey( 'body', $decoded );
+
+		$structured = $result->getStructuredContent();
+		$this->assertIsArray( $structured );
+		$this->assertArrayHasKey( 'ok', $structured );
+		$this->assertTrue( $structured['ok'] );
+		$this->assertArrayHasKey( 'body', $structured );
+		// structuredContent re-derived from sanitized text — no raw 0x80 reaches the outer envelope.
+		$this->assertStringNotContainsString( "\x80", $structured['body'] );
+	}
+
+	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
+	public function test_partial_output_substitution_is_logged_and_succeeds(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+
+		// Depth >512 flags JSON_ERROR_DEPTH on a PARTIAL_OUTPUT_ON_ERROR encode — the call
+		// succeeds with substitution but json_last_error() surfaces it. Recursion / resources
+		// / NAN take the same code path.
+		$deep = 'leaf';
+		for ( $i = 0; $i < 600; $i++ ) {
+			$deep = array( $deep );
+		}
+
+		$filter = static function () use ( $deep ) {
+			return array( 'nested' => $deep );
+		};
+		add_filter( 'mcp_adapter_tool_call_result', $filter );
+
+		try {
+			$result = $handler->call_tool(
+				array(
+					'params' => array(
+						'name'      => 'test-always-allowed',
+						'arguments' => array(),
+					),
+				),
+				1
+			);
+		} finally {
+			remove_filter( 'mcp_adapter_tool_call_result', $filter );
+		}
+
+		$this->assertInstanceOf( CallToolResult::class, $result );
+		$this->assertFalse( (bool) $result->getIsError() );
+
+		$content = $result->getContent();
+		$this->assertNotEmpty( $content );
+		$this->assertInstanceOf( TextContent::class, $content[0] );
+		$this->assertNotSame( '{}', $content[0]->getText() );
+
+		$messages = array_column( DummyErrorHandler::$logs, 'message' );
+		$matched  = array_filter(
+			$messages,
+			static fn ( string $m ): bool => false !== strpos( $m, 'substitution' )
+		);
+		$this->assertNotEmpty( $matched );
 	}
 }

--- a/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
@@ -422,13 +422,12 @@ final class ToolsHandlerCallTest extends TestCase {
 	}
 
 	/** @see https://github.com/WordPress/mcp-adapter/issues/195 */
-	public function test_partial_output_substitution_is_logged_and_succeeds(): void {
+	public function test_unencodable_result_emits_empty_payload_and_logs(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 
-		// Depth >512 flags JSON_ERROR_DEPTH on a PARTIAL_OUTPUT_ON_ERROR encode — the call
-		// succeeds with substitution but json_last_error() surfaces it. Recursion / resources
-		// / NAN take the same code path.
+		// Depth >512 triggers JSON_ERROR_DEPTH and wp_json_encode returns false (we no longer
+		// pass PARTIAL_OUTPUT_ON_ERROR, so depth/recursion/NAN/resources fall through here).
 		$deep = 'leaf';
 		for ( $i = 0; $i < 600; $i++ ) {
 			$deep = array( $deep );
@@ -459,12 +458,14 @@ final class ToolsHandlerCallTest extends TestCase {
 		$content = $result->getContent();
 		$this->assertNotEmpty( $content );
 		$this->assertInstanceOf( TextContent::class, $content[0] );
-		$this->assertNotSame( '{}', $content[0]->getText() );
+		$this->assertSame( '{}', $content[0]->getText() );
+
+		$this->assertNull( $result->getStructuredContent() );
 
 		$messages = array_column( DummyErrorHandler::$logs, 'message' );
 		$matched  = array_filter(
 			$messages,
-			static fn ( string $m ): bool => false !== strpos( $m, 'substitution' )
+			static fn ( string $m ): bool => false !== strpos( $m, 'could not be JSON-encoded' )
 		);
 		$this->assertNotEmpty( $matched );
 	}

--- a/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
@@ -368,4 +368,57 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertInstanceOf( CallToolResult::class, $result );
 		$this->assertFalse( (bool) $result->getIsError() );
 	}
+
+	/**
+	 * Regression: a non-UTF-8 byte anywhere in a tool result used to cause
+	 * wp_json_encode() to return false. The handler then substituted '{}' for
+	 * the text content but still passed the unencodable payload into
+	 * structuredContent, which made WP REST envelope serialization fail and
+	 * surfaced to clients as "MCP error -32000: Connection closed". With the
+	 * fix the bad byte is substituted (U+FFFD) and the response is well-formed.
+	 *
+	 * @see https://github.com/WordPress/mcp-adapter/issues/195
+	 */
+	public function test_non_utf8_byte_in_result_does_not_break_response(): void {
+		$server  = $this->makeServer( array( 'test/always-allowed' ) );
+		$handler = new ToolsHandler( $server );
+
+		$filter = static function () {
+			// 0x80 is not a valid leading byte for any UTF-8 sequence.
+			return array(
+				'ok'   => true,
+				'body' => "leading text \x80 trailing text",
+			);
+		};
+		add_filter( 'mcp_adapter_tool_call_result', $filter );
+
+		try {
+			$result = $handler->call_tool(
+				array(
+					'params' => array(
+						'name'      => 'test-always-allowed',
+						'arguments' => array(),
+					),
+				),
+				1
+			);
+		} finally {
+			remove_filter( 'mcp_adapter_tool_call_result', $filter );
+		}
+
+		$this->assertInstanceOf( CallToolResult::class, $result );
+		$this->assertFalse( (bool) $result->getIsError() );
+
+		$content = $result->getContent();
+		$this->assertNotEmpty( $content );
+		$this->assertInstanceOf( TextContent::class, $content[0] );
+
+		$text = $content[0]->getText();
+		$this->assertNotSame( '{}', $text, 'Pre-fix behavior substituted {} for unencodable results; should now be substituted JSON.' );
+
+		$decoded = json_decode( $text, true );
+		$this->assertIsArray( $decoded, 'Encoded text content must be valid JSON after substitution.' );
+		$this->assertTrue( $decoded['ok'] );
+		$this->assertArrayHasKey( 'body', $decoded );
+	}
 }

--- a/tests/phpunit/Unit/Tools/McpToolTest.php
+++ b/tests/phpunit/Unit/Tools/McpToolTest.php
@@ -470,6 +470,52 @@ final class McpToolTest extends TestCase {
 		$this->assertSame( 'Handler exploded', $result->get_error_message() );
 	}
 
+	public function test_execute_catches_throwable_from_ability(): void {
+		// WP_Ability catches its own callback exceptions, so to exercise McpTool's
+		// own catch we replace the underlying ability with a mock that throws.
+		$ability = wp_get_ability( 'test/always-allowed' );
+		$tool    = McpTool::fromAbility( $ability );
+		$this->assertNotWPError( $tool );
+
+		$throwing_ability = $this->getMockBuilder( \WP_Ability::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+		$throwing_ability->method( 'execute' )->willThrowException( new \RuntimeException( 'ability blew up' ) );
+
+		$prop = new \ReflectionProperty( McpTool::class, 'ability' );
+		$prop->setAccessible( true );
+		$prop->setValue( $tool, $throwing_ability );
+
+		$result = $tool->execute( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_execution_failed', $result->get_error_code() );
+		$this->assertSame( 'ability blew up', $result->get_error_message() );
+	}
+
+	public function test_check_permission_catches_throwable_from_ability(): void {
+		$ability = wp_get_ability( 'test/always-allowed' );
+		$tool    = McpTool::fromAbility( $ability );
+		$this->assertNotWPError( $tool );
+
+		$throwing_ability = $this->getMockBuilder( \WP_Ability::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'check_permissions' ) )
+			->getMock();
+		$throwing_ability->method( 'check_permissions' )->willThrowException( new \RuntimeException( 'permission blew up' ) );
+
+		$prop = new \ReflectionProperty( McpTool::class, 'ability' );
+		$prop->setAccessible( true );
+		$prop->setValue( $tool, $throwing_ability );
+
+		$result = $tool->check_permission( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mcp_permission_check_failed', $result->get_error_code() );
+		$this->assertSame( 'permission blew up', $result->get_error_message() );
+	}
+
 	public function test_check_permission_catches_exceptions(): void {
 		$tool = McpTool::fromArray(
 			array(


### PR DESCRIPTION
## What?
Closes #195

Make `wp_json_encode()` UTF-8-tolerant in the two call sites that
serialize tool/transport results, so a single bad byte no longer empties
the response body and no longer trips the "MCP error -32000: Connection
closed" symptom on the client. On residual encode failure, return a
proper error CallToolResult (HTTP) / preserve the request id (stdio)
and log `json_last_error_msg()`.

## Why?
When an MCP tool returns a result containing any non-UTF-8 byte
(smart-quote from copy-pasted content, custom-field binary blob, Word
import, etc.), `ToolsHandler::call_tool()` calls `wp_json_encode()` with
no flags, encoding fails, the code substitutes `'{}'` for the text
content — but still passes the unencodable `$result` into
`structuredContent`. WP REST then fails to serialize the outer envelope,
returns an empty body, and clients see "Connection closed" with no log
trail.

`StdioServerBridge::encode_response()` had the same fragility on its
fallback path: it dropped the request `id` (breaking JSON-RPC
correlation) and logged nothing.

## How?
- `includes/Handlers/Tools/ToolsHandler.php`: encode with
  `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE |
  JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR`. On
  residual failure return an error CallToolResult via the existing
  `create_error_result()` helper and log via the server's error handler.
- `includes/Cli/StdioServerBridge.php`: same flag set on
  `encode_response()`; the fallback now preserves the original request
  `id` and logs `json_last_error_msg()` to stderr.
- Two regression tests added (`ToolsHandlerCallTest.php`,
  `StdioServerBridgeTest.php`) covering a non-UTF-8 byte in the payload
  path that previously crashed the response.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: bug analysis, patch drafting, and test scaffolding. Final
implementation and tests were reviewed and edited by me.

## Testing Instructions
1. `composer install && npm install && npm run wp-env start`
2. `npm run lint:php && npm run lint:php:stan && npm run test:php`
   (1004 tests passing locally; 2 new regression tests included.)
3. Manual repro on the bug:
   ```sql
   UPDATE wp_posts SET post_content = CONCAT(post_content, 0x80)
     WHERE ID = <some-id> LIMIT 1;
