### PR TITLE
fix: normalize empty input to empty array for schema-defining abilities

### DIFF
--- a/includes/Domain/Utils/AbilityArgumentNormalizer.php
+++ b/includes/Domain/Utils/AbilityArgumentNormalizer.php
@@ -16,9 +16,13 @@ namespace WP\MCP\Domain\Utils;
  * PHP decodes this as [] (empty array).
  *
  * Abilities without an input_schema expect null, not an empty array.
- * Abilities with an input_schema expect an empty array, never null. PHP's
- * [] satisfies an empty object or empty array schema, but null fails
- * validation as "not of type <schema type>" (object, array, and so on).
+ * Abilities with an input_schema usually expect an empty array, never null:
+ * PHP's [] satisfies an empty object or empty array schema, but null fails
+ * validation as "not of type <schema type>" (object, array, and so on). Two
+ * exceptions keep null: a schema whose type explicitly permits null (an
+ * explicit null value is passed through), and a schema with a top-level
+ * default, where null lets the Abilities API apply that default for both a
+ * null and an empty {} input. In both, null is the author's declared intent.
  *
  * @since 0.5.0
  */
@@ -29,16 +33,19 @@ class AbilityArgumentNormalizer {
 	 *
 	 * No input schema: empty arrays are converted to null, so abilities that
 	 * take no parameters see null.
-	 * Has input schema: null or an empty array is converted to an empty array,
-	 * so a zero-argument call passes schema validation instead of failing as
-	 * "not of type <schema type>" (object, array, and so on).
+	 * Has input schema: null or an empty array normalizes to an empty array so a
+	 * zero-argument call passes schema validation instead of failing as "not of
+	 * type <schema type>" (object, array, and so on). Two exceptions return null:
+	 * a top-level default (both null and {} return null so the Abilities API
+	 * applies the default) and a type that explicitly permits null (an explicit
+	 * null is passed through).
 	 *
 	 * @param \WP_Ability $ability    The ability to normalize parameters for.
 	 * @param mixed       $parameters The parameters to normalize.
 	 *
-	 * @return mixed Normalized parameters (null when no schema and params are empty; empty array when a schema is present and params are empty or null).
+	 * @return mixed Normalized parameters (null when no schema and params are empty; empty array when a schema is present and params are empty or null, unless the schema declares a top-level default or its type permits null, in which case null is returned).
 	 * @since 0.5.0
-	 * @since n.e.x.t Empty or null parameters for schema-defining abilities normalize to an empty array.
+	 * @since n.e.x.t Empty or null parameters for schema-defining abilities normalize to an empty array, except when the schema declares a top-level default (honored for both null and empty {} input) or its type explicitly permits null.
 	 */
 	public static function normalize( \WP_Ability $ability, $parameters ) {
 		$input_schema = $ability->get_input_schema();
@@ -48,12 +55,53 @@ class AbilityArgumentNormalizer {
 			return is_array( $parameters ) && empty( $parameters ) ? null : $parameters;
 		}
 
-		// Has schema: a missing/empty argument set (null or {}) -> [], which
-		// satisfies an empty object or array schema. null never validates.
+		// Has schema, missing/empty argument set (null or {}).
 		if ( null === $parameters || array() === $parameters ) {
+			// A top-level default is the author's declared "no input" value.
+			// Return null for BOTH null and {} so WP_Ability::normalize_input()
+			// applies the default -- it fills the default only when input is null.
+			// An MCP client sends {} to mean "no arguments", so {} must honor the
+			// default too, not just an omitted parameter.
+			if ( array_key_exists( 'default', $input_schema ) ) {
+				return null;
+			}
+
+			// An explicit null from the client is kept only when the schema's
+			// type permits null; {} stays [] as an empty object.
+			if ( null === $parameters && self::schema_permits_null( $input_schema ) ) {
+				return null;
+			}
+
+			// Otherwise use [], which satisfies an empty object or array schema
+			// so a zero-argument call validates. null never validates on its own.
 			return array();
 		}
 
 		return $parameters;
+	}
+
+	/**
+	 * Whether the schema's top-level type explicitly permits null.
+	 *
+	 * Only an explicit top-level type is honored (JSON Schema "null", or a type
+	 * array containing "null"). Composition keywords that also permit null
+	 * (anyOf/oneOf/enum/const) are not inspected; such a schema falls through to
+	 * [], which still validates when object or array is among the allowed forms.
+	 * A schema with no type is treated as not permitting null, so a zero-argument
+	 * call still normalizes to [] for callbacks that expect an array.
+	 *
+	 * @param array<string,mixed> $input_schema The ability input schema.
+	 *
+	 * @return bool True when null is a valid top-level value for the schema.
+	 * @since n.e.x.t
+	 */
+	private static function schema_permits_null( array $input_schema ): bool {
+		$type = $input_schema['type'] ?? null;
+
+		if ( is_array( $type ) ) {
+			return in_array( 'null', $type, true );
+		}
+
+		return 'null' === $type;
 	}
 }

