### PR TITLE
chore(deps): bump wordpress/php-mcp-schema to v0.1.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "wordpress/php-mcp-schema",
-            "version": "v0.1.1",
+            "version": "v0.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/php-mcp-schema.git",
-                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9"
+                "url": "https://github.com/WordPress/php-mcp-schema",
+                "reference": "95df8a50a3bd54f6b7c4869c6e2185db380d4d63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/e2118ec421ead51a3e17a3d8160f4537727e91b9",
-                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/95df8a50a3bd54f6b7c4869c6e2185db380d4d63",
+                "reference": "95df8a50a3bd54f6b7c4869c6e2185db380d4d63",
                 "shasum": ""
             },
             "require": {
@@ -51,11 +51,7 @@
                 "php",
                 "schema"
             ],
-            "support": {
-                "issues": "https://github.com/WordPress/php-mcp-schema/issues",
-                "source": "https://github.com/WordPress/php-mcp-schema/tree/v0.1.1"
-            },
-            "time": "2026-04-10T19:35:16+00:00"
+            "time": "2026-06-05T08:26:32+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/Domain/Tools/McpToolValidator.php
+++ b/includes/Domain/Tools/McpToolValidator.php
@@ -265,6 +265,12 @@ class McpToolValidator {
 			);
 		}
 
+		// Normalize stdClass properties (e.g. an empty `{}` emitted by the schema DTO for
+		// parameter-less tools) to an array so the structural checks below treat it as a valid object.
+		if ( isset( $schema['properties'] ) && $schema['properties'] instanceof \stdClass ) {
+			$schema['properties'] = (array) $schema['properties'];
+		}
+
 		// If properties exist, they must be an array/object.
 		if ( isset( $schema['properties'] ) && ! is_array( $schema['properties'] ) ) {
 			$errors[] = sprintf(


### PR DESCRIPTION
## What?
See #35

Bumps the locked `wordpress/php-mcp-schema` dependency from v0.1.1 to v0.1.2, and fixes the adapter's tool validator to accept the empty `properties` object the new version emits for parameter-less tools. The dependency change itself is lockfile-only — the existing `^0.1.0` constraint already allows 0.1.2.

## Why?
v0.1.2 fixes `ToolInputSchema::toArray()` and `ToolOutputSchema::toArray()` to always emit `properties` as a JSON object, even for tools that declare no parameters. Previously a parameter-less tool serialized as `{"type":"object"}` (key omitted) or `[]` (JSON array). Strict JSON Schema validators — notably OpenAI strict function-calling mode — reject both with `object schema missing properties`. This is the same symptom reported in #35 (Cursor: `inputSchema.properties` → `Expected object, received array`), now fixed at the DTO serialization layer.

Upstream fix and full rationale: https://github.com/WordPress/php-mcp-schema/pull/7.

The adapter serializes every tool through this package's `Tool` DTO (`RegisterAbilityAsMcpTool` → `ToolsHandler` → `Tool::toArray()` → `ToolInputSchema::toArray()`). So `tools/list` output for any ability with no input arguments is affected. After this bump those tools emit a valid `"properties": {}` and pass strict validators. Tools with parameters are unchanged.

The bump also exposed a latent bug in the adapter's own `McpToolValidator`. v0.1.2 emits the empty `properties` as a PHP `\stdClass` (`{}`), but the validator checked `properties` with `is_array()` only and rejected the `\stdClass` with `Tool inputSchema properties must be an object/array`. This broke one unit test (`McpToolValidatorTest::test_validate_tool_dto_with_valid_tool`) across the whole CI matrix. The validator now normalizes a `\stdClass` `properties` value to an array before the structural check — mirroring the normalization it already does for the top-level schema and for individual property values.

## How?
Two commits:
1. `composer update wordpress/php-mcp-schema` — refreshes only the locked reference (e2118ec → 95df8a5) and timestamp in `composer.lock`. No constraint change.
2. `McpToolValidator::get_schema_validation_errors()` — casts a `\stdClass` `properties` value to an array before the `is_array()` check, so the validator accepts the `{}` that v0.1.2 emits for parameter-less tools.

Upstream changes pulled in:
- https://github.com/WordPress/php-mcp-schema/pull/7 — fix: emit empty tool schema properties as JSON object
- [v0.1.2 release / CHANGELOG](https://github.com/WordPress/php-mcp-schema/blob/v0.1.2/CHANGELOG.md)

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Drafting the PR description and verifying the serialization path; the dependency bump itself is a mechanical `composer update`.

## Testing Instructions
1. `composer install`
2. Register an ability with an empty input schema (no parameters) and expose it as an MCP tool.
3. Call `tools/list` and inspect the tool's `inputSchema` — it must be `{"type":"object","properties":{}}`, not `{"type":"object"}`.
4. `composer test` — the full PHPUnit suite, including `McpToolValidatorTest::test_validate_tool_dto_with_valid_tool`, should pass.

## Changelog Entry
> Fixed - Parameter-less tools now emit a valid empty `properties` object in `tools/list` and pass tool validation, fixing rejection by strict JSON Schema validators (via `php-mcp-schema` v0.1.2, WordPress/php-mcp-schema#7).


