### PR TITLE
fix: handle resources/templates/list method

### DIFF
--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -14,6 +14,7 @@ use WP\MCP\Handlers\HandlerHelperTrait;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\McpSchema\Common\Protocol\DTO\BlobResourceContents;
 use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
+use WP\McpSchema\Server\Resources\DTO\ListResourceTemplatesResult;
 use WP\McpSchema\Server\Resources\DTO\ListResourcesResult;
 use WP\McpSchema\Server\Resources\DTO\ReadResourceResult;
 
@@ -72,6 +73,24 @@ class ResourcesHandler {
 		return ListResourcesResult::fromArray(
 			array(
 				'resources' => $resources,
+			)
+		);
+	}
+
+	/**
+	 * Handles the resources/templates/list request.
+	 *
+	 * The adapter has no resource-template concept, so this always returns an empty
+	 * list. The method still needs a handler: `resources/templates/list` is part of
+	 * the base `resources` capability (no sub-flag gates it), which the server always
+	 * advertises, so spec-compliant clients call it during resource discovery.
+	 *
+	 * @return \WP\McpSchema\Server\Resources\DTO\ListResourceTemplatesResult Empty resource-templates list.
+	 */
+	public function list_resource_templates(): ListResourceTemplatesResult {
+		return ListResourceTemplatesResult::fromArray(
+			array(
+				'resourceTemplates' => array(),
 			)
 		);
 	}

--- a/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/Transport/Infrastructure/RequestRouter.php
@@ -71,17 +71,18 @@ class RequestRouter {
 		);
 
 		$handlers = array(
-			'initialize'     => function () use ( $params, $request_id, $http_context, &$new_session_id ) {
+			'initialize'               => function () use ( $params, $request_id, $http_context, &$new_session_id ) {
 				return $this->handle_initialize_with_session( $params, $request_id, $http_context, $new_session_id );
 			},
-			'ping'           => fn() => $this->context->system_handler->ping(),
-			'tools/list'     => fn() => $this->context->tools_handler->list_tools(),
-			'tools/list/all' => fn() => $this->context->tools_handler->list_all_tools(),
-			'tools/call'     => fn() => $this->context->tools_handler->call_tool( $params, $request_id ),
-			'resources/list' => fn() => $this->context->resources_handler->list_resources(),
-			'resources/read' => fn() => $this->context->resources_handler->read_resource( $params, $request_id ),
-			'prompts/list'   => fn() => $this->context->prompts_handler->list_prompts(),
-			'prompts/get'    => fn() => $this->context->prompts_handler->get_prompt( $params, $request_id ),
+			'ping'                     => fn() => $this->context->system_handler->ping(),
+			'tools/list'               => fn() => $this->context->tools_handler->list_tools(),
+			'tools/list/all'           => fn() => $this->context->tools_handler->list_all_tools(),
+			'tools/call'               => fn() => $this->context->tools_handler->call_tool( $params, $request_id ),
+			'resources/list'           => fn() => $this->context->resources_handler->list_resources(),
+			'resources/templates/list' => fn() => $this->context->resources_handler->list_resource_templates(),
+			'resources/read'           => fn() => $this->context->resources_handler->read_resource( $params, $request_id ),
+			'prompts/list'             => fn() => $this->context->prompts_handler->list_prompts(),
+			'prompts/get'              => fn() => $this->context->prompts_handler->get_prompt( $params, $request_id ),
 		);
 
 		try {

--- a/tests/phpunit/Unit/Handlers/ResourcesHandlerListTest.php
+++ b/tests/phpunit/Unit/Handlers/ResourcesHandlerListTest.php
@@ -9,6 +9,7 @@ use WP\MCP\Handlers\Resources\ResourcesHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Resources\DTO\ListResourceTemplatesResult;
 use WP\McpSchema\Server\Resources\DTO\ListResourcesResult;
 use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
@@ -47,6 +48,18 @@ final class ResourcesHandlerListTest extends TestCase {
 		$resource_array = $resources[0]->toArray();
 		$this->assertArrayHasKey( 'uri', $resource_array );
 		$this->assertArrayHasKey( 'name', $resource_array );
+	}
+
+	public function test_list_resource_templates_returns_empty_result(): void {
+		$server  = $this->makeServer( array(), array( 'test/resource' ) );
+		$handler = new ResourcesHandler( $server );
+
+		$result = $handler->list_resource_templates();
+
+		// The adapter has no resource-template concept, so the list is always empty,
+		// but the method must still respond so spec-compliant clients stop getting -32601.
+		$this->assertInstanceOf( ListResourceTemplatesResult::class, $result );
+		$this->assertSame( array(), $result->getResourceTemplates() );
 	}
 
 	public function test_list_resources_applies_resources_list_filter(): void {


### PR DESCRIPTION
Fixes #232

## Summary

- `RequestRouter::route_request()` had no handler for `resources/templates/list`, so every spec-compliant client got JSON-RPC `-32601` ("Method not found") during standard resource discovery.
- The server always advertises the `resources` capability, and per the MCP spec `resources/templates/list` is part of that base capability — no sub-flag gates it.
- Added `ResourcesHandler::list_resource_templates()` returning an empty `ListResourceTemplatesResult` (the adapter has no resource-template concept), and registered the method in the router handler map.

## Changes

- `includes/Handlers/Resources/ResourcesHandler.php` — new `list_resource_templates()` method.
- `includes/Transport/Infrastructure/RequestRouter.php` — new `'resources/templates/list'` handler-map entry.
- `tests/phpunit/Unit/Handlers/ResourcesHandlerListTest.php` — test asserting an empty `ListResourceTemplatesResult`.

No schema changes needed: `php-mcp-schema` already ships `ListResourceTemplatesRequest`/`ListResourceTemplatesResult`, and `ClientRequestFactory` already maps the method string.

Out of scope: `resources/subscribe` still returns `-32601`, which is correct — the server declares `subscribe: false`, so clients calling it are non-compliant.

## Testing

1. `vendor/bin/phpcs` on changed files — clean.
2. `vendor/bin/phpstan analyse` (Level 8) — no errors.
3. `vendor/bin/phpunit --filter ResourcesHandlerListTest` — 6/6 pass.
4. `vendor/bin/phpunit --filter "RequestRouterTest|TransportRoutingTest"` — 38/38 pass.
5. Expected: a `resources/templates/list` call returns `{"resourceTemplates":[]}` instead of a `-32601` error.