### PR TITLE
Move HttpTransport hook registration to boot()

### DIFF
--- a/docs/guides/custom-transports.md
+++ b/docs/guides/custom-transports.md
@@ -27,6 +27,7 @@ Custom transports implement one of two interfaces:
 ```php
 interface McpTransportInterface {
     public function __construct( McpTransportContext $context );
+    public function boot(): void;
     public function register_routes(): void;
 }
 ```
@@ -68,6 +69,9 @@ class ApiKeyTransport implements McpRestTransportInterface {
     
     public function __construct( McpTransportContext $context ) {
         $this->context = $context;
+    }
+
+    public function boot(): void {
         $this->register_routes();
     }
     
@@ -158,7 +162,8 @@ See [Transport Permissions](transport-permissions.md) for simpler authentication
 ## Implementation Notes
 
 ### Required Methods
-- `__construct()`: Accept `McpTransportContext` and call `register_routes()`
+- `__construct()`: Accept `McpTransportContext` and set up dependencies (no WordPress hooks)
+- `boot()`: Register WordPress hooks; `McpTransportFactory` calls this after construction
 - `register_routes()`: Register WordPress REST API endpoints
 - `check_permission()`: Validate request access (REST transports only)
 - `handle_request()`: Process MCP requests (REST transports only)

--- a/includes/Core/McpTransportFactory.php
+++ b/includes/Core/McpTransportFactory.php
@@ -83,8 +83,9 @@ class McpTransportFactory {
 			}
 
 			// Interface-based instantiation with dependency injection
-			$context = $this->create_transport_context();
-			new $mcp_transport( $context );
+			$context   = $this->create_transport_context();
+			$transport = new $mcp_transport( $context );
+			$transport->boot();
 		}
 	}
 

--- a/includes/Transport/Contracts/McpTransportInterface.php
+++ b/includes/Transport/Contracts/McpTransportInterface.php
@@ -29,6 +29,14 @@ interface McpTransportInterface {
 	public function __construct( McpTransportContext $context );
 
 	/**
+	 * Boot the transport after construction.
+	 *
+	 * Register WordPress hooks here rather than in the constructor.
+	 * Called by McpTransportFactory immediately after instantiation.
+	 */
+	public function boot(): void;
+
+	/**
 	 * Register transport-specific routes.
 	 *
 	 * Called during WordPress REST API initialization to register

--- a/includes/Transport/HttpTransport.php
+++ b/includes/Transport/HttpTransport.php
@@ -41,12 +41,20 @@ class HttpTransport implements McpRestTransportInterface {
 	protected HttpRequestHandler $request_handler;
 
 	/**
-	 * Initialize the class and register routes
+	 * Initialize the transport with the provided context.
 	 *
 	 * @param \WP\MCP\Transport\Infrastructure\McpTransportContext $transport_context The transport context.
 	 */
 	public function __construct( McpTransportContext $transport_context ) {
 		$this->request_handler = new HttpRequestHandler( $transport_context );
+	}
+
+	/**
+	 * Boot the transport and register WordPress hooks.
+	 *
+	 * Called by McpTransportFactory after construction so constructors stay free of hook side effects.
+	 */
+	public function boot(): void {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ), 16 );
 	}
 

--- a/tests/phpunit/Fixtures/DummyTransport.php
+++ b/tests/phpunit/Fixtures/DummyTransport.php
@@ -38,6 +38,10 @@ class DummyTransport implements McpRestTransportInterface {
 		return new \WP_REST_Response( array( 'success' => true ) );
 	}
 
+	public function boot(): void {
+		// No-op for testing
+	}
+
 	public function register_routes(): void {
 		// No-op for testing
 	}

--- a/tests/phpunit/Unit/Transport/HttpTransportBootTest.php
+++ b/tests/phpunit/Unit/Transport/HttpTransportBootTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Tests for HttpTransport boot lifecycle.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Transport;
+
+use WP\MCP\Core\McpServer;
+use WP\MCP\Handlers\Initialize\InitializeHandler;
+use WP\MCP\Handlers\Prompts\PromptsHandler;
+use WP\MCP\Handlers\Resources\ResourcesHandler;
+use WP\MCP\Handlers\System\SystemHandler;
+use WP\MCP\Handlers\Tools\ToolsHandler;
+use WP\MCP\Tests\Fixtures\DummyErrorHandler;
+use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
+use WP\MCP\Tests\TestCase;
+use WP\MCP\Transport\HttpTransport;
+use WP\MCP\Transport\Infrastructure\McpTransportContext;
+
+/**
+ * Test HttpTransport boot behavior.
+ */
+final class HttpTransportBootTest extends TestCase {
+
+	public function test_constructor_does_not_register_rest_api_init_hook(): void {
+		$transport = new HttpTransport( $this->createTransportContext() );
+
+		$this->assertFalse( has_action( 'rest_api_init', array( $transport, 'register_routes' ) ) );
+	}
+
+	public function test_boot_registers_rest_api_init_hook_at_expected_priority(): void {
+		$transport = new HttpTransport( $this->createTransportContext() );
+
+		$transport->boot();
+
+		$this->assertSame( 16, has_action( 'rest_api_init', array( $transport, 'register_routes' ) ) );
+	}
+
+	private function createTransportContext(): McpTransportContext {
+		$server = new McpServer(
+			'test-server',
+			'mcp/v1',
+			'/test-mcp',
+			'Test Server',
+			'Test server for HTTP transport boot',
+			'1.0.0',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class
+		);
+
+		return new McpTransportContext(
+			array(
+				'mcp_server'            => $server,
+				'initialize_handler'    => new InitializeHandler( $server ),
+				'tools_handler'         => new ToolsHandler( $server ),
+				'resources_handler'     => new ResourcesHandler( $server ),
+				'prompts_handler'       => new PromptsHandler( $server ),
+				'system_handler'        => new SystemHandler(),
+				'observability_handler' => new DummyObservabilityHandler(),
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #52 (review comment on #48): HttpTransport no longer registers est_api_init in its constructor.

- Add `boot()` to `McpTransportInterface` for WordPress hook registration after construction
- `McpTransportFactory` calls `boot()` immediately after instantiating each transport
- `HttpTransport::boot()` keeps the existing `rest_api_init` priority (16) behavior
- Update custom transport docs and add a small unit test for the boot lifecycle

## Motivation

Constructors should set up dependencies only; hook registration is explicit and easier to test in isolation. Happy to adjust naming or scope if maintainers prefer a lighter-touch approach (e.g. factory-only hook without an interface change).

Closes #52

## Test plan

- [ ] CI unit/integration suite passes
- [ ] `HttpTransportBootTest` confirms the constructor does not register hooks and `boot()` registers `rest_api_init` at priority 16
- [ ] Smoke: MCP REST route still resolves after plugin activation (`rest_url( 'mcp/mcp-adapter-default-server' )`)
