### PR TITLE
fix: guard SchemaTransformer recursion and strip WP-only schema keys (#207)

### DIFF
--- a/includes/Domain/Utils/SchemaTransformer.php
+++ b/includes/Domain/Utils/SchemaTransformer.php
@@ -19,6 +19,31 @@ namespace WP\MCP\Domain\Utils;
  */
 class SchemaTransformer {
 	/**
+	 * Maximum recursion depth for the normalize walk.
+	 *
+	 * Guards against pathological/cyclic structures blowing the PHP stack.
+	 *
+	 * @var int
+	 */
+	private const MAX_DEPTH = 64;
+
+	/**
+	 * WordPress-only argument keys that are not part of the JSON Schema spec.
+	 *
+	 * These must be stripped from the emitted MCP schema. They can carry
+	 * object-valued callables (e.g. sanitize_callback => array( $obj, 'method' ))
+	 * whose object graph may be cyclic.
+	 *
+	 * @var array<int,string>
+	 */
+	// phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- False positive: sniff mistakes array() commas for multi-const commas (only handles short syntax).
+	private const WP_ONLY_KEYS = array(
+		'sanitize_callback',
+		'validate_callback',
+		'arg_options',
+	);
+
+	/**
 	 * Transform a schema to MCP-compatible object format.
 	 *
 	 * If the schema is already an object type, it is returned unchanged.
@@ -120,17 +145,47 @@ class SchemaTransformer {
 	/**
 	 * Recursively convert objects to arrays.
 	 *
-	 * @param mixed $value The value to convert.
+	 * Casts objects to arrays as before, but guards against runaway recursion:
+	 * cyclic object graphs (e.g. an object-valued sanitize_callback whose object
+	 * references itself) are short-circuited via spl_object_id() tracking, and a
+	 * MAX_DEPTH ceiling stops any other pathological nesting. While walking, the
+	 * WordPress-only keys (sanitize_callback, validate_callback, arg_options) are
+	 * stripped because they are not valid JSON Schema and may carry such cyclic
+	 * callables. They are stripped wherever encountered: that is the behaviour the
+	 * issue asks for and the simplest correct approach. The risk of clobbering a
+	 * legitimately named data property is accepted as negligible for schema input.
+	 *
+	 * @param mixed              $value   The value to convert.
+	 * @param int                $depth   Current recursion depth.
+	 * @param array<int,bool>    $visited Object ids already seen on this branch.
 	 *
 	 * @return mixed The converted value.
 	 */
-	private static function convert_objects_to_arrays( $value ) {
+	private static function convert_objects_to_arrays( $value, int $depth = 0, array $visited = array() ) {
+		if ( $depth >= self::MAX_DEPTH ) {
+			return null;
+		}
+
 		if ( is_object( $value ) ) {
-			$value = (array) $value;
+			// Track identity BEFORE the cast, since (array) loses object identity.
+			$object_id = spl_object_id( $value );
+			if ( isset( $visited[ $object_id ] ) ) {
+				return null;
+			}
+			$visited[ $object_id ] = true;
+			$value                 = (array) $value;
 		}
 
 		if ( is_array( $value ) ) {
-			return array_map( array( self::class, 'convert_objects_to_arrays' ), $value );
+			$result = array();
+			foreach ( $value as $key => $item ) {
+				if ( in_array( $key, self::WP_ONLY_KEYS, true ) ) {
+					continue;
+				}
+				$result[ $key ] = self::convert_objects_to_arrays( $item, $depth + 1, $visited );
+			}
+
+			return $result;
 		}
 
 		return $value;

--- a/tests/phpunit/Unit/Domain/Utils/SchemaTransformerTest.php
+++ b/tests/phpunit/Unit/Domain/Utils/SchemaTransformerTest.php
@@ -373,4 +373,164 @@ final class SchemaTransformerTest extends TestCase {
 		$this->assertIsArray( $result['schema']['properties']['name'] );
 		$this->assertSame( 'string', $result['schema']['properties']['name']['type'] );
 	}
+
+	/**
+	 * Issue #207: A schema property may carry an object-valued WP callback
+	 * (e.g. sanitize_callback => array( $obj, 'method' )). If that object's
+	 * graph contains a back-reference (cycle), convert_objects_to_arrays()
+	 * recurses without a cycle guard until the PHP stack/memory blows.
+	 *
+	 * This test asserts the transform completes and returns a 'schema' key
+	 * without a fatal. NOTE: on current (buggy) code a real stack overflow is
+	 * an uncatchable fatal that crashes the whole PHPUnit process, so this can
+	 * only turn green after the guard lands. The RED proof for this case is
+	 * demonstrated via a constrained subprocess repro (see task notes).
+	 */
+	public function test_transform_withCyclicObjectValuedCallback_doesNotBlowStack(): void {
+		$obj       = new \stdClass();
+		$obj->self = $obj;
+
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'image' => array(
+					'type'              => 'string',
+					'sanitize_callback' => array( $obj, 'method' ),
+				),
+			),
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $schema );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'schema', $result );
+	}
+
+	/**
+	 * Issue #207: the cycle guard must hold independently of key-stripping.
+	 * Here the back-reference lives under a legitimate JSON Schema key
+	 * (properties), which is NOT stripped, so only the spl_object_id() guard
+	 * can prevent the runaway recursion. This pins the guard directly rather
+	 * than relying on the WP-only key being skipped before recursion.
+	 */
+	public function test_transform_withCycleUnderNonStrippedKey_doesNotBlowStack(): void {
+		$node             = new \stdClass();
+		$node->type       = 'object';
+		$node->properties = new \stdClass();
+		// Back-reference under 'properties' (a legit, non-stripped key).
+		$node->properties->child = $node;
+
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'node' => $node,
+			),
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $schema );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'schema', $result );
+	}
+
+	/**
+	 * Issue #207: WordPress-only keys (sanitize_callback, validate_callback,
+	 * arg_options) are not part of the JSON Schema spec and must not leak into
+	 * the emitted MCP schema. They should be stripped recursively while
+	 * legitimate JSON Schema keys are preserved.
+	 */
+	public function test_transform_stripsWpOnlyKeysFromEmittedSchema(): void {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'title' => array(
+					'type'              => 'string',
+					'description'       => 'Post title',
+					'enum'              => array( 'a', 'b' ),
+					'sanitize_callback' => 'sanitize_text_field',
+					'validate_callback' => 'rest_validate_request_arg',
+					'arg_options'       => array( 'sanitize_callback' => 'sanitize_text_field' ),
+				),
+			),
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $schema );
+
+		$emitted = $result['schema'];
+
+		$this->assertFalse( self::schema_contains_key( $emitted, 'sanitize_callback' ), 'sanitize_callback must be stripped' );
+		$this->assertFalse( self::schema_contains_key( $emitted, 'validate_callback' ), 'validate_callback must be stripped' );
+		$this->assertFalse( self::schema_contains_key( $emitted, 'arg_options' ), 'arg_options must be stripped' );
+
+		$property = $emitted['properties']['title'];
+		$this->assertSame( 'string', $property['type'] );
+		$this->assertSame( 'Post title', $property['description'] );
+		$this->assertSame( array( 'a', 'b' ), $property['enum'] );
+	}
+
+	/**
+	 * Issue #207 regression guard: a legitimate nested object schema, where
+	 * properties arrive as stdClass instances (as from a JSON decode cycle)
+	 * and carry no callbacks, must still convert to the expected array
+	 * structure.
+	 */
+	public function test_transform_legitimateNestedObjectSchema_stillConverts(): void {
+		$address               = new \stdClass();
+		$address->type         = 'object';
+		$street                = new \stdClass();
+		$street->type          = 'string';
+		$city                  = new \stdClass();
+		$city->type            = 'string';
+		$address_props         = new \stdClass();
+		$address_props->street = $street;
+		$address_props->city   = $city;
+		$address->properties   = $address_props;
+
+		$properties          = new \stdClass();
+		$properties->address = $address;
+
+		$schema = array(
+			'type'       => 'object',
+			'properties' => $properties,
+		);
+
+		$result = SchemaTransformer::transform_to_object_schema( $schema );
+
+		$this->assertFalse( $result['was_transformed'] );
+
+		$emitted = $result['schema'];
+		$this->assertIsArray( $emitted['properties'] );
+		$this->assertIsArray( $emitted['properties']['address'] );
+		$this->assertSame( 'object', $emitted['properties']['address']['type'] );
+		$this->assertIsArray( $emitted['properties']['address']['properties'] );
+		$this->assertSame( 'string', $emitted['properties']['address']['properties']['street']['type'] );
+		$this->assertSame( 'string', $emitted['properties']['address']['properties']['city']['type'] );
+	}
+
+	/**
+	 * Recursively determine whether a schema array contains the given key
+	 * anywhere in its structure.
+	 *
+	 * @param mixed  $value The value to search.
+	 * @param string $key   The key to look for.
+	 *
+	 * @return bool True if the key exists anywhere.
+	 */
+	private static function schema_contains_key( $value, string $key ): bool {
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+
+		if ( array_key_exists( $key, $value ) ) {
+			return true;
+		}
+
+		foreach ( $value as $item ) {
+			if ( self::schema_contains_key( $item, $key ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }


### PR DESCRIPTION
## What?
Closes #207 (recursion guard + key-stripping; create_server fail-soft split to a follow-up)

This PR hardens `SchemaTransformer` against a stack-overflow fatal triggered by object-valued schema callbacks, and stops WordPress-only argument keys from leaking into the emitted MCP schema.

## Why?
Issue #207 reports three problems. Two of them share a single root cause in `SchemaTransformer::convert_objects_to_arrays()`:

1. **Stack overflow (uncatchable fatal).** The method recursed over the schema graph, casting every object to an array and `array_map`-ing over it with no depth or cycle guard. When a schema argument carries an object-valued callable — for example an object-valued `sanitize_callback` whose object references itself — the cast preserves the cyclic graph and the recursion blows the PHP stack. The fatal is uncatchable, so it escapes the per-ability handling and takes down the whole server response. A real-world trigger is the WordPress/ai ability `ai/alt-text-generation`, which uses an object-valued `sanitize_callback`.
2. **WordPress-only keys leaking.** The keys `sanitize_callback`, `validate_callback`, and `arg_options` are WordPress argument conventions, not JSON Schema, yet they passed straight through into the emitted MCP schema.

The third problem reported in #207 — `create_server()` aborting the whole server on a single bad ability — is intentionally **not** in this PR (see Changelog/Testing notes). It is a narrower design decision and is split to a design-gated follow-up; once this fix lands, an uncatchable stack-overflow fatal no longer escapes the existing per-ability handling.

## How?
The unguarded recursive `array_map` in `convert_objects_to_arrays()` is replaced with a guarded `foreach` walk that:

- **Caps recursion** at `MAX_DEPTH = 64` to stop any pathological nesting.
- **Short-circuits cycles** by tracking visited objects via `spl_object_id()`, captured **before** the `(array)` cast — the cast discards object identity, so the id must be read first. A revisited object on the current branch returns `null`.
- **Strips the WordPress-only keys** (`sanitize_callback`, `validate_callback`, `arg_options`) during the same walk, so they never reach the output and any cyclic callable they carry is dropped before it can be traversed.

The public signature and return shape of `transform_to_object_schema()` are unchanged; the new `$depth` and `$visited` parameters are internal-only defaults on the private helper. The code is PHP 7.4 compatible.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: multi-agent investigation of the issue, test authoring, implementation, and review. All output was reviewed, edited, and is owned by the submitter.

## Testing Instructions
1. Install dev dependencies: `composer install`.
2. Run the unit suite: `npm run test:php` (or `composer test`). The suite passes — 23 tests / 116 assertions.
3. Run static analysis and linting: `npm run lint:php:stan` and `npm run lint:php` — both clean.
4. The four new tests in `tests/phpunit/Unit/Domain/Utils/SchemaTransformerTest.php` specifically cover:
   - a cyclic object-valued callback no longer overflows the stack;
   - a cycle placed under a non-stripped key pins the depth/cycle guard directly;
   - the WordPress-only keys are stripped from the output;
   - a legitimate nested object schema still converts correctly.
5. Optional end-to-end check: register an ability with an object-valued `sanitize_callback` (e.g. via WordPress/ai `ai/alt-text-generation`) and confirm the MCP server returns its tool schema instead of fataling.

## Changelog Entry

> Fixed - Guard `SchemaTransformer` against stack overflow from cyclic object-valued schema callbacks, and strip the WordPress-only keys (`sanitize_callback`, `validate_callback`, `arg_options`) from the emitted MCP schema.
