### PR TITLE
docs: document required `category` field for abilities

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -36,6 +36,7 @@ add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/get-site-info', [
         'label' => 'Get Site Information',
         'description' => 'Retrieves basic information about the current WordPress site',
+        'category' => 'site',
         'input_schema' => [
             'type' => 'object',
             'properties' => [

--- a/docs/getting-started/basic-examples.md
+++ b/docs/getting-started/basic-examples.md
@@ -2,6 +2,8 @@
 
 This guide provides simple, working examples for creating MCP tools, resources, and prompts using the WordPress MCP Adapter.
 
+> **Every ability needs a `category`.** It must be a registered category, or `wp_register_ability()` returns `null` and the ability never appears (no `WP_Error`, just a `_doing_it_wrong()` notice you'll miss unless `WP_DEBUG` is on). Core provides `site` and `user`; register custom categories on the `wp_abilities_api_categories_init` hook first. See [Ability categories](../guides/creating-abilities.md#ability-categories-required).
+
 ## Example 1: Tool - Create Post
 
 Tools execute actions and return results. Here's a simple post creation tool:
@@ -13,6 +15,7 @@ add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/create-post', [
         'label' => 'Create Post',
         'description' => 'Creates a new WordPress post with the specified content',
+        'category' => 'site',
         'input_schema' => [
             'type' => 'object',
             'properties' => [
@@ -130,6 +133,7 @@ add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/site-config', [
         'label' => 'Site Configuration',
         'description' => 'WordPress site configuration and settings',
+        'category' => 'site',
         'execute_callback' => function() {
             return [
                 'site_name' => get_bloginfo( 'name' ),
@@ -183,6 +187,7 @@ add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/code-review', [
         'label' => 'Code Review Prompt',
         'description' => 'Generate a code review prompt with specific focus areas',
+        'category' => 'site',
         'execute_callback' => function( $input ) {
             $code = $input['code'] ?? '';
             $focus = $input['focus'] ?? ['security', 'performance'];

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -85,6 +85,7 @@ class MyMcpPlugin {
             wp_register_ability( 'my-plugin/get-posts', [
                 'label' => 'Get Posts',
                 'description' => 'Retrieve WordPress posts',
+                'category' => 'site',
                 'input_schema' => [
                     'type' => 'object',
                     'properties' => [

--- a/docs/guides/creating-abilities.md
+++ b/docs/guides/creating-abilities.md
@@ -34,12 +34,32 @@ The `type` parameter specifies how the ability should be exposed in the MCP serv
 
 If not specified, abilities default to `type: 'tool'`.
 
+## Ability categories (required)
+
+Every ability **must** declare a `category`, and that category must already be registered when `wp_register_ability()` runs. If you omit `category` or use one that isn't registered, `wp_register_ability()` returns `null` and the ability never appears. There is no `WP_Error`; core calls `_doing_it_wrong()`, which only surfaces a PHP notice when `WP_DEBUG` is on. With `WP_DEBUG` off (typical on production) the failure looks completely silent.
+
+WordPress core registers two categories you can use right away: `site` and `user`.
+
+To use your own category, register it first on the `wp_abilities_api_categories_init` hook. Categories register on this hook; abilities register on `wp_abilities_api_init` — a separate, later hook. Register the category before any ability that references it:
+
+```php
+add_action( 'wp_abilities_api_categories_init', function () {
+    wp_register_ability_category( 'my-plugin', [
+        'label'       => 'My Plugin',
+        'description' => 'Abilities provided by My Plugin.',
+    ] );
+} );
+```
+
+Then reference the slug in your abilities: `'category' => 'my-plugin'`.
+
 ## Basic Ability Structure
 
 ```php
 wp_register_ability('my-plugin/my-ability', [
     'label' => 'My Ability',
     'description' => 'What this ability does',
+    'category' => 'site',         // Required. Must be a registered category (core: 'site', 'user').
     'input_schema' => [...],      // For tools (supports both object and flattened schemas)
     'output_schema' => [...],     // Optional for tools
     'execute_callback' => 'my_callback',
@@ -419,6 +439,7 @@ Resources and Prompts share the same annotation schema per MCP specification:
 wp_register_ability('my-plugin/analyze-data', [
     'label' => 'Data Analyzer',
     'description' => 'Analyze data with various algorithms',
+    'category' => 'site',
     'input_schema' => [...],
     'execute_callback' => 'analyze_data_callback',
     'permission_callback' => function() { return current_user_can('read'); },
@@ -441,6 +462,7 @@ wp_register_ability('my-plugin/analyze-data', [
 wp_register_ability('my-plugin/user-data', [
     'label' => 'User Data Resource',
     'description' => 'Access to user profile data',
+    'category' => 'user',
     'execute_callback' => 'get_user_data',
     'permission_callback' => function() { return current_user_can('read'); },
     'meta' => [
@@ -461,6 +483,7 @@ wp_register_ability('my-plugin/user-data', [
 wp_register_ability('my-plugin/review-prompt', [
     'label' => 'Code Review Prompt',
     'description' => 'Generate structured code review prompts',
+    'category' => 'site',
     'input_schema' => [
         'type' => 'object',
         'properties' => [
@@ -492,6 +515,7 @@ Tools execute actions and return results:
 wp_register_ability('my-plugin/create-post', [
     'label' => 'Create Post',
     'description' => 'Create a new WordPress post with the given title and content',
+    'category' => 'site',
     'input_schema' => [
         'type' => 'object',
         'properties' => [
@@ -556,6 +580,7 @@ For simple tools that accept and return single values, you can use flattened sch
 wp_register_ability('my-plugin/count-posts', [
     'label' => 'Count Posts',
     'description' => 'Count posts of a specific type',
+    'category' => 'site',
     'input_schema' => [
         'type' => 'string',
         'description' => 'Post type to count',
@@ -599,6 +624,7 @@ Resources provide access to data or content. They require a `uri` in the meta fi
 wp_register_ability('my-plugin/site-config', [
     'label' => 'Site Configuration',
     'description' => 'WordPress site configuration and settings',
+    'category' => 'site',
     'execute_callback' => function() {
         return [
             'site_name' => get_bloginfo('name'),
@@ -656,6 +682,7 @@ Prompts use standard JSON Schema `input_schema` to define their parameters. The 
 wp_register_ability('my-plugin/code-review', [
     'label' => 'Code Review Prompt',
     'description' => 'Generate a code review prompt with specific focus areas',
+    'category' => 'site',
     'input_schema' => [
         'type' => 'object',
         'properties' => [
@@ -712,6 +739,7 @@ You can also annotate the generated message content according to the [MCP specif
 wp_register_ability('my-plugin/analysis-prompt', [
     'label' => 'Analysis Prompt',
     'description' => 'Generate analysis prompts with content annotations',
+    'category' => 'site',
     'input_schema' => [
         'type' => 'object',
         'properties' => [

--- a/docs/guides/default-server.md
+++ b/docs/guides/default-server.md
@@ -393,6 +393,7 @@ The default server implements a metadata-driven security model:
 wp_register_ability('my-plugin/safe-tool', [
     'label' => 'Safe Tool',
     'description' => 'A safe tool for MCP access',
+    'category' => 'site',
     'execute_callback' => 'my_safe_callback',
     'permission_callback' => function() {
         return current_user_can('read');

--- a/docs/guides/transport-permissions.md
+++ b/docs/guides/transport-permissions.md
@@ -167,7 +167,10 @@ $adapter->create_server(
     }
 );
 
-// Individual abilities check specific permissions:
+// Individual abilities check specific permissions.
+// Partial snippet — only the permission_callback is shown. A working
+// registration also needs 'label', 'description', 'category', and
+// 'execute_callback' (see the Creating Abilities guide).
 wp_register_ability('my-plugin/edit-post', [
     'permission_callback' => function($args) {
         // Ability: Check if user can edit THIS specific post

--- a/docs/guides/transport-permissions.md
+++ b/docs/guides/transport-permissions.md
@@ -168,9 +168,9 @@ $adapter->create_server(
 );
 
 // Individual abilities check specific permissions.
-// Partial snippet — only the permission_callback is shown. A working
+// Partial snippet: only the permission_callback is shown. A working
 // registration also needs 'label', 'description', 'category', and
-// 'execute_callback' (see the Creating Abilities guide).
+// 'execute_callback'.
 wp_register_ability('my-plugin/edit-post', [
     'permission_callback' => function($args) {
         // Ability: Check if user can edit THIS specific post
@@ -179,6 +179,8 @@ wp_register_ability('my-plugin/edit-post', [
     // ...
 ]);
 ```
+
+The omitted fields are required. See [Creating Abilities](creating-abilities.md) for the full registration shape.
 
 ## Best Practices
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -245,6 +245,40 @@ function(): bool {
 
 ## Ability Issues
 
+### `wp_register_ability()` returns `null`
+
+A common cause is a missing or unregistered `category`. `wp_register_ability()` requires a `category`, and that category must already be registered when registration runs. If it is missing or unknown, the function returns `null` and the ability never appears. There is no `WP_Error`; core calls `_doing_it_wrong()`, which only surfaces a notice when `WP_DEBUG` is on. With `WP_DEBUG` off (typical on production) it looks completely silent, so enable it and check the debug log for a message like `Ability category "..." is not registered`.
+
+```php
+// Wrong: no category → returns null, ability never registers.
+wp_register_ability( 'my-plugin/my-ability', [
+    'label'       => 'My Ability',
+    'description' => 'Test ability',
+    // ...
+] );
+
+// Right: use a registered category. Core provides 'site' and 'user'.
+wp_register_ability( 'my-plugin/my-ability', [
+    'label'       => 'My Ability',
+    'description' => 'Test ability',
+    'category'    => 'site',
+    // ...
+] );
+```
+
+For a custom category, register it first on the `wp_abilities_api_categories_init` hook (a separate, earlier hook than `wp_abilities_api_init`):
+
+```php
+add_action( 'wp_abilities_api_categories_init', function () {
+    wp_register_ability_category( 'my-plugin', [
+        'label'       => 'My Plugin',
+        'description' => 'Abilities provided by My Plugin.',
+    ] );
+} );
+```
+
+See [Ability categories](../guides/creating-abilities.md#ability-categories-required) for details.
+
 ### Ability Not Found
 ```bash
 # Check ability is registered

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -247,7 +247,7 @@ function(): bool {
 
 ### `wp_register_ability()` returns `null`
 
-A common cause is a missing or unregistered `category`. `wp_register_ability()` requires a `category`, and that category must already be registered when registration runs. If it is missing or unknown, the function returns `null` and the ability never appears. There is no `WP_Error`; core calls `_doing_it_wrong()`, which only surfaces a notice when `WP_DEBUG` is on. With `WP_DEBUG` off (typical on production) it looks completely silent, so enable it and check the debug log for a message like `Ability category "..." is not registered`.
+A common cause is a missing or unregistered `category`. `wp_register_ability()` requires a `category`, and that category must already be registered when registration runs. If it is missing or unknown, the function returns `null` and the ability never appears. There is no `WP_Error`; core calls `_doing_it_wrong()`, which only surfaces a notice when `WP_DEBUG` is on. With `WP_DEBUG` off (typical on production) it looks completely silent. Enable `WP_DEBUG` to surface the notice, plus `WP_DEBUG_LOG` to capture it in `wp-content/debug.log`, then look for a message like `Ability category "..." is not registered`.
 
 ```php
 // Wrong: no category → returns null, ability never registers.


### PR DESCRIPTION
## What?
Closes #135

Documents the required `category` field for WordPress abilities across the docs, and clarifies what actually happens when it's missing.

## Why?
In #135, `wp_register_ability()` returned `NULL` for a user and they couldn't tell why. They suspected a load-order conflict with WooCommerce's bundled Abilities API. It wasn't that.

The real cause: core requires a `category`, and every registration example in our docs omitted it. So copy-pasting our docs reproduced the failure. @justlevine flagged this as a recurring DX/docs stumbling block, which is what this PR addresses.

I verified the behavior against WordPress 6.9 core source (`wp-includes/abilities.php`, `default-filters.php`) rather than trusting the issue thread:
- `category` is required.
- Core registers exactly two default categories: `site` and `user` (via `wp_register_core_ability_categories()`, hooked on `wp_abilities_api_categories_init`). No plugin code needed to use them.
- On a missing or unregistered category, `wp_register_ability()` returns `null` with **no** `WP_Error`, but does call `_doing_it_wrong()`. That notice only surfaces with `WP_DEBUG` on, so on production it looks completely silent. That's why it's so easy to misdiagnose.

## How?
- Added `'category'` to every ability-registration example across the docs (`site`, or `user` for the user-data resource example).
- Added a dedicated **"Ability categories (required)"** section in `creating-abilities.md` covering the core defaults, registering a custom category with `wp_register_ability_category()`, and the `wp_abilities_api_categories_init` vs `wp_abilities_api_init` hook ordering.
- Added a top callout in `basic-examples.md`.
- Added a troubleshooting entry in `common-issues.md` for the `null` return, including the tip to enable `WP_DEBUG` and check the log for `Ability category "..." is not registered`.
- Worded the failure accurately: returns `null`, no `WP_Error`, `_doing_it_wrong()` notice only with `WP_DEBUG` on (not truly "silent").

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Drafting the doc edits and verifying the core-behavior claims (default categories, null-on-failure path) against WordPress core source. All claims were checked against `wordpress-develop` 6.9/trunk and reviewed and edited by me.

## Testing Instructions
Docs-only change, no code paths touched.

1. Rendered-docs check: confirm the new "Ability categories (required)" section renders and the cross-links from `basic-examples.md` and `common-issues.md` resolve to it.
2. (Optional) Confirm the documented behavior on a WP 6.9 site:
   ```bash
   # Without a category -> registration fails (returns null)
   wp eval 'var_dump( wp_register_ability( "demo/x", [ "label"=>"X", "description"=>"d", "execute_callback"=>"__return_true", "permission_callback"=>"__return_true" ] ) );'

   # With a core category -> registers
   wp eval 'var_dump( (bool) wp_register_ability( "demo/y", [ "label"=>"Y", "description"=>"d", "category"=>"site", "execute_callback"=>"__return_true", "permission_callback"=>"__return_true" ] ) );'
   ```

## Changelog Entry
> Developer - Documented the required `category` field for abilities, the core `site`/`user` categories, registering custom categories, and the `null`-on-missing-category failure mode.