### PR TITLE
Add mcp_adapter_server_config filter and fix default ability hook timing

### DIFF
--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -58,6 +58,12 @@ final class McpAdapter {
 		if ( ! isset( self::$instance ) ) {
 			self::$instance = new self();
 
+			// Wire the default abilities now so they catch `wp_abilities_api_init`,
+			// which fires during the `init` action, before `rest_api_init` runs.
+			// Deferred initialization handles transports and the `mcp_adapter_init`
+			// action, neither of which need to be in place before `init`.
+			self::$instance->register_default_ability_hooks();
+
 			// In WP-CLI context, initialize immediately so commands have access to servers
 			if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
 				add_action( 'init', array( self::$instance, 'init' ), 20 );
@@ -68,6 +74,32 @@ final class McpAdapter {
 		}
 
 		return self::$instance;
+	}
+
+	/**
+	 * Wire the default server's ability registration hooks at instance() time.
+	 *
+	 * `wp_abilities_api_categories_init` and `wp_abilities_api_init` fire during
+	 * WordPress's `init` action. Because `instance()` is typically called during
+	 * plugin bootstrap (before `init`), wiring these handlers here ensures they
+	 * catch the abilities-api init pass. The previous placement inside
+	 * {@see self::maybe_create_default_server()} ran on `rest_api_init`, which is
+	 * after `init`, so the default abilities never registered for the abilities
+	 * API to discover.
+	 *
+	 * Gated by `mcp_adapter_create_default_server` so a host disabling the
+	 * default server does not register default abilities either.
+	 *
+	 * @internal For use by adapter initialization only.
+	 */
+	private function register_default_ability_hooks(): void {
+		/** This filter is documented in {@see self::maybe_create_default_server()}. */
+		if ( ! apply_filters( 'mcp_adapter_create_default_server', true ) ) {
+			return;
+		}
+
+		add_action( 'wp_abilities_api_categories_init', array( $this, 'register_default_category' ) );
+		add_action( 'wp_abilities_api_init', array( $this, 'register_default_abilities' ) );
 	}
 
 	/**
@@ -118,10 +150,9 @@ final class McpAdapter {
 			return;
 		}
 
-		// Register category before abilities
-		add_action( 'wp_abilities_api_categories_init', array( $this, 'register_default_category' ) );
-		add_action( 'wp_abilities_api_init', array( $this, 'register_default_abilities' ) );
-
+		// Ability registration hooks are wired earlier in
+		// {@see self::register_default_ability_hooks()} so they catch
+		// `wp_abilities_api_init`. This stage only schedules server creation.
 		add_action( 'mcp_adapter_init', array( DefaultServerFactory::class, 'create' ) );
 	}
 

--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -143,13 +143,68 @@ class McpServer {
 		array $prompts = array(),
 		?callable $transport_permission_callback = null
 	) {
-		// Store server configuration
-		$this->server_id                     = $server_id;
-		$this->server_route_namespace        = $server_route_namespace;
-		$this->server_route                  = $server_route;
-		$this->server_name                   = $server_name;
-		$this->server_description            = $server_description;
-		$this->server_version                = $server_version;
+		// Pack the host-facing configuration so plugins can shape any
+		// server (not just the default) before properties are assigned.
+		$config = array(
+			'server_id'              => $server_id,
+			'server_route_namespace' => $server_route_namespace,
+			'server_route'           => $server_route,
+			'server_name'            => $server_name,
+			'server_description'     => $server_description,
+			'server_version'         => $server_version,
+			'tools'                  => $tools,
+			'resources'              => $resources,
+			'prompts'                => $prompts,
+		);
+
+		/**
+		 * Filters the configuration of an MCP server before properties are assigned.
+		 *
+		 * Fires for every server during construction, allowing site-wide customization
+		 * across the default server and any plugin-created servers. Use the
+		 * `$server_id` parameter to target a specific server, or apply changes
+		 * uniformly across all servers.
+		 *
+		 * Runtime-critical wiring is intentionally outside this filter:
+		 * transport classes, error/observability handlers, and the transport
+		 * permission callback are not exposed here.
+		 *
+		 * @since 0.6.0
+		 *
+		 * @param array  $config {
+		 *     Server configuration array.
+		 *
+		 *     @type string   $server_id              Server identifier.
+		 *     @type string   $server_route_namespace REST API namespace.
+		 *     @type string   $server_route           REST API route.
+		 *     @type string   $server_name            Human-readable server name.
+		 *     @type string   $server_description     Server description.
+		 *     @type string   $server_version         Server version.
+		 *     @type string[] $tools                  Ability names to expose as tools.
+		 *     @type string[] $resources              Ability names to expose as resources.
+		 *     @type string[] $prompts                Ability names to expose as prompts.
+		 * }
+		 * @param string $server_id The server identifier (matches `$config['server_id']`).
+		 */
+		$filtered = apply_filters( 'mcp_adapter_server_config', $config, $server_id );
+
+		// Tolerate filters that drop keys or return a non-array by falling
+		// back to the constructor-supplied defaults.
+		if ( ! is_array( $filtered ) ) {
+			$filtered = $config;
+		}
+		$filtered = wp_parse_args( $filtered, $config );
+
+		// Store server configuration from the (possibly filtered) config.
+		$this->server_id                     = (string) $filtered['server_id'];
+		$this->server_route_namespace        = (string) $filtered['server_route_namespace'];
+		$this->server_route                  = (string) $filtered['server_route'];
+		$this->server_name                   = (string) $filtered['server_name'];
+		$this->server_description            = (string) $filtered['server_description'];
+		$this->server_version                = (string) $filtered['server_version'];
+		$tools                               = array_values( (array) $filtered['tools'] );
+		$resources                           = array_values( (array) $filtered['resources'] );
+		$prompts                             = array_values( (array) $filtered['prompts'] );
 		$this->transport_permission_callback = $transport_permission_callback;
 
 		/**

--- a/tests/phpunit/Integration/WordPressFiltersTest.php
+++ b/tests/phpunit/Integration/WordPressFiltersTest.php
@@ -30,4 +30,154 @@ final class WordPressFiltersTest extends TestCase {
 
 		remove_filter( 'mcp_adapter_validation_enabled', '__return_false' );
 	}
+
+	public function test_server_config_filter_can_rewrite_string_fields(): void {
+		add_filter(
+			'mcp_adapter_server_config',
+			static function ( array $config ): array {
+				$config['server_id']          = 'rewritten-id';
+				$config['server_name']        = 'Rewritten Name';
+				$config['server_description'] = 'Rewritten description';
+				return $config;
+			}
+		);
+
+		$server = new McpServer(
+			'original-id',
+			'mcp/v1',
+			'/mcp',
+			'Original Name',
+			'Original description',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+		);
+
+		$this->assertSame( 'rewritten-id', $server->get_server_id() );
+		$this->assertSame( 'Rewritten Name', $server->get_server_name() );
+		$this->assertSame( 'Rewritten description', $server->get_server_description() );
+
+		remove_all_filters( 'mcp_adapter_server_config' );
+	}
+
+	public function test_server_config_filter_receives_server_id_as_second_arg(): void {
+		$captured = null;
+		add_filter(
+			'mcp_adapter_server_config',
+			static function ( array $config, string $server_id ) use ( &$captured ): array {
+				$captured = $server_id;
+				return $config;
+			},
+			10,
+			2
+		);
+
+		new McpServer(
+			'unique-srv-id',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+		);
+
+		$this->assertSame( 'unique-srv-id', $captured );
+
+		remove_all_filters( 'mcp_adapter_server_config' );
+	}
+
+	public function test_server_config_filter_returning_non_array_falls_back_to_constructor_defaults(): void {
+		add_filter(
+			'mcp_adapter_server_config',
+			static fn () => 'invalid_non_array_return'
+		);
+
+		$server = new McpServer(
+			'fallback-id',
+			'mcp/v1',
+			'/mcp',
+			'Fallback Name',
+			'Fallback description',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+		);
+
+		$this->assertSame( 'fallback-id', $server->get_server_id() );
+		$this->assertSame( 'Fallback Name', $server->get_server_name() );
+
+		remove_all_filters( 'mcp_adapter_server_config' );
+	}
+
+	public function test_server_config_filter_dropping_a_key_falls_back_to_supplied_default(): void {
+		add_filter(
+			'mcp_adapter_server_config',
+			static function ( array $config ): array {
+				unset( $config['server_name'] );
+				return $config;
+			}
+		);
+
+		$server = new McpServer(
+			'srv',
+			'mcp/v1',
+			'/mcp',
+			'Kept Name',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+		);
+
+		$this->assertSame( 'Kept Name', $server->get_server_name() );
+
+		remove_all_filters( 'mcp_adapter_server_config' );
+	}
+
+	public function test_server_config_filter_fires_for_each_server_constructed(): void {
+		$captured_ids = array();
+		add_filter(
+			'mcp_adapter_server_config',
+			static function ( array $config, string $server_id ) use ( &$captured_ids ): array {
+				$captured_ids[] = $server_id;
+				return $config;
+			},
+			10,
+			2
+		);
+
+		new McpServer(
+			'first',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+		);
+
+		new McpServer(
+			'second',
+			'mcp/v1',
+			'/mcp',
+			'Srv',
+			'desc',
+			'0.0.1',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+		);
+
+		$this->assertSame( array( 'first', 'second' ), $captured_ids );
+
+		remove_all_filters( 'mcp_adapter_server_config' );
+	}
 }

--- a/tests/phpunit/Unit/Core/McpAdapterDefaultAbilityHooksTest.php
+++ b/tests/phpunit/Unit/Core/McpAdapterDefaultAbilityHooksTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\MCP\Tests\Unit\Core;
+
+use WP\MCP\Core\McpAdapter;
+use WP\MCP\Tests\TestCase;
+
+/**
+ * Regression coverage for the timing of the default server's ability hooks.
+ *
+ * `wp_abilities_api_categories_init` and `wp_abilities_api_init` fire during
+ * the WordPress `init` action. Wiring their handlers inside the deferred
+ * `rest_api_init` initialization missed both, leaving the default abilities
+ * unregistered (see issue #117). The hooks are now wired during `instance()`
+ * so they catch the abilities-api init pass.
+ */
+final class McpAdapterDefaultAbilityHooksTest extends TestCase {
+
+	public function test_default_ability_hooks_are_registered_at_instance_time(): void {
+		$adapter = McpAdapter::instance();
+
+		$this->assertNotFalse(
+			has_action(
+				'wp_abilities_api_categories_init',
+				array( $adapter, 'register_default_category' )
+			),
+			'register_default_category should be hooked to wp_abilities_api_categories_init at instance() time'
+		);
+
+		$this->assertNotFalse(
+			has_action(
+				'wp_abilities_api_init',
+				array( $adapter, 'register_default_abilities' )
+			),
+			'register_default_abilities should be hooked to wp_abilities_api_init at instance() time'
+		);
+	}
+}


### PR DESCRIPTION
## What?

Closes #190
Closes #117

Two related changes to server construction and the default server's ability registration:

1. Adds an `mcp_adapter_server_config` filter inside `McpServer::__construct()` so plugins can shape the config of any server (not just the default one) before it is applied.
2. Moves the default abilities' registration hooks so they are wired at `McpAdapter::instance()` time instead of during `rest_api_init`, fixing the default abilities silently failing to register.

## Why?

**#190** — The existing `mcp_adapter_default_server_config` filter only covers the default server created by `DefaultServerFactory`. There is no way to alter the config of a custom server created via `mcp_adapter_init`, or to apply a site-wide rule across all servers, without forking the creation logic. Plugins want to add/remove abilities from a server's tools, rename or reroute a server they did not create, or apply visibility allowlists uniformly.

**#117** — The three default abilities (`mcp-adapter/discover-abilities`, `get-ability-info`, `execute-ability`) fail to register. `McpAdapter::instance()` defers `init()` to `rest_api_init`, but `wp_abilities_api_init` fires during the earlier `init` action. The `add_action()` calls for ability registration lived inside `maybe_create_default_server()`, which runs on `rest_api_init`, so they were added too late to catch the abilities-api init pass, producing `WordPress ability '...' does not exist` errors.

## How?

**#190** — `__construct()` now packs the host-facing parameters (`server_id`, route namespace/route, name, description, version, tools, resources, prompts) into a `$config` array, applies `mcp_adapter_server_config` with `$server_id` as the second arg, then assigns from the filtered result. Runtime-critical wiring (transport classes, error/observability handlers, the transport permission callback) is intentionally left out of the filter. A non-array return or dropped keys fall back to the constructor-supplied values via `wp_parse_args`, and the array fields are normalized with `array_values()` to preserve their `list<string>` shape.

**#117** — Ability registration hooks move into a new `register_default_ability_hooks()` method called directly from `instance()`, so they are wired before `init` fires. The method is gated by the same `mcp_adapter_create_default_server` filter, so disabling the default server still skips registering its abilities. `maybe_create_default_server()` keeps the `mcp_adapter_init` server-creation hook, which has no timing issue.

## Testing Instructions

1. `composer install && npm install && npm run wp-env start`
2. `npm run test:php` — full suite passes (1008 tests).
3. For #117: with the plugin active, confirm the debug log no longer shows `WordPress ability 'mcp-adapter/discover-abilities' does not exist` and the default server's tools resolve.
4. For #190: hook `mcp_adapter_server_config`, mutate `$config['server_name']` (or `tools`), and confirm the change applies to a custom server, not just the default.

New tests:
- `tests/phpunit/Integration/WordPressFiltersTest.php` — filter rewrites fields, receives `$server_id`, falls back on non-array/dropped keys, fires once per server.
- `tests/phpunit/Unit/Core/McpAdapterDefaultAbilityHooksTest.php` — ability hooks are registered at `instance()` time.

## Changelog Entry

> Added - `mcp_adapter_server_config` filter to customize any MCP server's configuration at construction time.
> Fixed - Default abilities failing to register because their hooks were added after `wp_abilities_api_init` had fired.
