### PR TITLE
Fix static trait property access deprecation in RequestRouter

### DIFF
--- a/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/Transport/Infrastructure/RequestRouter.php
@@ -10,7 +10,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Transport\Infrastructure;
 
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
-use WP\MCP\Infrastructure\Observability\ErrorLogMcpObservabilityHandler;
+use WP\MCP\Infrastructure\Observability\McpObservabilityHelperTrait;
 use WP\McpSchema\Common\AbstractDataTransferObject;
 use WP\McpSchema\Common\Content\DTO\TextContent;
 use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
@@ -23,6 +23,8 @@ use WP\McpSchema\Server\Tools\DTO\CallToolResult;
  * all transport implementations via dependency injection.
  */
 class RequestRouter {
+
+	use McpObservabilityHelperTrait;
 
 	/**
 	 * The transport context.
@@ -290,8 +292,7 @@ class RequestRouter {
 			// Filter argument keys to exclude sensitive-looking ones.
 			$safe_keys = array();
 			foreach ( array_keys( $params['arguments'] ) as $arg_key ) {
-				// @todo Replace this with a less-coupled way to access `McpObservabilityHelperTrait:is_sensitive_key()`.
-				if ( ErrorLogMcpObservabilityHandler::is_sensitive_key( (string) $arg_key ) ) {
+				if ( self::is_sensitive_key( (string) $arg_key ) ) {
 					$safe_keys[] = '[REDACTED]';
 				} else {
 					$safe_keys[] = $arg_key;


### PR DESCRIPTION
## Problem

`RequestRouter::sanitize_params_for_logging()` calls `ErrorLogMcpObservabilityHandler::is_sensitive_key()` as a static call, reaching across into a class that isn't `RequestRouter` itself. `is_sensitive_key()` internally reads `self::$sensitive_patterns`, a private static property declared in `McpObservabilityHelperTrait`. Since `RequestRouter` never brings that trait in, this is effectively borrowing another class's copy of a trait-provided static member, which triggers a PHP 8.1+ deprecation notice. Per the PHP manual, this pattern is slated to become a fatal error in a future major version.

Also reported independently by @ahmed0magdy in the comments with the same root-cause diagnosis (0.5.0, WP 7.0, PHP 8.2).

## Fix

Bring `McpObservabilityHelperTrait` into `RequestRouter` directly and call the method via `self::` instead of via the unrelated class:

- Swap the `ErrorLogMcpObservabilityHandler` import for `McpObservabilityHelperTrait`
- `use McpObservabilityHelperTrait;` inside `RequestRouter`
- `ErrorLogMcpObservabilityHandler::is_sensitive_key(...)` → `self::is_sensitive_key(...)`
- Drop the now-resolved `@todo` above it

This is the smaller of the two fixes discussed on the issue (the other being extraction of `is_sensitive_key`/`$sensitive_patterns` into a separate shared utility class both handlers delegate to — also reasonable, but more invasive for the same outcome).

Note: the trait also defines `categorize_error()`, which `RequestRouter` already implements itself (with a different, non-static signature). PHP resolves this without conflict — a class's own method silently takes precedence over a same-named trait method — so no behavior change there; verified locally.

Fixes #182