### PR TITLE
Add McpAdapter::on_init() helper for safe server registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,23 @@ add_action( 'mcp_adapter_init', function( $adapter ) {
 } );
 ```
 
+> [!IMPORTANT]
+> Always register servers against the `$adapter` instance passed to your callback (as above). Do **not** call `\WP\MCP\Core\McpAdapter::instance()` from inside the callback. The `mcp_adapter_init` action name is global, so if two active plugins each bundle their own copy of this library, every copy's dispatch runs every copy's `mcp_adapter_init` callbacks. Using the passed-in `$adapter` keeps each callback registering against the copy that actually dispatched it; reaching for `instance()` instead resolves to *your* copy's singleton on every dispatch and produces `duplicate_server_id` errors.
+
+### Registering servers with `on_init()`
+
+`McpAdapter::on_init()` is a convenience wrapper around `add_action( 'mcp_adapter_init', ... )` that builds the identity check in for you: the wrapped callback only runs when *this* adapter is the one dispatching, so it is safe even when multiple copies of the library are active in the same request. Call it on your copy's adapter at plugin load — there is no need to add the action yourself:
+
+```php
+\WP\MCP\Core\McpAdapter::instance()->on_init( function ( $adapter ) {
+    $adapter->create_server(
+        // ...same arguments as above...
+    );
+} );
+```
+
+If you already register against the `$adapter` passed to your own `mcp_adapter_init` callback (as shown in the previous section), you are equally safe — `on_init()` simply makes that guarantee explicit and harder to get wrong.
+
 ### Custom Transport Implementation
 
 The MCP Adapter includes production-ready HTTP transports. For specialized requirements like custom authentication, message queues, or enterprise integrations, you can create custom transport protocols.

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -99,6 +99,38 @@ final class McpAdapter {
 	}
 
 	/**
+	 * Register a callback to run when this adapter initializes.
+	 *
+	 * Prefer this over `add_action( 'mcp_adapter_init', ... )` in plugin code.
+	 * The `mcp_adapter_init` action name is global, so when more than one copy
+	 * of this library is active in the same request (e.g. two plugins that
+	 * each vendor `wordpress/mcp-adapter`, with or without namespace prefixing),
+	 * every copy's dispatch runs every copy's subscribers. Registering servers
+	 * inside an unguarded subscriber causes duplicate-registration errors on
+	 * subsequent dispatches.
+	 *
+	 * This helper wraps the action with an identity check so the callback only
+	 * runs when this adapter is the one dispatching.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param callable $callback Receives this adapter instance when invoked.
+	 *
+	 * @return void
+	 */
+	public function on_init( callable $callback ): void {
+		add_action(
+			'mcp_adapter_init',
+			function ( $adapter = null ) use ( $callback ) {
+				if ( $adapter !== $this ) {
+					return;
+				}
+				$callback( $adapter );
+			}
+		);
+	}
+
+	/**
 	 * Conditionally create the default server based on filter.
 	 *
 	 * @internal For use by adapter initialization only.

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -101,16 +101,18 @@ final class McpAdapter {
 	/**
 	 * Register a callback to run when this adapter initializes.
 	 *
-	 * Prefer this over `add_action( 'mcp_adapter_init', ... )` in plugin code.
-	 * The `mcp_adapter_init` action name is global, so when more than one copy
-	 * of this library is active in the same request (e.g. two plugins that
-	 * each vendor `wordpress/mcp-adapter`, with or without namespace prefixing),
-	 * every copy's dispatch runs every copy's subscribers. Registering servers
-	 * inside an unguarded subscriber causes duplicate-registration errors on
-	 * subsequent dispatches.
+	 * An alternative to `add_action( 'mcp_adapter_init', ... )` that builds the
+	 * identity guard in for you. The `mcp_adapter_init` action name is global,
+	 * so when more than one copy of this library is active in the same request
+	 * (e.g. two plugins that each vendor `wordpress/mcp-adapter`, with or without
+	 * namespace prefixing), every copy's dispatch runs every copy's subscribers.
+	 * Registering servers inside an unguarded subscriber causes
+	 * duplicate-registration errors on subsequent dispatches.
 	 *
-	 * This helper wraps the action with an identity check so the callback only
-	 * runs when this adapter is the one dispatching.
+	 * A subscriber that uses the `$adapter` passed to its `mcp_adapter_init`
+	 * callback is already safe; this helper just wraps the action with the same
+	 * identity check so the callback only runs when this adapter is the one
+	 * dispatching.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/tests/phpunit/Unit/Core/McpAdapterOnInitTest.php
+++ b/tests/phpunit/Unit/Core/McpAdapterOnInitTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\MCP\Tests\Unit\Core;
+
+use WP\MCP\Core\McpAdapter;
+use WP\MCP\Tests\TestCase;
+
+final class McpAdapterOnInitTest extends TestCase {
+
+	private McpAdapter $adapter;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->adapter = McpAdapter::instance();
+
+		// Isolate the shared action so do_action() only triggers callbacks
+		// registered within each test, regardless of suite execution order.
+		remove_all_actions( 'mcp_adapter_init' );
+	}
+
+	public function tear_down(): void {
+		remove_all_actions( 'mcp_adapter_init' );
+		parent::tear_down();
+	}
+
+	public function test_on_init_runs_callback_when_our_adapter_dispatches(): void {
+		$received = null;
+		$this->adapter->on_init(
+			static function ( $adapter ) use ( &$received ) {
+				$received = $adapter;
+			}
+		);
+
+		do_action( 'mcp_adapter_init', $this->adapter );
+
+		$this->assertSame( $this->adapter, $received );
+	}
+
+	public function test_on_init_skips_callback_when_a_foreign_adapter_dispatches(): void {
+		$called = false;
+		$this->adapter->on_init(
+			static function () use ( &$called ) {
+				$called = true;
+			}
+		);
+
+		// Simulate another vendored copy's adapter dispatching the shared action.
+		$foreign = ( new \ReflectionClass( McpAdapter::class ) )->newInstanceWithoutConstructor();
+		do_action( 'mcp_adapter_init', $foreign );
+
+		$this->assertFalse(
+			$called,
+			'on_init() callback must not fire when a foreign adapter instance dispatched the shared action.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Adds `McpAdapter::on_init()`, a small convenience wrapper around `add_action( 'mcp_adapter_init', ... )` that builds an adapter-identity check in for the caller.

This was split out of #173 (per review feedback) so the new public API can be discussed and documented on its own. The `duplicate_server_id` crash itself is fixed independently by the factory guard in #173; this helper is an ergonomic addition, not required for that fix.

## Why

The `mcp_adapter_init` action name is global. When more than one active plugin vendors `wordpress/mcp-adapter` (with or without namespace prefixing), every copy's dispatch runs every copy's subscribers. A subscriber that registers servers without checking *which* adapter dispatched ends up registering on every dispatch, causing duplicate-registration errors.

A consumer that uses the `$adapter` passed to its `mcp_adapter_init` callback is already safe. `on_init()` simply makes that guarantee explicit and harder to get wrong:

```php
\WP\MCP\Core\McpAdapter::instance()->on_init( function ( $adapter ) {
    $adapter->create_server( /* ... */ );
} );
```

The wrapped callback only runs when this adapter is the one dispatching.

## Public API note

This adds a new public method, so it is a commitment once shipped — hence the dedicated PR and docs. Feedback on the name/shape welcome.

## Tests & docs

- Two unit tests: callback runs for the matching adapter, and is skipped when a foreign adapter dispatches the shared action.
- README section documenting the helper alongside the existing custom-server example, plus a note to prefer the passed-in `$adapter` over `McpAdapter::instance()` inside `mcp_adapter_init` callbacks.
- Full unit suite passes locally (963 tests).