### PR TITLE
fix: use Jetpack Autoloader to resolve WP\MCP\ version conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,12 @@ jobs:
         uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
         with:
           composer-options: '--no-dev'
+        env:
+          # Give the Jetpack Autoloader the real plugin version for its class
+          # manifest, so "newest copy wins" works when another plugin (e.g.
+          # WooCommerce) bundles an older copy of the WP\MCP\ classes. Without
+          # this, Composer guesses a dev-* version from the git ref.
+          COMPOSER_ROOT_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 		"optimize-autoloader": true,
 		"preferred-install": "dist",
 		"allow-plugins": {
+			"automattic/jetpack-autoloader": true,
 			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"phpstan/extension-installer": true
 		}
@@ -52,6 +53,7 @@
 	},
 	"require": {
 		"php": "^7.4 || ^8.0",
+		"automattic/jetpack-autoloader": "^5.0",
 		"wordpress/php-mcp-schema": "^0.1.0",
 		"ext-json": "*"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,72 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eab1e59f0252f2ffc0acdc7fb7c49ee6",
+    "content-hash": "2bf3c59511fe4c61bb8f869ad43cc29c",
     "packages": [
+        {
+            "name": "automattic/jetpack-autoloader",
+            "version": "v5.0.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "b6abf43a9ea638d6a0edc02f0dd7575703f9c2a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/b6abf43a9ea638d6a0edc02f0dd7575703f9c2a1",
+                "reference": "b6abf43a9ea638d6a0edc02f0dd7575703f9c2a1",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "^1.0.9",
+                "composer/composer": "^2.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-autoloader",
+                "branch-alias": {
+                    "dev-trunk": "5.0.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-autoloader/compare/v${old}...v${new}"
+                },
+                "version-constants": {
+                    "::VERSION": "src/AutoloadGenerator.php"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Autoloader\\": "src"
+                },
+                "classmap": [
+                    "src/AutoloadGenerator.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "keywords": [
+                "autoload",
+                "autoloader",
+                "composer",
+                "jetpack",
+                "plugin",
+                "wordpress"
+            ],
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v5.0.20"
+            },
+            "time": "2026-06-15T12:15:05+00:00"
+        },
         {
             "name": "wordpress/php-mcp-schema",
             "version": "v0.1.2",

--- a/includes/Autoloader.php
+++ b/includes/Autoloader.php
@@ -40,10 +40,7 @@ final class Autoloader {
 			return self::$is_loaded;
 		}
 
-		// Load through the Jetpack Autoloader. When more than one active plugin
-		// ships the WP\MCP\ classes (for example WooCommerce vendors its own
-		// copy), it loads the newest version of each class instead of whichever
-		// plugin registered its autoloader first.
+		// Jetpack Autoloader uses `autoload_packages.php` instead of `autoload.php`.
 		$autoloader      = WP_MCP_DIR . '/vendor/autoload_packages.php';
 		self::$is_loaded = self::require_autoloader( $autoloader );
 

--- a/includes/Autoloader.php
+++ b/includes/Autoloader.php
@@ -40,19 +40,11 @@ final class Autoloader {
 			return self::$is_loaded;
 		}
 
-		// Prefer the Jetpack Autoloader. When more than one active plugin ships
-		// the WP\MCP\ classes (for example WooCommerce vendors its own copy),
-		// it loads the newest version of each class instead of whichever plugin
-		// registered its autoloader first.
-		$jetpack_autoloader = WP_MCP_DIR . '/vendor/autoload_packages.php';
-		if ( is_readable( $jetpack_autoloader ) ) {
-			self::$is_loaded = self::require_autoloader( $jetpack_autoloader );
-
-			return self::$is_loaded;
-		}
-
-		// Fallback to the classic Composer autoloader.
-		$autoloader      = WP_MCP_DIR . '/vendor/autoload.php';
+		// Load through the Jetpack Autoloader. When more than one active plugin
+		// ships the WP\MCP\ classes (for example WooCommerce vendors its own
+		// copy), it loads the newest version of each class instead of whichever
+		// plugin registered its autoloader first.
+		$autoloader      = WP_MCP_DIR . '/vendor/autoload_packages.php';
 		self::$is_loaded = self::require_autoloader( $autoloader );
 
 		return self::$is_loaded;

--- a/includes/Autoloader.php
+++ b/includes/Autoloader.php
@@ -40,6 +40,18 @@ final class Autoloader {
 			return self::$is_loaded;
 		}
 
+		// Prefer the Jetpack Autoloader. When more than one active plugin ships
+		// the WP\MCP\ classes (for example WooCommerce vendors its own copy),
+		// it loads the newest version of each class instead of whichever plugin
+		// registered its autoloader first.
+		$jetpack_autoloader = WP_MCP_DIR . '/vendor/autoload_packages.php';
+		if ( is_readable( $jetpack_autoloader ) ) {
+			self::$is_loaded = self::require_autoloader( $jetpack_autoloader );
+
+			return self::$is_loaded;
+		}
+
+		// Fallback to the classic Composer autoloader.
 		$autoloader      = WP_MCP_DIR . '/vendor/autoload.php';
 		self::$is_loaded = self::require_autoloader( $autoloader );
 


### PR DESCRIPTION
## What

The standalone plugin now loads its classes through the [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) instead of the plain Composer autoloader.

- Add `automattic/jetpack-autoloader` to `require` (and allow its Composer plugin).
- Bootstrap prefers `vendor/autoload_packages.php`, falling back to the classic `vendor/autoload.php` if it is missing.
- Set `COMPOSER_ROOT_VERSION` in the release build so the generated class manifest records the real plugin version, not a guessed `dev-*` one.

## Why

WooCommerce (and other plugins) bundle their own copy of mcp-adapter and autoload the same `WP\MCP\` namespace. When both the standalone plugin and a bundled copy are active, PHP loads whichever registered its autoloader **first** — not the newest version.

A maintainer traced exactly this on production WooCommerce sites in #229: WooCommerce 10.9.1 vendors mcp-adapter `^0.3.0`, and its old `ExecuteAbilityAbility` won the class race, so fixes shipped in the standalone plugin never ran. New classes (only present in the newer copy) loaded from the standalone plugin — a mixed-version load.

The Jetpack Autoloader fixes this: every active copy registers into a shared manifest, and the newest version of each class is loaded regardless of plugin load order. This is the same approach WooCommerce and Jetpack already use, and it is the pattern this project's own README recommends to downstream consumers.

### Why `COMPOSER_ROOT_VERSION`

"Newest wins" needs a real version to compare. Composer knows dependency versions, but for the root package (this plugin) it guesses a `dev-*` version from the git ref unless told otherwise. `dev-*` is treated as "always newest", which would wrongly make the standalone copy win even against a genuinely newer bundled copy. Passing the release tag as `COMPOSER_ROOT_VERSION` bakes the real semver (e.g. `0.5.0`) into the manifest at build time.

## Scope

This is the structural root-cause fix for #229. It is separate from #230, which is the narrower empty-input normalization fix. Note: this only helps once shipped copies carry the autoloader — it cannot retroactively change WooCommerce's already-vendored 0.3.x. Full resolution on today's WooCommerce sites still needs WooCommerce to bump its bundled dependency.

## Testing

- `composer validate`: clean.
- PHPCS: clean on the changed bootstrap.
- Confirmed `composer install` generates `vendor/autoload_packages.php` and a class manifest with correct per-package versions.
- Confirmed `COMPOSER_ROOT_VERSION=0.5.0` makes the manifest record `0.5.0` for the root `WP\MCP\` classes instead of `dev-trunk`.
- Runtime smoke test (WordPress functions shimmed): both a plugin class (`WP\MCP\...\AbilityArgumentNormalizer`) and a dependency class (`WP\McpSchema\...\DTO\Tool`) resolve through the Jetpack Autoloader.
- Unit test bootstrap is unaffected — it uses the classic `vendor/autoload.php`, which is still generated alongside.
- Full PHPUnit suite not run locally (wp-env has a pre-existing config error); please rely on CI.

Refs #229.