--- a/includes/Domain/Utils/AbilityArgumentNormalizer.php
+++ b/includes/Domain/Utils/AbilityArgumentNormalizer.php
@@ -16,8 +16,9 @@ namespace WP\MCP\Domain\Utils;
  * PHP decodes this as [] (empty array).
  *
  * Abilities without an input_schema expect null, not an empty array.
- * Abilities with an input_schema expect an empty array (a valid empty
- * object), never null, or validation rejects it as "not of type object".
+ * Abilities with an input_schema expect an empty array, never null. PHP's
+ * [] satisfies an empty object or empty array schema, but null fails
+ * validation as "not of type <schema type>" (object, array, and so on).
  *
  * @since 0.5.0
  */
@@ -29,8 +30,8 @@ class AbilityArgumentNormalizer {
 	 * No input schema: empty arrays are converted to null, so abilities that
 	 * take no parameters see null.
 	 * Has input schema: null or an empty array is converted to an empty array,
-	 * so a zero-argument call validates as an empty object instead of failing
-	 * as "not of type object".
+	 * so a zero-argument call passes schema validation instead of failing as
+	 * "not of type <schema type>" (object, array, and so on).
 	 *
 	 * @param \WP_Ability $ability    The ability to normalize parameters for.
 	 * @param mixed       $parameters The parameters to normalize.
@@ -47,8 +48,8 @@ class AbilityArgumentNormalizer {
 			return is_array( $parameters ) && empty( $parameters ) ? null : $parameters;
 		}
 
-		// Has schema: a missing/empty argument set (null or {}) -> empty object,
-		// so validation sees a valid empty object, never null.
+		// Has schema: a missing/empty argument set (null or {}) -> [], which
+		// satisfies an empty object or array schema. null never validates.
 		if ( null === $parameters || array() === $parameters ) {
 			return array();
 		}

--- a/includes/Domain/Utils/AbilityArgumentNormalizer.php
+++ b/includes/Domain/Utils/AbilityArgumentNormalizer.php
@@ -14,7 +14,10 @@ namespace WP\MCP\Domain\Utils;
  *
  * MCP clients send {} (empty object) for tools without arguments.
  * PHP decodes this as [] (empty array).
- * Abilities without input_schema expect null, not empty array.
+ *
+ * Abilities without an input_schema expect null, not an empty array.
+ * Abilities with an input_schema expect an empty array (a valid empty
+ * object), never null, or validation rejects it as "not of type object".
  *
  * @since 0.5.0
  */
@@ -23,21 +26,31 @@ class AbilityArgumentNormalizer {
 	/**
 	 * Normalize parameters for an ability based on its input schema.
 	 *
-	 * If the ability has no input schema, empty arrays are converted to null.
-	 * This ensures compatibility with abilities that don't accept parameters.
+	 * No input schema: empty arrays are converted to null, so abilities that
+	 * take no parameters see null.
+	 * Has input schema: null or an empty array is converted to an empty array,
+	 * so a zero-argument call validates as an empty object instead of failing
+	 * as "not of type object".
 	 *
-	 * @param \WP_Ability $ability The ability to normalize parameters for.
-	 * @param mixed $parameters The parameters to normalize.
+	 * @param \WP_Ability $ability    The ability to normalize parameters for.
+	 * @param mixed       $parameters The parameters to normalize.
 	 *
-	 * @return mixed Normalized parameters (null if ability has no schema and params are empty).
+	 * @return mixed Normalized parameters (null when no schema and params are empty; empty array when a schema is present and params are empty or null).
 	 * @since 0.5.0
-	 *
+	 * @since n.e.x.t Empty or null parameters for schema-defining abilities normalize to an empty array.
 	 */
 	public static function normalize( \WP_Ability $ability, $parameters ) {
 		$input_schema = $ability->get_input_schema();
 
-		if ( empty( $input_schema ) && is_array( $parameters ) && empty( $parameters ) ) {
-			return null;
+		// No schema: an empty {} means "no arguments" -> null.
+		if ( empty( $input_schema ) ) {
+			return is_array( $parameters ) && empty( $parameters ) ? null : $parameters;
+		}
+
+		// Has schema: a missing/empty argument set (null or {}) -> empty object,
+		// so validation sees a valid empty object, never null.
+		if ( null === $parameters || array() === $parameters ) {
+			return array();
 		}
 
 		return $parameters;

--- a/tests/phpunit/Unit/Domain/Utils/AbilityArgumentNormalizerTest.php
+++ b/tests/phpunit/Unit/Domain/Utils/AbilityArgumentNormalizerTest.php
@@ -116,6 +116,96 @@ final class AbilityArgumentNormalizerTest extends TestCase {
 	}
 
 	/**
+	 * Test that null is preserved when the schema's type explicitly permits null.
+	 *
+	 * A schema typed ["null","object"] declares null as a valid value. Forcing []
+	 * would discard the author's intent, so null must pass through unchanged.
+	 * See issue #229 discussion.
+	 */
+	public function test_null_parameters_preserved_when_schema_permits_null(): void {
+		$ability = $this->create_ability_mock(
+			array(
+				'type'       => array( 'null', 'object' ),
+				'properties' => array(
+					'name' => array( 'type' => 'string' ),
+				),
+			)
+		);
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, null );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that null is preserved when the schema declares a top-level default.
+	 *
+	 * WP_Ability::normalize_input() fills a top-level default only when input is
+	 * null. Forcing [] would skip the default, so null must pass through for the
+	 * Abilities API to apply it. See issue #229 discussion.
+	 */
+	public function test_null_parameters_preserved_when_schema_has_default(): void {
+		$ability = $this->create_ability_mock(
+			array(
+				'type'    => 'array',
+				'items'   => array( 'type' => 'string' ),
+				'default' => array( 'a', 'b' ),
+			)
+		);
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, null );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that an empty {} is kept as null when the schema declares a default.
+	 *
+	 * WP_Ability::normalize_input() applies a top-level default only when input
+	 * is null. An MCP client sends {} to mean "no arguments", so {} (decoded as
+	 * []) must also return null here, otherwise the default is skipped and a
+	 * schema with required fields fails. Issue #229's title covers "empty {} /
+	 * omitted parameters" alike.
+	 */
+	public function test_empty_array_preserved_as_null_when_schema_has_default(): void {
+		$ability = $this->create_ability_mock(
+			array(
+				'type'       => 'object',
+				'required'   => array( 'x' ),
+				'default'    => array( 'x' => 1 ),
+				'properties' => array(
+					'x' => array( 'type' => 'integer' ),
+				),
+			)
+		);
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, array() );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that an empty array still normalizes to [] even when the schema permits null.
+	 *
+	 * Only a null value is preserved; an explicit empty {} from the client stays [].
+	 */
+	public function test_empty_array_normalized_to_empty_array_when_schema_permits_null(): void {
+		$ability = $this->create_ability_mock(
+			array(
+				'type'       => array( 'null', 'object' ),
+				'properties' => array(
+					'name' => array( 'type' => 'string' ),
+				),
+			)
+		);
+
+		$result = AbilityArgumentNormalizer::normalize( $ability, array() );
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+
+	/**
 	 * Test that non-array parameters are passed through unchanged.
 	 */
 	public function test_non_array_parameters_passed_through(): void {

--- a/tests/phpunit/Unit/Domain/Utils/AbilityArgumentNormalizerTest.php
+++ b/tests/phpunit/Unit/Domain/Utils/AbilityArgumentNormalizerTest.php
@@ -93,9 +93,13 @@ final class AbilityArgumentNormalizerTest extends TestCase {
 	}
 
 	/**
-	 * Test that null parameters remain null even with input schema.
+	 * Test that null parameters normalize to an empty array when the ability has an input schema.
+	 *
+	 * A schema-defining ability validates its input against the schema. null is
+	 * rejected as "not of type object"; an empty array is a valid empty object.
+	 * See issue #229.
 	 */
-	public function test_null_parameters_remain_null_with_schema(): void {
+	public function test_null_parameters_normalized_to_empty_array_with_schema(): void {
 		$ability = $this->create_ability_mock(
 			array(
 				'type'       => 'object',
@@ -107,7 +111,8 @@ final class AbilityArgumentNormalizerTest extends TestCase {
 
 		$result = AbilityArgumentNormalizer::normalize( $ability, null );
 
-		$this->assertNull( $result );
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
 	}
 
 	/**


### PR DESCRIPTION
## What

`AbilityArgumentNormalizer::normalize()` now converts `null` or an empty array to an empty array when the ability has an `input_schema`. Abilities without a schema keep the existing empty-to-`null` behavior.

## Why

A zero-argument tool call sends `{}` (or omits `arguments`). For an ability that declares an `input_schema`, that value could reach `WP_Ability::execute()` as `null`, and validation rejected it:

```
Ability "example/get-info" has invalid input. Reason: input is not of type object.
```

An empty array is a valid empty object in WordPress (`rest_is_object([])` is `true`), so passing `[]` instead of `null` lets a no-argument call through, while abilities with required properties still fail as they should.

Refs #229.

## Testing

Verified live through the MCP Inspector over HTTP (default server, `mcp-adapter-execute-ability` and direct-tool paths), on WP 6.9 and 7.0:

| Ability schema | Empty `{}` before | Empty `{}` after |
|---|---|---|
| `object`, all-optional | passed already | passes |
| `array` / non-object | **failed** ("not of type array") | passes |

- PHPCS: clean
- PHPStan L8: clean
- Normalizer unit test updated (`test_null_parameters_normalized_to_empty_array_with_schema`)
- Full PHPUnit suite not run locally (tests wp-env would not start); please rely on CI.

## Note on #229

I could not reproduce the reporter's exact case (an `object` schema failing on `{}`) on either `v0.5.0` or trunk. This change fixes the real failure I did find (non-object schemas) and hardens the object path against `null`. It may not be the exact cause on their sites, so I'd keep #229 open until they share a failing ability's `input_schema`.

https://claude.ai/code/session_012RXWKvFkSm6LtNAYzPySHt