### PR TITLE
fix: resources/read fails when the client lowercases the URI scheme

### DIFF
--- a/includes/Core/McpComponentRegistry.php
+++ b/includes/Core/McpComponentRegistry.php
@@ -14,6 +14,7 @@ use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
 use WP\MCP\Domain\Prompts\McpPrompt;
 use WP\MCP\Domain\Resources\McpResource;
 use WP\MCP\Domain\Tools\McpTool;
+use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface;
 use WP\MCP\Infrastructure\Observability\FailureReason;
@@ -629,7 +630,20 @@ class McpComponentRegistry {
 	 *
 	 */
 	public function get_mcp_resource( string $resource_uri ): ?McpResource {
-		return $this->mcp_resources[ $resource_uri ] ?? null;
+		if ( isset( $this->mcp_resources[ $resource_uri ] ) ) {
+			return $this->mcp_resources[ $resource_uri ];
+		}
+
+		// URI schemes are case-insensitive (RFC 3986 §3.1): clients that lowercase
+		// the scheme would otherwise miss a resource advertised with mixed case.
+		$folded = McpValidator::fold_uri_scheme( $resource_uri );
+		foreach ( $this->mcp_resources as $stored_uri => $mcp_resource ) {
+			if ( McpValidator::fold_uri_scheme( (string) $stored_uri ) === $folded ) {
+				return $mcp_resource;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/Domain/Utils/McpValidator.php
+++ b/includes/Domain/Utils/McpValidator.php
@@ -21,6 +21,18 @@ use DateTime;
 class McpValidator {
 
 	/**
+	 * URI scheme grammar per RFC 3986 §3.1 (regex character class, no anchors).
+	 *
+	 * Shared by URI validation and scheme folding so the two can never drift
+	 * apart on what counts as a scheme.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var string
+	 */
+	private const URI_SCHEME_PATTERN = '[a-zA-Z][a-zA-Z0-9+.-]*';
+
+	/**
 	 * Allowed MIME types for MCP icons per specification.
 	 *
 	 * MUST support: image/png, image/jpeg, image/jpg
@@ -512,7 +524,28 @@ class McpValidator {
 
 		// Basic URI validation: must have scheme followed by colon (RFC 3986).
 		// This accepts any protocol as per MCP specification.
-		return (bool) preg_match( '/^[a-zA-Z][a-zA-Z0-9+.-]*:.+/', $uri );
+		return (bool) preg_match( '/^' . self::URI_SCHEME_PATTERN . ':.+/', $uri );
+	}
+
+	/**
+	 * Lowercase the scheme (the part before the first ":") of a URI.
+	 *
+	 * URI schemes are case-insensitive per RFC 3986, so "Foo://x" and "foo://x"
+	 * identify the same resource. Lowercasing the scheme on both sides of a
+	 * comparison lets the two forms match. Everything after the scheme is left
+	 * untouched, because case may be meaningful there.
+	 *
+	 * @param string $uri Resource URI.
+	 *
+	 * @return string Same URI with a lowercased scheme.
+	 * @since n.e.x.t
+	 */
+	public static function fold_uri_scheme( string $uri ): string {
+		return (string) preg_replace_callback(
+			'/^(' . self::URI_SCHEME_PATTERN . '):/',
+			static fn( array $matches ): string => strtolower( $matches[1] ) . ':',
+			$uri
+		);
 	}
 
 	/**

--- a/includes/Domain/Utils/McpValidator.php
+++ b/includes/Domain/Utils/McpValidator.php
@@ -21,7 +21,7 @@ use DateTime;
 class McpValidator {
 
 	/**
-	 * URI scheme grammar per RFC 3986 §3.1 (regex character class, no anchors).
+	 * URI scheme grammar per RFC 3986 §3.1 (unanchored regex fragment).
 	 *
 	 * Shared by URI validation and scheme folding so the two can never drift
 	 * apart on what counts as a scheme.
@@ -541,11 +541,12 @@ class McpValidator {
 	 * @since n.e.x.t
 	 */
 	public static function fold_uri_scheme( string $uri ): string {
-		return (string) preg_replace_callback(
+		// On PCRE failure preg_replace_callback() returns null; keep the URI as-is.
+		return preg_replace_callback(
 			'/^(' . self::URI_SCHEME_PATTERN . '):/',
 			static fn( array $matches ): string => strtolower( $matches[1] ) . ':',
 			$uri
-		);
+		) ?? $uri;
 	}
 
 	/**

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -178,7 +178,11 @@ class ResourcesHandler {
 			// Contents should be an array of resource content items.
 			// If it's already an array of properly formatted items, convert each to a DTO.
 			// Otherwise, wrap the result as text content.
-			$content_dtos = $this->convert_contents_to_dtos( $contents, $uri );
+			//
+			// Seed the fallback content URI with the advertised URI, not the client's
+			// request URI, so contents[].uri matches resources/list even when the client
+			// lowercased the scheme (RFC 3986 3.1). For an exact-case read the two are equal.
+			$content_dtos = $this->convert_contents_to_dtos( $contents, $resource->getUri() );
 
 			return ReadResourceResult::fromArray(
 				array(

--- a/tests/phpunit/Unit/Core/McpComponentRegistryTest.php
+++ b/tests/phpunit/Unit/Core/McpComponentRegistryTest.php
@@ -352,6 +352,57 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertNull( $nonexistent );
 	}
 
+	/**
+	 * Resource lookup ignores scheme case (RFC 3986 §3.1).
+	 *
+	 * A resource advertised with a mixed-case scheme must be readable when the
+	 * client canonicalizes the scheme to lowercase, and vice versa.
+	 */
+	public function test_get_mcp_resource_matches_regardless_of_scheme_case(): void {
+		$advertised_uri = 'WordPress://test/case-resource';
+
+		$this->register_ability_in_hook(
+			'test/resource-scheme-case',
+			array(
+				'label'               => 'Scheme Case Resource',
+				'description'         => 'Resource with a mixed-case scheme',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return 'content';
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => $advertised_uri,
+					),
+				),
+			)
+		);
+
+		$this->registry->register_resources( array( 'test/resource-scheme-case' ) );
+
+		$this->assertNotNull(
+			$this->registry->get_mcp_resource( $advertised_uri ),
+			'Exact advertised URI should resolve'
+		);
+
+		$this->assertNotNull(
+			$this->registry->get_mcp_resource( 'wordpress://test/case-resource' ), // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- The lowercase scheme is the point of the test.
+			'Lowercased scheme should match the mixed-case advertised URI'
+		);
+
+		$this->assertNull(
+			$this->registry->get_mcp_resource( 'wordpress://test/CASE-resource' ), // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- The lowercase scheme is the point of the test.
+			'Only the scheme is case-insensitive; the path must still match exactly'
+		);
+
+		wp_unregister_ability( 'test/resource-scheme-case' );
+	}
+
 	public function test_get_mcp_prompt_by_name(): void {
 		$this->registry->register_prompts( array( 'test/prompt' ) );
 

--- a/tests/phpunit/Unit/Core/McpComponentRegistryTest.php
+++ b/tests/phpunit/Unit/Core/McpComponentRegistryTest.php
@@ -395,6 +395,11 @@ final class McpComponentRegistryTest extends TestCase {
 			'Lowercased scheme should match the mixed-case advertised URI'
 		);
 
+		$this->assertNotNull(
+			$this->registry->get_mcp_resource( 'WORDPRESS://test/case-resource' ), // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- The uppercase scheme is the point of the test.
+			'Uppercased scheme should match the mixed-case advertised URI'
+		);
+
 		$this->assertNull(
 			$this->registry->get_mcp_resource( 'wordpress://test/CASE-resource' ), // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- The lowercase scheme is the point of the test.
 			'Only the scheme is case-insensitive; the path must still match exactly'

--- a/tests/phpunit/Unit/Handlers/ResourcesHandlerReadTest.php
+++ b/tests/phpunit/Unit/Handlers/ResourcesHandlerReadTest.php
@@ -155,6 +155,31 @@ final class ResourcesHandlerReadTest extends TestCase {
 		$this->assertSame( 'WordPress://local/resource-plain-string', $contents[0]->getUri() );
 	}
 
+	public function test_read_resource_with_lowercased_scheme_echoes_advertised_uri(): void {
+		wp_set_current_user( 1 );
+
+		$server  = $this->makeServer( array(), array( 'test/resource-plain-string' ) );
+		$handler = new ResourcesHandler( $server );
+
+		// The resource is advertised with a mixed-case scheme (WordPress://...). A client
+		// that canonicalizes the scheme to lowercase per RFC 3986 3.1 still resolves it, and
+		// the response must echo the advertised URI, not the request's lowercased scheme, so
+		// contents[].uri stays consistent with resources/list.
+		$result = $handler->read_resource(
+			array( 'params' => array( 'uri' => 'wordpress://local/resource-plain-string' ) ) // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- The lowercase scheme is the point of the test.
+		);
+
+		$this->assertInstanceOf( ReadResourceResult::class, $result );
+
+		$contents = $result->getContents();
+		$this->assertNotEmpty( $contents );
+		$this->assertSame(
+			'WordPress://local/resource-plain-string',
+			$contents[0]->getUri(),
+			'Read response must echo the advertised URI, not the client-lowercased scheme.'
+		);
+	}
+
 	public function test_pre_resource_read_filter_can_modify_params(): void {
 		wp_set_current_user( 1 );
 		$server  = $this->makeServer( array(), array( 'test/resource' ) );


### PR DESCRIPTION
## What?
Closes #235

Makes `resources/read` resolve a resource even when the client changes the case of the URI scheme (e.g. sends `wordpress://...` for an advertised `WordPress://...`).

## Why?
URI schemes are case-insensitive per RFC 3986, and lowercase is the canonical form, so many MCP clients lowercase the scheme before sending `resources/read`. The registry stored resources under a case-sensitive PHP array key, so those clients received `-32002 Resource not found` for a URI the server had just advertised in `resources/list`.

## How?
- New `McpValidator::fold_uri_scheme()` lowercases only the scheme of a URI. It shares one `URI_SCHEME_PATTERN` constant with `validate_resource_uri()` so the two definitions of "scheme" cannot drift apart.
- `McpComponentRegistry::get_mcp_resource()` keeps the exact array-key match as the fast path. On a miss, it compares scheme-folded URIs across stored resources.
- Nothing else changes observably: stored keys, `resources/list` output, and duplicate detection keep the original case. Only the scheme is folded — path, query, and fragment stay case-sensitive per the RFC.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Implementation and tests; reviewed and edited by me.

## Testing Instructions
1. Register an ability-backed resource whose URI has a mixed-case scheme, e.g. `WordPress://demo/resource`.
2. Call `resources/read` with the lowercased scheme (`wordpress://demo/resource`): before this PR it returns `-32002 Resource not found`; with this PR it returns the contents.
3. Run the unit tests: `npm run test:php -- --filter McpComponentRegistryTest`

## Changelog Entry
> Fixed - `resources/read` now matches the resource URI scheme case-insensitively, per RFC 3986.