### PR TITLE
feat: map open_world ability annotation to openWorldHint

### DIFF
--- a/docs/guides/creating-abilities.md
+++ b/docs/guides/creating-abilities.md
@@ -312,7 +312,7 @@ The MCP Adapter automatically converts WordPress Abilities API annotation names 
         'readonly' => true,        // Auto-converted to readOnlyHint
         'destructive' => false,    // Auto-converted to destructiveHint
         'idempotent' => true,      // Auto-converted to idempotentHint
-        'openWorldHint' => false,  // No WordPress equivalent, use MCP format
+        'open_world' => false,     // Auto-converted to openWorldHint
         'title' => 'My Tool'       // No WordPress equivalent, use MCP format
     ]
 ]
@@ -336,7 +336,7 @@ The MCP Adapter automatically converts WordPress Abilities API annotation names 
 | `readonly` | `readOnlyHint` | Tool doesn't modify data |
 | `destructive` | `destructiveHint` | Tool may delete/destroy data |
 | `idempotent` | `idempotentHint` | Same input → same output |
-| *(no equivalent)* | `openWorldHint` | Can work with arbitrary data |
+| `open_world` | `openWorldHint` | Can work with arbitrary data |
 | *(no equivalent)* | `title` | Custom display title |
 
 **Why Use WordPress Format?**
@@ -386,6 +386,7 @@ Tools support these MCP specification annotations:
 - `readonly` → `readOnlyHint`
 - `destructive` → `destructiveHint`
 - `idempotent` → `idempotentHint`
+- `open_world` → `openWorldHint`
 
 ### Resource & Prompt Annotations (Annotations)
 
@@ -427,7 +428,7 @@ wp_register_ability('my-plugin/analyze-data', [
             'readonly' => true,              // WordPress format → readOnlyHint
             'destructive' => false,          // WordPress format → destructiveHint
             'idempotent' => true,            // WordPress format → idempotentHint
-            'openWorldHint' => false,        // No WordPress equivalent
+            'open_world' => false,           // WordPress format → openWorldHint
             'title' => 'Data Analysis Tool'  // No WordPress equivalent
         ],
         'mcp' => [

--- a/includes/Domain/Utils/McpAnnotationMapper.php
+++ b/includes/Domain/Utils/McpAnnotationMapper.php
@@ -74,7 +74,7 @@ class McpAnnotationMapper {
 		'openWorldHint'   => array(
 			'type'             => 'boolean',
 			'features'         => array( 'tool' ),
-			'ability_property' => null,
+			'ability_property' => 'open_world',
 		),
 		'title'           => array(
 			'type'             => 'string',

--- a/tests/phpunit/Unit/Domain/Utils/McpAnnotationMapperTest.php
+++ b/tests/phpunit/Unit/Domain/Utils/McpAnnotationMapperTest.php
@@ -150,6 +150,30 @@ final class McpAnnotationMapperTest extends TestCase {
 		$this->assertTrue( $result['idempotentHint'] );
 	}
 
+	public function test_map_maps_open_world_to_openworldhint(): void {
+		$annotations = array(
+			'open_world' => false,
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'tool' );
+
+		$this->assertArrayHasKey( 'openWorldHint', $result );
+		$this->assertArrayNotHasKey( 'open_world', $result );
+		$this->assertFalse( $result['openWorldHint'] );
+	}
+
+	public function test_open_world_override_takes_precedence_over_openworldhint(): void {
+		$annotations = array(
+			'openWorldHint' => true,
+			'open_world'    => false,
+		);
+
+		$result = McpAnnotationMapper::map( $annotations, 'tool' );
+
+		$this->assertArrayHasKey( 'openWorldHint', $result );
+		$this->assertFalse( $result['openWorldHint'], 'WordPress-format open_world should override openWorldHint value' );
+	}
+
 	public function test_map_excludes_tool_fields_for_resource(): void {
 		$annotations = array(
 			'readonly'    => true,
@@ -232,15 +256,13 @@ final class McpAnnotationMapperTest extends TestCase {
 	public function test_map_with_null_ability_property_uses_mcp_field_name_for_tools(): void {
 		$annotations = array(
 			// Fields with null ability_property should map 1:1.
-			// For tools, only openWorldHint and title have null ability_property.
-			'openWorldHint' => true,
-			'title'         => 'Test',
+			// For tools, only title has null ability_property.
+			'title' => 'Test',
 		);
 
 		$result = McpAnnotationMapper::map( $annotations, 'tool' );
 
 		// These should map 1:1 (ability_property is null)
-		$this->assertArrayHasKey( 'openWorldHint', $result );
 		$this->assertArrayHasKey( 'title', $result );
 	}
 


### PR DESCRIPTION
## What?

Follow up to WordPress/ai#739, which introduces the WordPress-format `open_world` annotation on the `core/read-content` ability.

Adds `open_world` to the WordPress → MCP annotation conversion in `McpAnnotationMapper`, so abilities can declare the MCP `openWorldHint` tool annotation using the WordPress Abilities API naming convention, like the existing `readonly`, `destructive`, and `idempotent` keys.

## Why?

The adapter already converts WordPress-format annotation keys to MCP tool annotations (`readonly` → `readOnlyHint`, `destructive` → `destructiveHint`, `idempotent` → `idempotentHint`), but `openWorldHint` had no WordPress-format equivalent (`ability_property => null`), so a WordPress-format `'open_world' => false` annotation was silently dropped.

Per the MCP specification, clients assume `openWorldHint` is `true` when the hint is absent. That means closed-world abilities that declare `'open_world' => false` — such as `core/read-content` in WordPress/ai#739, which only reads the local database — were presented to MCP clients as tools that may interact with external systems.

## How?

- Sets the `ability_property` for `openWorldHint` to `open_world` in `McpAnnotationMapper::$mcp_annotations`. The existing resolution logic handles the rest: the WordPress-format key takes precedence when both are present, and the direct MCP-format `openWorldHint` key keeps working unchanged.
- Adds unit tests for the new mapping and its precedence over the MCP-format key, and updates the null-`ability_property` test (for tools, only `title` remains without a WordPress equivalent).
- Documents the new mapping in `docs/guides/creating-abilities.md`.

## Testing Instructions

1. Register an ability with `'meta' => array( 'annotations' => array( 'open_world' => false ) )` and expose it as a tool on an MCP server.
2. Call `tools/list` on the server and confirm the tool's annotations include `"openWorldHint": false` (before this change the hint was missing).

Or run the mapper unit tests:

```
npm run test:php -- --filter McpAnnotationMapperTest
```

## Changelog Entry

> Added - Support the WordPress-format `open_world` ability annotation, mapped to the MCP `openWorldHint` tool annotation.
