### PR TITLE
docs: clarify Abilities API is core in 6.9+ (fixes #150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For a full breakdown of the component structure, see the [Architecture Overview]
 ## Dependencies
 
 - **PHP**: >= 7.4
-- **WordPress**: >= 6.9
+- **WordPress**: >= 6.9 (includes the [Abilities API](https://developer.wordpress.org/news/2025/11/introducing-the-wordpress-abilities-api/) in core — no separate plugin)
 - **[php-mcp-schema](https://github.com/WordPress/php-mcp-schema)** (`^0.1.0`): Typed DTOs for MCP protocol types — installed automatically via Composer
 
 ## Installation

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -9,21 +9,25 @@ The MCP Adapter transforms WordPress abilities into AI-accessible interfaces, al
 ## Prerequisites
 
 - **PHP 7.4 or higher**
-- **WordPress 6.9 or higher**
-- **Composer** (recommended)
+- **WordPress 6.9 or higher** (Abilities API is built into core — no separate plugin)
+- **Composer** (optional — for plugin developers bundling the adapter as a dependency)
 
 ## Quick Start
 
 ### Step 1: Install MCP Adapter
 
-**Recommended: Composer Package**
-```bash
-composer require wordpress/mcp-adapter
-```
+**Recommended: WordPress plugin**
 
-**Alternative: WordPress Plugin**
 ```bash
 wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip --activate
+```
+
+Or download the latest release from [GitHub](https://github.com/WordPress/mcp-adapter/releases/latest) and install it like any other plugin.
+
+**For plugin developers: Composer package**
+
+```bash
+composer require wordpress/mcp-adapter
 ```
 
 ### Step 2: Register a Simple Ability

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,9 +4,21 @@ This guide covers different installation methods for the MCP Adapter.
 
 ## Installation Methods
 
-### Method 1: Composer Package (Recommended)
+### Method 1: WordPress Plugin (Recommended)
 
-The MCP Adapter is designed to be installed as a Composer package. This is the primary and recommended installation method:
+Download the latest release from [GitHub](https://github.com/WordPress/mcp-adapter/releases/latest) and install it like any other WordPress plugin, or use WP-CLI:
+
+```bash
+wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip --activate
+```
+
+The plugin automatically initializes and creates a default MCP server at `/wp-json/mcp/mcp-adapter-default-server`.
+
+Requires WordPress 6.9 or newer. The Abilities API ships with core — you do not need a separate abilities-api plugin.
+
+### Method 2: Composer Package (for plugin developers)
+
+If you are building a plugin that depends on MCP Adapter, install it as a Composer package:
 
 ```bash
 composer require wordpress/mcp-adapter
@@ -133,23 +145,13 @@ class MyMcpPlugin {
     
     public function missing_abilities_api_notice() {
         echo '<div class="notice notice-error"><p>';
-        echo 'My MCP Plugin requires the WordPress Abilities API to be loaded.';
+        echo 'My MCP Plugin requires WordPress 6.9 or newer (Abilities API is included in core).';
         echo '</p></div>';
     }
 }
 
 new MyMcpPlugin();
 ```
-
-### Method 2: WordPress Plugin (Alternative)
-
-Alternatively, you can install the MCP Adapter as a traditional WordPress plugin:
-
-```bash
-wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip --activate
-```
-
-The plugin automatically initializes and creates a default MCP server at `/wp-json/mcp/mcp-adapter-default-server`.
 
 ## Verifying Installation
 
@@ -197,7 +199,7 @@ add_action( 'wp_loaded', function() {
 - Run `composer install` in the plugin directory
 
 **"WordPress Abilities API not available"**
-- Ensure you're running WordPress 6.9 or higher.
+- Requires WordPress 6.9 or higher. The Abilities API is part of core — there is no separate plugin to install.
 
 **REST API not responding**
 - Check WordPress REST API is enabled

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -137,7 +137,7 @@ if ( ! class_exists( 'WP\MCP\Core\McpAdapter' ) ) {
 // Check in your plugin
 if ( ! function_exists( 'wp_register_ability' ) ) {
     add_action( 'admin_notices', function() {
-        echo '<div class="notice notice-error"><p>WordPress Abilities API is required.</p></div>';
+        echo '<div class="notice notice-error"><p>MCP Adapter requires WordPress 6.9 or newer. The Abilities API is included in core.</p></div>';
     });
     return;
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -76,7 +76,7 @@ final class Plugin {
 				'admin_notices',
 				static function () {
 					wp_admin_notice(
-						__( 'Abilities API not available (wp_register_ability function not found)', 'mcp-adapter' ),
+						__( 'MCP Adapter requires WordPress 6.9 or newer. The Abilities API is included in WordPress core.', 'mcp-adapter' ),
 						array(
 							'type'    => 'error',
 							'dismiss' => false,

--- a/readme.txt
+++ b/readme.txt
@@ -27,11 +27,11 @@ The MCP Adapter bridges WordPress's Abilities API with the [Model Context Protoc
 
 == Installation ==
 
-The primary installation method is via Composer:
+Install MCP Adapter as a WordPress plugin from the [latest GitHub release](https://github.com/WordPress/mcp-adapter/releases/latest), or see the [README](https://github.com/WordPress/mcp-adapter#installation) for WP-CLI and wp-env options.
 
-`composer require wordpress/mcp-adapter`
+Plugin developers can also add it as a Composer dependency: `composer require wordpress/mcp-adapter`
 
-The adapter can also be installed as a standard WordPress plugin from a GitHub release or a Git clone. See the [README](https://github.com/WordPress/mcp-adapter#installation) for detailed instructions.
+Requires WordPress 6.9 or newer (the Abilities API is included in core).
 
 == Changelog ==
 


### PR DESCRIPTION
﻿## Summary

Some docs still read like you need a separate Abilities API install. README.md was mostly updated in #165 and #204, but readme.txt and the getting-started guides were still Composer-first and pretty quiet about core.

This PR lines those up: says plainly that Abilities API ships with WordPress 6.9+, matches install docs to README (plugin first, Composer for plugin devs), and tightens the admin notice when core is too old.

Closes #150

## What changed

- README.md: one line in Dependencies
- readme.txt: plugin-first install wording
- docs/getting-started/README.md and installation.md: same story, flipped order
- common-issues.md + Plugin.php: clearer "you need WP 6.9+" messaging

## Test plan

- [x] Read-through for stale abilities-api / composer require references
- [ ] Maintainer eyeball on install doc ordering
