### PR TITLE
Make the built-in discover/get-info/execute tools' MCP exposure check filterable (#243)

### DIFF
--- a/includes/Abilities/DiscoverAbilitiesAbility.php
+++ b/includes/Abilities/DiscoverAbilitiesAbility.php
@@ -89,8 +89,8 @@ final class DiscoverAbilitiesAbility {
 		foreach ( $abilities as $ability ) {
 			$ability_name = $ability->get_name();
 
-			// Check if ability is publicly exposed via MCP
-			if ( ! self::is_ability_mcp_public( $ability ) ) {
+			// Check if ability is exposed via MCP for the discover path.
+			if ( ! self::is_ability_mcp_exposed( $ability, McpAbilityExposureContext::PATH_DISCOVER ) ) {
 				continue;
 			}
 

--- a/includes/Abilities/ExecuteAbilityAbility.php
+++ b/includes/Abilities/ExecuteAbilityAbility.php
@@ -174,7 +174,7 @@ final class ExecuteAbilityAbility {
 		}
 
 		// Check MCP exposure restrictions
-		$exposure_check = self::check_ability_mcp_exposure( $ability_name );
+		$exposure_check = self::check_ability_mcp_exposure( $ability_name, McpAbilityExposureContext::PATH_EXECUTE );
 		if ( is_wp_error( $exposure_check ) ) {
 			return $exposure_check;
 		}

--- a/includes/Abilities/GetAbilityInfoAbility.php
+++ b/includes/Abilities/GetAbilityInfoAbility.php
@@ -153,7 +153,7 @@ final class GetAbilityInfoAbility {
 		}
 
 		// Check MCP exposure restrictions
-		return self::check_ability_mcp_exposure( $ability_name );
+		return self::check_ability_mcp_exposure( $ability_name, McpAbilityExposureContext::PATH_GET_INFO );
 	}
 
 	/**

--- a/includes/Abilities/McpAbilityExposureContext.php
+++ b/includes/Abilities/McpAbilityExposureContext.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Value object describing the context of an MCP ability exposure check.
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Abilities;
+
+use WP\MCP\Core\McpServer;
+
+/**
+ * Describes *when* and *for whom* the built-in discover / get-info /
+ * execute tools are asking whether an ability is exposed via MCP.
+ *
+ * Passed as the third argument to the `mcp_adapter_is_ability_exposed`
+ * filter so integrators can make exposure decisions that vary by:
+ *
+ *   - the MCP server handling the current request (multiple servers can
+ *     be registered per site, each with its own scope),
+ *   - the authenticated principal and its WordPress roles,
+ *   - the current site (multisite / multi-tenant),
+ *   - the *path* by which the decision is being asked (listing vs.
+ *     inspecting vs. executing an ability — see the PATH_* constants).
+ *
+ * Treat instances as immutable: exposure decisions and any caches built
+ * on top of them should be keyed by the full context, not by a subset.
+ *
+ * @since 0.6.0
+ */
+final class McpAbilityExposureContext {
+
+	/**
+	 * Exposure path: the discover-abilities listing.
+	 *
+	 * @var string
+	 */
+	public const PATH_DISCOVER = 'discover';
+
+	/**
+	 * Exposure path: the get-ability-info inspection.
+	 *
+	 * @var string
+	 */
+	public const PATH_GET_INFO = 'get_info';
+
+	/**
+	 * Exposure path: the execute-ability invocation gate.
+	 *
+	 * Note: exposure is not authorization. An ability that is "exposed"
+	 * via this path still has its own `permission_callback` checked by
+	 * the execute-ability tool before the ability actually runs.
+	 *
+	 * @var string
+	 */
+	public const PATH_EXECUTE = 'execute';
+
+	/**
+	 * The MCP server handling the current request, if any.
+	 *
+	 * Null when the ability is invoked outside of an MCP request
+	 * (e.g. WP-CLI, cron, or a direct `wp_get_ability( ... )->execute()`
+	 * call), in which case per-server allowlists should fall back to
+	 * the ability's default (`$is_exposed`).
+	 *
+	 * @var \WP\MCP\Core\McpServer|null
+	 */
+	public ?McpServer $server;
+
+	/**
+	 * The authenticated principal's user ID. Zero if unauthenticated.
+	 *
+	 * @var int
+	 */
+	public int $principal_id;
+
+	/**
+	 * The authenticated principal's WordPress roles.
+	 *
+	 * @var array<int, string>
+	 */
+	public array $roles;
+
+	/**
+	 * The current site ID (`get_current_blog_id()`). Non-zero on both
+	 * multisite and single-site installs.
+	 *
+	 * @var int
+	 */
+	public int $site_id;
+
+	/**
+	 * The exposure path — one of the PATH_* constants above.
+	 *
+	 * @var string
+	 */
+	public string $exposure_path;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param \WP\MCP\Core\McpServer|null $server        The current server, or null.
+	 * @param int                         $principal_id  User ID (0 if not logged in).
+	 * @param array<int, string>          $roles         Role slugs.
+	 * @param int                         $site_id       Current site ID.
+	 * @param string                      $exposure_path One of the PATH_* constants.
+	 */
+	public function __construct(
+		?McpServer $server,
+		int $principal_id,
+		array $roles,
+		int $site_id,
+		string $exposure_path
+	) {
+		$this->server        = $server;
+		$this->principal_id  = $principal_id;
+		$this->roles         = $roles;
+		$this->site_id       = $site_id;
+		$this->exposure_path = $exposure_path;
+	}
+}

--- a/includes/Abilities/McpAbilityHelperTrait.php
+++ b/includes/Abilities/McpAbilityHelperTrait.php
@@ -11,6 +11,7 @@ namespace WP\MCP\Abilities;
 
 use WP\MCP\Core\McpAdapter;
 use WP_Error;
+use WP_User;
 
 /**
  * Trait McpAbilityHelperTrait
@@ -20,23 +21,29 @@ use WP_Error;
 trait McpAbilityHelperTrait {
 
 	/**
-	 * Checks if ability is publicly exposed via MCP.
+	 * Checks if ability is exposed via MCP for a specific exposure path.
 	 *
-	 * Validates against the ability's mcp.public metadata flag.
-	 * Only abilities with mcp.public=true are accessible via default MCP server.
+	 * Wraps `is_ability_mcp_exposed()` and translates a negative decision
+	 * into the `ability_not_public_mcp` WP_Error that callers of this
+	 * helper (`GetAbilityInfoAbility`, `ExecuteAbilityAbility`) return
+	 * as their permission failure.
 	 *
-	 * @param string $ability_name The ability name to check.
+	 * @param string $ability_name  The ability name to check.
+	 * @param string $exposure_path One of `McpAbilityExposureContext::PATH_*`.
 	 *
-	 * @return bool|\WP_Error True if publicly exposed, WP_Error if not.
+	 * @return bool|\WP_Error True if exposed, WP_Error if not.
 	 */
-	protected static function check_ability_mcp_exposure( string $ability_name ) {
+	protected static function check_ability_mcp_exposure( string $ability_name, string $exposure_path ) {
 		$ability = wp_get_ability( $ability_name );
 
 		if ( ! $ability ) {
 			return new WP_Error( 'ability_not_found', "Ability '{$ability_name}' not found" );
 		}
 
-		if ( ! self::is_ability_mcp_public( $ability ) ) {
+		if ( ! self::is_ability_mcp_exposed( $ability, $exposure_path ) ) {
+			// Error code preserved for backward compatibility with clients
+			// catching the pre-filter behavior; the message is intentionally
+			// unchanged for the same reason.
 			return new WP_Error(
 				'ability_not_public_mcp',
 				sprintf( 'Ability "%s" is not exposed via MCP (mcp.public!=true)', $ability_name )
@@ -47,44 +54,99 @@ trait McpAbilityHelperTrait {
 	}
 
 	/**
-	 * Checks if ability is publicly exposed via MCP (simple boolean version).
+	 * Decides whether an ability is exposed via MCP for the given path.
 	 *
-	 * This is a simplified version that returns only boolean values,
-	 * useful for filtering operations where WP_Error handling isn't needed.
+	 * The default answer is the ability's static `meta.mcp.public` flag.
+	 * The `mcp_adapter_is_ability_exposed` filter allows integrators to
+	 * override that answer per ability and per context (server, principal,
+	 * site, exposure path).
 	 *
-	 * @param \WP_Ability $ability The ability object to check.
+	 * All three built-in tools — discover-abilities, get-ability-info,
+	 * and execute-ability — route through this method with their own
+	 * `PATH_*` value, so the filter is the single point of truth for the
+	 * exposure decision. See `check_ability_mcp_exposure()` for the
+	 * WP_Error-returning wrapper used by the permission-check paths.
 	 *
-	 * @return bool True if publicly exposed, false otherwise.
+	 * @param \WP_Ability $ability       The ability object to check.
+	 * @param string      $exposure_path One of `McpAbilityExposureContext::PATH_*`.
+	 *
+	 * @return bool True if exposed, false otherwise.
 	 */
-	protected static function is_ability_mcp_public( \WP_Ability $ability ): bool {
-		$meta      = $ability->get_meta();
-		$is_public = (bool) ( $meta['mcp']['public'] ?? false );
+	protected static function is_ability_mcp_exposed( \WP_Ability $ability, string $exposure_path ): bool {
+		$meta       = $ability->get_meta();
+		$is_exposed = (bool) ( $meta['mcp']['public'] ?? false );
 
+		$context = self::build_exposure_context( $exposure_path );
+
+		/**
+		 * Filters whether an ability is exposed via MCP for the built-in
+		 * discover / get-info / execute tools.
+		 *
+		 * The default value is the ability's `meta.mcp.public` flag.
+		 * Return true to expose an ability that is not statically marked
+		 * public, or false to hide one that is. The current request
+		 * context is provided so integrators can implement per-server,
+		 * per-principal, or per-tenant exposure without touching the
+		 * ability's own metadata.
+		 *
+		 * **Exposure is not authorization.** Returning true here does not
+		 * bypass the ability's own `permission_callback`; the execute path
+		 * still runs `WP_Ability::check_permissions()` before invoking the
+		 * ability. Use exposure to control *visibility* (whether the tool
+		 * acknowledges the ability exists / is invocable at all) and use
+		 * capability filters (`mcp_adapter_execute_ability_capability`,
+		 * etc.) and the ability's own permission callback to control
+		 * *authorization*.
+		 *
+		 * If you cache the result of this decision, the cache key MUST
+		 * include every dimension that can influence it: the ability
+		 * name, the exposure path, and any context field your callback
+		 * reads (server ID, principal ID, roles, site ID, plus any
+		 * feature-flag state you consult). Missing dimensions will
+		 * cross-contaminate contexts and can silently expose an ability
+		 * to the wrong principal or server.
+		 *
+		 * @since 0.6.0
+		 *
+		 * @param bool                                       $is_exposed Whether the ability is exposed by default (from `meta.mcp.public`).
+		 * @param \WP_Ability                                $ability    The ability being checked.
+		 * @param \WP\MCP\Abilities\McpAbilityExposureContext $context   The exposure context (server, principal, site, path).
+		 */
+		return (bool) apply_filters( 'mcp_adapter_is_ability_exposed', $is_exposed, $ability, $context );
+	}
+
+	/**
+	 * Builds the exposure context for the current request.
+	 *
+	 * All context construction lives here so every exposure decision — no
+	 * matter which of the three built-in tools issued it — uses the same
+	 * definition of "who's asking" and "which server". Downstream callers
+	 * should not attempt to build their own contexts by reaching into
+	 * request globals; that will silently drift out of sync with this
+	 * one.
+	 *
+	 * @param string $exposure_path One of `McpAbilityExposureContext::PATH_*`.
+	 *
+	 * @return \WP\MCP\Abilities\McpAbilityExposureContext
+	 */
+	private static function build_exposure_context( string $exposure_path ): McpAbilityExposureContext {
 		$server = class_exists( McpAdapter::class )
 			? McpAdapter::instance()->get_current_server()
 			: null;
 
-		/**
-		 * Filters whether an ability is considered publicly exposed via MCP
-		 * for the purposes of the built-in discover/get-info/execute tools.
-		 *
-		 * The default value reflects the ability's `meta.mcp.public` flag.
-		 * Return true to expose an ability that is not statically marked
-		 * public, or false to hide one that is.
-		 *
-		 * The current MCP server (if any) is passed so integrators can make
-		 * per-server exposure decisions — e.g. reveal an ability on an
-		 * internal server but hide it on a public one. `$server` is null
-		 * when the ability is invoked outside of an MCP request (e.g.
-		 * WP-CLI or a direct `wp_get_ability( ... )->execute()` call).
-		 *
-		 * @since 0.6.0
-		 *
-		 * @param bool                        $is_public Whether the ability is publicly exposed via MCP by default.
-		 * @param \WP_Ability                 $ability   The ability being checked.
-		 * @param \WP\MCP\Core\McpServer|null $server    The MCP server handling the current request, or null.
-		 */
-		return (bool) apply_filters( 'mcp_adapter_is_ability_public', $is_public, $ability, $server );
+		$principal_id = 0;
+		$roles        = array();
+		if ( function_exists( 'wp_get_current_user' ) ) {
+			$user = wp_get_current_user();
+			if ( $user instanceof WP_User && $user->ID > 0 ) {
+				$principal_id = (int) $user->ID;
+				$roles        = array_values( array_map( 'strval', (array) $user->roles ) );
+			}
+		}
+
+		$site_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+
+		return new McpAbilityExposureContext( $server, $principal_id, $roles, $site_id, $exposure_path );
 	}
 
 	/**

--- a/includes/Abilities/McpAbilityHelperTrait.php
+++ b/includes/Abilities/McpAbilityHelperTrait.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Abilities;
 
+use WP\MCP\Core\McpAdapter;
 use WP_Error;
 
 /**
@@ -35,10 +36,7 @@ trait McpAbilityHelperTrait {
 			return new WP_Error( 'ability_not_found', "Ability '{$ability_name}' not found" );
 		}
 
-		$meta          = $ability->get_meta();
-		$is_public_mcp = $meta['mcp']['public'] ?? false;
-
-		if ( ! $is_public_mcp ) {
+		if ( ! self::is_ability_mcp_public( $ability ) ) {
 			return new WP_Error(
 				'ability_not_public_mcp',
 				sprintf( 'Ability "%s" is not exposed via MCP (mcp.public!=true)', $ability_name )
@@ -59,9 +57,34 @@ trait McpAbilityHelperTrait {
 	 * @return bool True if publicly exposed, false otherwise.
 	 */
 	protected static function is_ability_mcp_public( \WP_Ability $ability ): bool {
-		$meta = $ability->get_meta();
+		$meta      = $ability->get_meta();
+		$is_public = (bool) ( $meta['mcp']['public'] ?? false );
 
-		return (bool) ( $meta['mcp']['public'] ?? false );
+		$server = class_exists( McpAdapter::class )
+			? McpAdapter::instance()->get_current_server()
+			: null;
+
+		/**
+		 * Filters whether an ability is considered publicly exposed via MCP
+		 * for the purposes of the built-in discover/get-info/execute tools.
+		 *
+		 * The default value reflects the ability's `meta.mcp.public` flag.
+		 * Return true to expose an ability that is not statically marked
+		 * public, or false to hide one that is.
+		 *
+		 * The current MCP server (if any) is passed so integrators can make
+		 * per-server exposure decisions — e.g. reveal an ability on an
+		 * internal server but hide it on a public one. `$server` is null
+		 * when the ability is invoked outside of an MCP request (e.g.
+		 * WP-CLI or a direct `wp_get_ability( ... )->execute()` call).
+		 *
+		 * @since 0.6.0
+		 *
+		 * @param bool                        $is_public Whether the ability is publicly exposed via MCP by default.
+		 * @param \WP_Ability                 $ability   The ability being checked.
+		 * @param \WP\MCP\Core\McpServer|null $server    The MCP server handling the current request, or null.
+		 */
+		return (bool) apply_filters( 'mcp_adapter_is_ability_public', $is_public, $ability, $server );
 	}
 
 	/**

--- a/includes/Abilities/McpAbilityHelperTrait.php
+++ b/includes/Abilities/McpAbilityHelperTrait.php
@@ -42,11 +42,14 @@ trait McpAbilityHelperTrait {
 
 		if ( ! self::is_ability_mcp_exposed( $ability, $exposure_path ) ) {
 			// Error code preserved for backward compatibility with clients
-			// catching the pre-filter behavior; the message is intentionally
-			// unchanged for the same reason.
+			// catching the pre-filter behavior. Message intentionally omits
+			// the "mcp.public!=true" parenthetical from prior releases: the
+			// exposure filter can now hide an ability whose `mcp.public` is
+			// true, so citing that specific field in the message would
+			// mislead in the filter-driven cases.
 			return new WP_Error(
 				'ability_not_public_mcp',
-				sprintf( 'Ability "%s" is not exposed via MCP (mcp.public!=true)', $ability_name )
+				sprintf( 'Ability "%s" is not exposed via MCP', $ability_name )
 			);
 		}
 

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -50,6 +50,19 @@ final class McpAdapter {
 	private array $servers = array();
 
 	/**
+	 * The MCP server handling the current request, if any.
+	 *
+	 * Set by transport-layer handlers around request dispatch so that
+	 * downstream code (e.g. the built-in discover/get-info/execute
+	 * abilities, or filters they expose) can identify which server
+	 * the current call is coming from. Null when no server context
+	 * is active (e.g. WP-CLI, direct ability invocation).
+	 *
+	 * @var \WP\MCP\Core\McpServer|null
+	 */
+	private ?McpServer $current_server = null;
+
+	/**
 	 * Get the registry instance
 	 *
 	 * @return \WP\MCP\Core\McpAdapter
@@ -323,6 +336,41 @@ final class McpAdapter {
 	 */
 	public function get_servers(): array {
 		return $this->servers;
+	}
+
+	/**
+	 * Set the MCP server handling the current request.
+	 *
+	 * Called by transport-layer handlers (e.g. ToolsHandler) around
+	 * request dispatch so that code invoked deeper in the stack —
+	 * ability permission checks, execute callbacks, and any filters
+	 * they expose — can identify which server initiated the call.
+	 *
+	 * Pass null to clear the context (do this in a `finally` block
+	 * so exceptions do not leak stale server state to unrelated
+	 * subsequent calls).
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param \WP\MCP\Core\McpServer|null $server The current server, or null to clear.
+	 */
+	public function set_current_server( ?McpServer $server ): void {
+		$this->current_server = $server;
+	}
+
+	/**
+	 * Get the MCP server handling the current request, if any.
+	 *
+	 * Returns null when no server context is active (e.g. the current
+	 * call originated from WP-CLI, cron, or a direct
+	 * `wp_get_ability( ... )->execute()` outside of an MCP request).
+	 *
+	 * @since 0.6.0
+	 *
+	 * @return \WP\MCP\Core\McpServer|null The current server, or null.
+	 */
+	public function get_current_server(): ?McpServer {
+		return $this->current_server;
 	}
 
 	/**

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Handlers\Tools;
 
+use WP\MCP\Core\McpAdapter;
 use WP\MCP\Core\McpServer;
 use WP\MCP\Domain\Utils\ContentBlockHelper;
 use WP\MCP\Handlers\HandlerHelperTrait;
@@ -127,6 +128,13 @@ class ToolsHandler {
 		if ( isset( $request_params['arguments'] ) && ! is_array( $request_params['arguments'] ) ) {
 			return McpErrorFactory::invalid_params( $request_id, 'arguments must be an object' );
 		}
+
+		// Expose the current server to downstream code (ability
+		// permission checks, execute callbacks, filters they trigger)
+		// so it can identify which server the call is coming from.
+		// Cleared in `finally` below to survive exceptions and early
+		// returns.
+		McpAdapter::instance()->set_current_server( $this->mcp );
 
 		try {
 			$tool_name = trim( (string) $request_params['name'] );
@@ -318,6 +326,8 @@ class ToolsHandler {
 			);
 
 			return McpErrorFactory::internal_error( $request_id, 'Failed to execute tool' );
+		} finally {
+			McpAdapter::instance()->set_current_server( null );
 		}
 	}
 

--- a/tests/phpunit/Integration/ExposureFilterIntegrationTest.php
+++ b/tests/phpunit/Integration/ExposureFilterIntegrationTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * End-to-end tests for the `mcp_adapter_is_ability_exposed` filter as
+ * seen from an actual tool dispatch through `ToolsHandler::call_tool()`.
+ *
+ * Confirms that the current-server holder wired in `ToolsHandler` is
+ * observable from inside the exposure filter — i.e. the filter receives
+ * the real `McpServer` instance during a tool call, not a synthetic
+ * value produced by direct helper invocation.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Integration;
+
+use WP\MCP\Abilities\McpAbilityExposureContext;
+use WP\MCP\Core\McpAdapter;
+use WP\MCP\Core\McpServer;
+use WP\MCP\Handlers\Tools\ToolsHandler;
+use WP\MCP\Tests\TestCase;
+
+final class ExposureFilterIntegrationTest extends TestCase {
+
+	/**
+	 * User ID for authenticated tests.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'exposureintuser',
+				'user_pass'  => 'testpass',
+				'user_email' => 'exposureint@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user_id );
+	}
+
+	public function tear_down(): void {
+		McpAdapter::instance()->set_current_server( null );
+		wp_set_current_user( 0 );
+		wp_delete_user( $this->user_id );
+		parent::tear_down();
+	}
+
+	public function test_call_tool_threads_actual_server_into_exposure_filter(): void {
+		$this->register_ability_in_hook(
+			'test/integration-target',
+			array(
+				'label'               => 'Integration Target',
+				'description'         => 'Probed via the filter while the built-in discover tool runs.',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array(); },
+				'permission_callback' => static function () {
+					return true; },
+				'meta'                => array( 'mcp' => array( 'type' => 'tool' ) ),
+			)
+		);
+
+		$server = $this->makeServer( array( 'mcp-adapter/discover-abilities' ) );
+
+		$captured_server = 'unset';
+		$captured_path   = null;
+		$filter          = function ( $is_exposed, $ability, $context ) use ( &$captured_server, &$captured_path ) {
+			if ( 'test/integration-target' === $ability->get_name() ) {
+				$captured_server = $context->server;
+				$captured_path   = $context->exposure_path;
+			}
+			return $is_exposed;
+		};
+		add_filter( 'mcp_adapter_is_ability_exposed', $filter, 10, 3 );
+
+		try {
+			$handler = new ToolsHandler( $server );
+			$handler->call_tool(
+				array(
+					'params' => array(
+						'name'      => 'mcp-adapter/discover-abilities',
+						'arguments' => new \stdClass(),
+					),
+				)
+			);
+		} finally {
+			remove_filter( 'mcp_adapter_is_ability_exposed', $filter, 10 );
+			wp_unregister_ability( 'test/integration-target' );
+		}
+
+		$this->assertInstanceOf(
+			McpServer::class,
+			$captured_server,
+			'The exposure filter must receive the real McpServer when invoked through ToolsHandler::call_tool(), not null.'
+		);
+		$this->assertSame(
+			$server,
+			$captured_server,
+			'The exposure filter must receive the same McpServer instance the ToolsHandler was constructed with.'
+		);
+		$this->assertSame(
+			McpAbilityExposureContext::PATH_DISCOVER,
+			$captured_path,
+			'The exposure path must reflect the built-in tool that triggered the check.'
+		);
+	}
+
+	public function test_call_tool_clears_current_server_after_dispatch(): void {
+		$this->assertNull(
+			McpAdapter::instance()->get_current_server(),
+			'Sanity: nothing should be set before dispatch.'
+		);
+
+		$server  = $this->makeServer( array( 'mcp-adapter/discover-abilities' ) );
+		$handler = new ToolsHandler( $server );
+		$handler->call_tool(
+			array(
+				'params' => array(
+					'name'      => 'mcp-adapter/discover-abilities',
+					'arguments' => new \stdClass(),
+				),
+			)
+		);
+
+		$this->assertNull(
+			McpAdapter::instance()->get_current_server(),
+			'ToolsHandler must clear the current-server holder after dispatch so subsequent, unrelated calls do not observe stale server state.'
+		);
+	}
+}

--- a/tests/phpunit/Integration/ExposureFilterIntegrationTest.php
+++ b/tests/phpunit/Integration/ExposureFilterIntegrationTest.php
@@ -85,7 +85,7 @@ final class ExposureFilterIntegrationTest extends TestCase {
 				array(
 					'params' => array(
 						'name'      => 'mcp-adapter/discover-abilities',
-						'arguments' => new \stdClass(),
+						'arguments' => array(),
 					),
 				)
 			);
@@ -123,7 +123,7 @@ final class ExposureFilterIntegrationTest extends TestCase {
 			array(
 				'params' => array(
 					'name'      => 'mcp-adapter/discover-abilities',
-					'arguments' => new \stdClass(),
+					'arguments' => array(),
 				),
 			)
 		);

--- a/tests/phpunit/Integration/ExposureFilterIntegrationTest.php
+++ b/tests/phpunit/Integration/ExposureFilterIntegrationTest.php
@@ -51,27 +51,25 @@ final class ExposureFilterIntegrationTest extends TestCase {
 	}
 
 	public function test_call_tool_threads_actual_server_into_exposure_filter(): void {
-		$this->register_ability_in_hook(
-			'test/integration-target',
-			array(
-				'label'               => 'Integration Target',
-				'description'         => 'Probed via the filter while the built-in discover tool runs.',
-				'category'            => 'test',
-				'input_schema'        => array( 'type' => 'object' ),
-				'execute_callback'    => static function () {
-					return array(); },
-				'permission_callback' => static function () {
-					return true; },
-				'meta'                => array( 'mcp' => array( 'type' => 'tool' ) ),
-			)
+		// Use the already-registered `test/always-allowed` fixture (has
+		// `mcp.public => true`), which is guaranteed to be present in
+		// `wp_get_abilities()` in every test run — avoids any
+		// registration-timing ambiguity.
+		$this->assertTrue(
+			wp_has_ability( 'test/always-allowed' ),
+			'Sanity: fixture ability must be registered before this test runs.'
 		);
 
 		$server = $this->makeServer( array( 'mcp-adapter/discover-abilities' ) );
 
 		$captured_server = 'unset';
 		$captured_path   = null;
-		$filter          = function ( $is_exposed, $ability, $context ) use ( &$captured_server, &$captured_path ) {
-			if ( 'test/integration-target' === $ability->get_name() ) {
+		$fire_count      = 0;
+		$saw_names       = array();
+		$filter          = function ( $is_exposed, $ability, $context ) use ( &$captured_server, &$captured_path, &$fire_count, &$saw_names ) {
+			++$fire_count;
+			$saw_names[] = $ability->get_name();
+			if ( 'test/always-allowed' === $ability->get_name() ) {
 				$captured_server = $context->server;
 				$captured_path   = $context->exposure_path;
 			}
@@ -79,9 +77,10 @@ final class ExposureFilterIntegrationTest extends TestCase {
 		};
 		add_filter( 'mcp_adapter_is_ability_exposed', $filter, 10, 3 );
 
+		$result = null;
 		try {
 			$handler = new ToolsHandler( $server );
-			$handler->call_tool(
+			$result  = $handler->call_tool(
 				array(
 					'params' => array(
 						'name'      => 'mcp-adapter/discover-abilities',
@@ -91,8 +90,30 @@ final class ExposureFilterIntegrationTest extends TestCase {
 			);
 		} finally {
 			remove_filter( 'mcp_adapter_is_ability_exposed', $filter, 10 );
-			wp_unregister_ability( 'test/integration-target' );
 		}
+
+		// Diagnostic assertion first — surfaces the actual state in CI
+		// output if the filter never fired (rather than a bare "unset"
+		// mismatch that hides the root cause).
+		$this->assertGreaterThan(
+			0,
+			$fire_count,
+			sprintf(
+				'Exposure filter never fired. call_tool returned %s. Abilities seen by filter: %s',
+				null === $result ? 'null' : get_class( $result ),
+				empty( $saw_names ) ? '(none)' : implode( ', ', $saw_names )
+			)
+		);
+
+		$this->assertContains(
+			'test/always-allowed',
+			$saw_names,
+			sprintf(
+				'Filter fired %d times but never for test/always-allowed. Names seen: %s',
+				$fire_count,
+				implode( ', ', $saw_names )
+			)
+		);
 
 		$this->assertInstanceOf(
 			McpServer::class,

--- a/tests/phpunit/Integration/ExposureFilterIntegrationTest.php
+++ b/tests/phpunit/Integration/ExposureFilterIntegrationTest.php
@@ -83,7 +83,10 @@ final class ExposureFilterIntegrationTest extends TestCase {
 			$result  = $handler->call_tool(
 				array(
 					'params' => array(
-						'name'      => 'mcp-adapter/discover-abilities',
+						// McpNameSanitizer replaces "/" with "-" for the tool name;
+// the *ability* name still contains the slash but the MCP tool
+// name the client invokes does not.
+'name'      => 'mcp-adapter-discover-abilities',
 						'arguments' => array(),
 					),
 				)
@@ -143,7 +146,10 @@ final class ExposureFilterIntegrationTest extends TestCase {
 		$handler->call_tool(
 			array(
 				'params' => array(
-					'name'      => 'mcp-adapter/discover-abilities',
+					// McpNameSanitizer replaces "/" with "-" for the tool name;
+// the *ability* name still contains the slash but the MCP tool
+// name the client invokes does not.
+'name'      => 'mcp-adapter-discover-abilities',
 					'arguments' => array(),
 				),
 			)

--- a/tests/phpunit/Unit/Abilities/DiscoverAbilitiesAbilityTest.php
+++ b/tests/phpunit/Unit/Abilities/DiscoverAbilitiesAbilityTest.php
@@ -239,4 +239,48 @@ final class DiscoverAbilitiesAbilityTest extends TestCase {
 		$this->assertFalse( $annotations['destructive'] );
 		$this->assertTrue( $annotations['idempotent'] );
 	}
+
+	public function test_is_ability_public_filter_can_expose_non_public_ability(): void {
+		$this->register_ability_in_hook(
+			'test/filter-exposed',
+			array(
+				'label'               => 'Filter Exposed',
+				'description'         => 'Not statically public; forced visible via filter.',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array(); },
+				'permission_callback' => static function () {
+					return true; },
+				'meta'                => array( 'mcp' => array( 'type' => 'tool' ) ),
+			)
+		);
+
+		$before        = DiscoverAbilitiesAbility::execute( array() );
+		$before_names  = array_column( $before['abilities'], 'name' );
+		$this->assertNotContains( 'test/filter-exposed', $before_names, 'Sanity: non-public ability is hidden by default.' );
+
+		$captured_ability_name = null;
+		$captured_server       = 'unset';
+		$filter                = function ( $is_public, $ability, $server ) use ( &$captured_ability_name, &$captured_server ) {
+			if ( 'test/filter-exposed' === $ability->get_name() ) {
+				$captured_ability_name = $ability->get_name();
+				$captured_server       = $server;
+				return true;
+			}
+			return $is_public;
+		};
+		add_filter( 'mcp_adapter_is_ability_public', $filter, 10, 3 );
+
+		try {
+			$after       = DiscoverAbilitiesAbility::execute( array() );
+			$after_names = array_column( $after['abilities'], 'name' );
+			$this->assertContains( 'test/filter-exposed', $after_names, 'Filter should be able to force-include a non-public ability.' );
+			$this->assertSame( 'test/filter-exposed', $captured_ability_name );
+			$this->assertNull( $captured_server, 'Server arg should be null when no MCP request is in flight.' );
+		} finally {
+			remove_filter( 'mcp_adapter_is_ability_public', $filter, 10 );
+			wp_unregister_ability( 'test/filter-exposed' );
+		}
+	}
 }

--- a/tests/phpunit/Unit/Abilities/DiscoverAbilitiesAbilityTest.php
+++ b/tests/phpunit/Unit/Abilities/DiscoverAbilitiesAbilityTest.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Tests\Unit\Abilities;
 
 use WP\MCP\Abilities\DiscoverAbilitiesAbility;
+use WP\MCP\Abilities\McpAbilityExposureContext;
 use WP\MCP\Tests\TestCase;
 use WP_Error;
 
@@ -240,7 +241,7 @@ final class DiscoverAbilitiesAbilityTest extends TestCase {
 		$this->assertTrue( $annotations['idempotent'] );
 	}
 
-	public function test_is_ability_public_filter_can_expose_non_public_ability(): void {
+	public function test_is_ability_exposed_filter_can_expose_non_public_ability(): void {
 		$this->register_ability_in_hook(
 			'test/filter-exposed',
 			array(
@@ -256,30 +257,32 @@ final class DiscoverAbilitiesAbilityTest extends TestCase {
 			)
 		);
 
-		$before        = DiscoverAbilitiesAbility::execute( array() );
-		$before_names  = array_column( $before['abilities'], 'name' );
+		$before       = DiscoverAbilitiesAbility::execute( array() );
+		$before_names = array_column( $before['abilities'], 'name' );
 		$this->assertNotContains( 'test/filter-exposed', $before_names, 'Sanity: non-public ability is hidden by default.' );
 
 		$captured_ability_name = null;
-		$captured_server       = 'unset';
-		$filter                = function ( $is_public, $ability, $server ) use ( &$captured_ability_name, &$captured_server ) {
+		$captured_context      = null;
+		$filter                = function ( $is_exposed, $ability, $context ) use ( &$captured_ability_name, &$captured_context ) {
 			if ( 'test/filter-exposed' === $ability->get_name() ) {
 				$captured_ability_name = $ability->get_name();
-				$captured_server       = $server;
+				$captured_context      = $context;
 				return true;
 			}
-			return $is_public;
+			return $is_exposed;
 		};
-		add_filter( 'mcp_adapter_is_ability_public', $filter, 10, 3 );
+		add_filter( 'mcp_adapter_is_ability_exposed', $filter, 10, 3 );
 
 		try {
 			$after       = DiscoverAbilitiesAbility::execute( array() );
 			$after_names = array_column( $after['abilities'], 'name' );
 			$this->assertContains( 'test/filter-exposed', $after_names, 'Filter should be able to force-include a non-public ability.' );
 			$this->assertSame( 'test/filter-exposed', $captured_ability_name );
-			$this->assertNull( $captured_server, 'Server arg should be null when no MCP request is in flight.' );
+			$this->assertInstanceOf( McpAbilityExposureContext::class, $captured_context );
+			$this->assertSame( McpAbilityExposureContext::PATH_DISCOVER, $captured_context->exposure_path );
+			$this->assertNull( $captured_context->server, 'Context server should be null when no MCP request is in flight.' );
 		} finally {
-			remove_filter( 'mcp_adapter_is_ability_public', $filter, 10 );
+			remove_filter( 'mcp_adapter_is_ability_exposed', $filter, 10 );
 			wp_unregister_ability( 'test/filter-exposed' );
 		}
 	}

--- a/tests/phpunit/Unit/Abilities/ExecuteAbilityAbilityTest.php
+++ b/tests/phpunit/Unit/Abilities/ExecuteAbilityAbilityTest.php
@@ -519,6 +519,72 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 	}
 
 	/**
+	 * SECURITY INVARIANT: exposure is not authorization — the caller
+	 * still has to pass the tool's own authentication / capability
+	 * gate before the exposure filter is even consulted.
+	 *
+	 * A downstream widening exposure (e.g. to reveal an ability to
+	 * server-scoped clients) must not thereby grant execution rights
+	 * to an unauthenticated principal.
+	 */
+	public function test_exposure_filter_does_not_bypass_capability_check_for_unauthorized_principal(): void {
+		$this->register_ability_in_hook(
+			'test/exposed-but-unauthorized',
+			array(
+				'label'               => 'Exposed But Unauthorized',
+				'description'         => 'Ability the exposure filter widens for an unauthenticated caller.',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array( 'ok' => true ); },
+				// The ability itself is permissive — the failure must
+				// come from the tool-level capability gate, not from
+				// the ability's own permission_callback.
+				'permission_callback' => static function () {
+					return true; },
+			)
+		);
+
+		$filter = static function ( $is_exposed, $ability ) {
+			return 'test/exposed-but-unauthorized' === $ability->get_name() ? true : $is_exposed;
+		};
+		add_filter( 'mcp_adapter_is_ability_exposed', $filter, 10, 3 );
+
+		// Unauthenticated principal.
+		$previous_user = get_current_user_id();
+		wp_set_current_user( 0 );
+
+		try {
+			$result = ExecuteAbilityAbility::check_permission(
+				array(
+					'ability_name' => 'test/exposed-but-unauthorized',
+					'parameters'   => new \stdClass(),
+				)
+			);
+
+			$this->assertInstanceOf(
+				WP_Error::class,
+				$result,
+				'An exposure filter that returns true must not upgrade an unauthenticated principal into an authorized one.'
+			);
+			$this->assertSame(
+				'authentication_required',
+				$result->get_error_code(),
+				"The failure must come from the tool's authentication gate, not from the exposure gate."
+			);
+			$this->assertNotSame(
+				'ability_not_public_mcp',
+				$result->get_error_code(),
+				'The exposure gate must not run before the authentication gate.'
+			);
+		} finally {
+			wp_set_current_user( $previous_user );
+			remove_filter( 'mcp_adapter_is_ability_exposed', $filter, 10 );
+			wp_unregister_ability( 'test/exposed-but-unauthorized' );
+		}
+	}
+
+	/**
 	 * SECURITY INVARIANT: exposure is not authorization.
 	 *
 	 * Even if the `mcp_adapter_is_ability_exposed` filter marks an

--- a/tests/phpunit/Unit/Abilities/ExecuteAbilityAbilityTest.php
+++ b/tests/phpunit/Unit/Abilities/ExecuteAbilityAbilityTest.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Tests\Unit\Abilities;
 
 use WP\MCP\Abilities\ExecuteAbilityAbility;
+use WP\MCP\Abilities\McpAbilityExposureContext;
 use WP\MCP\Tests\TestCase;
 use WP_Error;
 
@@ -468,7 +469,7 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 		$this->assertFalse( $annotations['idempotent'] );
 	}
 
-	public function test_is_ability_public_filter_can_bypass_exposure_gate(): void {
+	public function test_is_ability_exposed_filter_can_bypass_exposure_gate(): void {
 		$this->register_ability_in_hook(
 			'test/not-public-execute-filter',
 			array(
@@ -492,10 +493,15 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $blocked );
 		$this->assertEquals( 'ability_not_public_mcp', $blocked->get_error_code() );
 
-		$filter = static function ( $is_public, $ability ) {
-			return 'test/not-public-execute-filter' === $ability->get_name() ? true : $is_public;
+		$captured_path = null;
+		$filter        = static function ( $is_exposed, $ability, $context ) use ( &$captured_path ) {
+			if ( 'test/not-public-execute-filter' === $ability->get_name() ) {
+				$captured_path = $context->exposure_path;
+				return true;
+			}
+			return $is_exposed;
 		};
-		add_filter( 'mcp_adapter_is_ability_public', $filter, 10, 3 );
+		add_filter( 'mcp_adapter_is_ability_exposed', $filter, 10, 3 );
 
 		try {
 			$allowed = ExecuteAbilityAbility::check_permission(
@@ -505,9 +511,65 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 				)
 			);
 			$this->assertTrue( $allowed, 'Filter should be able to bypass the exposure gate.' );
+			$this->assertSame( McpAbilityExposureContext::PATH_EXECUTE, $captured_path );
 		} finally {
-			remove_filter( 'mcp_adapter_is_ability_public', $filter, 10 );
+			remove_filter( 'mcp_adapter_is_ability_exposed', $filter, 10 );
 			wp_unregister_ability( 'test/not-public-execute-filter' );
+		}
+	}
+
+	/**
+	 * SECURITY INVARIANT: exposure is not authorization.
+	 *
+	 * Even if the `mcp_adapter_is_ability_exposed` filter marks an
+	 * ability as exposed, the execute-ability tool must still consult
+	 * the ability's own `permission_callback`. Otherwise a downstream
+	 * that widens exposure for visibility reasons would inadvertently
+	 * grant *invocation* rights it never intended.
+	 */
+	public function test_exposure_filter_does_not_replace_ability_permission_check(): void {
+		$this->register_ability_in_hook(
+			'test/exposed-but-denied',
+			array(
+				'label'               => 'Exposed But Denied',
+				'description'         => 'Ability with denying permission_callback.',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array( 'ok' => true ); },
+				'permission_callback' => static function () {
+					return new WP_Error( 'ability_permission_denied', 'Nope.' );
+				},
+			)
+		);
+
+		$filter = static function ( $is_exposed, $ability ) {
+			return 'test/exposed-but-denied' === $ability->get_name() ? true : $is_exposed;
+		};
+		add_filter( 'mcp_adapter_is_ability_exposed', $filter, 10, 3 );
+
+		try {
+			$result = ExecuteAbilityAbility::check_permission(
+				array(
+					'ability_name' => 'test/exposed-but-denied',
+					'parameters'   => new \stdClass(),
+				)
+			);
+
+			$this->assertInstanceOf( WP_Error::class, $result, 'Exposure must not bypass the ability permission callback.' );
+			$this->assertSame(
+				'ability_permission_denied',
+				$result->get_error_code(),
+				"The failure must come from the ability's permission_callback, not the exposure gate."
+			);
+			$this->assertNotSame(
+				'ability_not_public_mcp',
+				$result->get_error_code(),
+				'The exposure gate should have passed; the error must originate from the permission callback instead.'
+			);
+		} finally {
+			remove_filter( 'mcp_adapter_is_ability_exposed', $filter, 10 );
+			wp_unregister_ability( 'test/exposed-but-denied' );
 		}
 	}
 }

--- a/tests/phpunit/Unit/Abilities/ExecuteAbilityAbilityTest.php
+++ b/tests/phpunit/Unit/Abilities/ExecuteAbilityAbilityTest.php
@@ -467,4 +467,47 @@ final class ExecuteAbilityAbilityTest extends TestCase {
 		$this->assertTrue( $annotations['destructive'] );
 		$this->assertFalse( $annotations['idempotent'] );
 	}
+
+	public function test_is_ability_public_filter_can_bypass_exposure_gate(): void {
+		$this->register_ability_in_hook(
+			'test/not-public-execute-filter',
+			array(
+				'label'               => 'Not Public Execute Filter Test',
+				'description'         => 'Ability without mcp.public metadata',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array( 'ok' => true ); },
+				'permission_callback' => static function () {
+					return true; },
+			)
+		);
+
+		$blocked = ExecuteAbilityAbility::check_permission(
+			array(
+				'ability_name' => 'test/not-public-execute-filter',
+				'parameters'   => new \stdClass(),
+			)
+		);
+		$this->assertInstanceOf( WP_Error::class, $blocked );
+		$this->assertEquals( 'ability_not_public_mcp', $blocked->get_error_code() );
+
+		$filter = static function ( $is_public, $ability ) {
+			return 'test/not-public-execute-filter' === $ability->get_name() ? true : $is_public;
+		};
+		add_filter( 'mcp_adapter_is_ability_public', $filter, 10, 3 );
+
+		try {
+			$allowed = ExecuteAbilityAbility::check_permission(
+				array(
+					'ability_name' => 'test/not-public-execute-filter',
+					'parameters'   => new \stdClass(),
+				)
+			);
+			$this->assertTrue( $allowed, 'Filter should be able to bypass the exposure gate.' );
+		} finally {
+			remove_filter( 'mcp_adapter_is_ability_public', $filter, 10 );
+			wp_unregister_ability( 'test/not-public-execute-filter' );
+		}
+	}
 }

--- a/tests/phpunit/Unit/Abilities/GetAbilityInfoAbilityTest.php
+++ b/tests/phpunit/Unit/Abilities/GetAbilityInfoAbilityTest.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Tests\Unit\Abilities;
 
 use WP\MCP\Abilities\GetAbilityInfoAbility;
+use WP\MCP\Abilities\McpAbilityExposureContext;
 use WP\MCP\Tests\TestCase;
 use WP_Error;
 
@@ -320,7 +321,7 @@ final class GetAbilityInfoAbilityTest extends TestCase {
 		$this->assertEquals( 'test/always-allowed', $result1['name'] );
 	}
 
-	public function test_is_ability_public_filter_can_bypass_exposure_gate(): void {
+	public function test_is_ability_exposed_filter_can_bypass_exposure_gate(): void {
 		$this->register_ability_in_hook(
 			'test/not-public-info-filter',
 			array(
@@ -341,18 +342,24 @@ final class GetAbilityInfoAbilityTest extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $blocked );
 		$this->assertEquals( 'ability_not_public_mcp', $blocked->get_error_code() );
 
-		$filter = static function ( $is_public, $ability ) {
-			return 'test/not-public-info-filter' === $ability->get_name() ? true : $is_public;
+		$captured_path = null;
+		$filter        = static function ( $is_exposed, $ability, $context ) use ( &$captured_path ) {
+			if ( 'test/not-public-info-filter' === $ability->get_name() ) {
+				$captured_path = $context->exposure_path;
+				return true;
+			}
+			return $is_exposed;
 		};
-		add_filter( 'mcp_adapter_is_ability_public', $filter, 10, 3 );
+		add_filter( 'mcp_adapter_is_ability_exposed', $filter, 10, 3 );
 
 		try {
 			$allowed = GetAbilityInfoAbility::check_permission(
 				array( 'ability_name' => 'test/not-public-info-filter' )
 			);
 			$this->assertTrue( $allowed, 'Filter should be able to bypass the exposure gate.' );
+			$this->assertSame( McpAbilityExposureContext::PATH_GET_INFO, $captured_path );
 		} finally {
-			remove_filter( 'mcp_adapter_is_ability_public', $filter, 10 );
+			remove_filter( 'mcp_adapter_is_ability_exposed', $filter, 10 );
 			wp_unregister_ability( 'test/not-public-info-filter' );
 		}
 	}

--- a/tests/phpunit/Unit/Abilities/GetAbilityInfoAbilityTest.php
+++ b/tests/phpunit/Unit/Abilities/GetAbilityInfoAbilityTest.php
@@ -319,4 +319,41 @@ final class GetAbilityInfoAbilityTest extends TestCase {
 		$this->assertArrayHasKey( 'name', $result1 );
 		$this->assertEquals( 'test/always-allowed', $result1['name'] );
 	}
+
+	public function test_is_ability_public_filter_can_bypass_exposure_gate(): void {
+		$this->register_ability_in_hook(
+			'test/not-public-info-filter',
+			array(
+				'label'               => 'Not Public Info Filter Test',
+				'description'         => 'Ability without mcp.public metadata',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array( 'test' => 'result' ); },
+				'permission_callback' => static function () {
+					return true; },
+			)
+		);
+
+		$blocked = GetAbilityInfoAbility::check_permission(
+			array( 'ability_name' => 'test/not-public-info-filter' )
+		);
+		$this->assertInstanceOf( WP_Error::class, $blocked );
+		$this->assertEquals( 'ability_not_public_mcp', $blocked->get_error_code() );
+
+		$filter = static function ( $is_public, $ability ) {
+			return 'test/not-public-info-filter' === $ability->get_name() ? true : $is_public;
+		};
+		add_filter( 'mcp_adapter_is_ability_public', $filter, 10, 3 );
+
+		try {
+			$allowed = GetAbilityInfoAbility::check_permission(
+				array( 'ability_name' => 'test/not-public-info-filter' )
+			);
+			$this->assertTrue( $allowed, 'Filter should be able to bypass the exposure gate.' );
+		} finally {
+			remove_filter( 'mcp_adapter_is_ability_public', $filter, 10 );
+			wp_unregister_ability( 'test/not-public-info-filter' );
+		}
+	}
 }

--- a/tests/phpunit/Unit/Abilities/McpAbilityExposureContextTest.php
+++ b/tests/phpunit/Unit/Abilities/McpAbilityExposureContextTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Tests for the McpAbilityExposureContext value object.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Abilities;
+
+use WP\MCP\Abilities\McpAbilityExposureContext;
+use WP\MCP\Tests\TestCase;
+
+final class McpAbilityExposureContextTest extends TestCase {
+
+	public function test_path_constants_are_stable(): void {
+		// These string values are part of the public contract of the
+		// `mcp_adapter_is_ability_exposed` filter — downstream code may
+		// compare `$context->exposure_path` to string literals. Do not
+		// change these without treating it as a BC break.
+		$this->assertSame( 'discover', McpAbilityExposureContext::PATH_DISCOVER );
+		$this->assertSame( 'get_info', McpAbilityExposureContext::PATH_GET_INFO );
+		$this->assertSame( 'execute', McpAbilityExposureContext::PATH_EXECUTE );
+	}
+
+	public function test_construction_populates_all_fields(): void {
+		$context = new McpAbilityExposureContext(
+			null,
+			42,
+			array( 'editor', 'contributor' ),
+			7,
+			McpAbilityExposureContext::PATH_EXECUTE
+		);
+
+		$this->assertNull( $context->server );
+		$this->assertSame( 42, $context->principal_id );
+		$this->assertSame( array( 'editor', 'contributor' ), $context->roles );
+		$this->assertSame( 7, $context->site_id );
+		$this->assertSame( McpAbilityExposureContext::PATH_EXECUTE, $context->exposure_path );
+	}
+}

--- a/tests/phpunit/Unit/Abilities/McpAbilityExposureInvariantsTest.php
+++ b/tests/phpunit/Unit/Abilities/McpAbilityExposureInvariantsTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Cross-cutting invariants that the `mcp_adapter_is_ability_exposed`
+ * filter must satisfy across all three built-in MCP ability tools.
+ *
+ * These invariants are the security contract of the filter. Regressions
+ * here would let one tool's exposure decision drift from another's, or
+ * let downstreams silently observe inconsistent context shapes across
+ * discover / get-info / execute — either of which could result in an
+ * ability being exposed to the wrong caller.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Abilities;
+
+use WP\MCP\Abilities\DiscoverAbilitiesAbility;
+use WP\MCP\Abilities\ExecuteAbilityAbility;
+use WP\MCP\Abilities\GetAbilityInfoAbility;
+use WP\MCP\Abilities\McpAbilityExposureContext;
+use WP\MCP\Tests\TestCase;
+
+/**
+ * Verifies the shared shape and semantics of the exposure filter.
+ */
+final class McpAbilityExposureInvariantsTest extends TestCase {
+
+	/**
+	 * User ID for authenticated tests.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'exposureuser',
+				'user_pass'  => 'testpass',
+				'user_email' => 'exposure@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user_id );
+
+		$this->register_ability_in_hook(
+			'test/exposure-invariant',
+			array(
+				'label'               => 'Exposure Invariant Test',
+				'description'         => 'Ability probed by all three built-in tools.',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function () {
+					return array( 'ok' => true ); },
+				'permission_callback' => static function () {
+					return true; },
+				// Statically public so all three tools reach the filter.
+				'meta'                => array( 'mcp' => array( 'public' => true, 'type' => 'tool' ) ),
+			)
+		);
+	}
+
+	public function tear_down(): void {
+		wp_unregister_ability( 'test/exposure-invariant' );
+		wp_set_current_user( 0 );
+		wp_delete_user( $this->user_id );
+		parent::tear_down();
+	}
+
+	/**
+	 * INVARIANT: all three built-in tools call the same filter, with a
+	 * context of the same shape and only `exposure_path` differing.
+	 *
+	 * If this ever fails, one of the tools has diverged and downstream
+	 * exposure filters can no longer trust that their view is uniform
+	 * across discover / get-info / execute.
+	 */
+	public function test_exposure_filter_receives_identical_context_shape_across_all_three_tools(): void {
+		$captured = array();
+		$filter   = static function ( $is_exposed, $ability, $context ) use ( &$captured ) {
+			if ( 'test/exposure-invariant' === $ability->get_name() ) {
+				$captured[ $context->exposure_path ] = $context;
+			}
+			return $is_exposed;
+		};
+		add_filter( 'mcp_adapter_is_ability_exposed', $filter, 10, 3 );
+
+		try {
+			DiscoverAbilitiesAbility::execute( array() );
+			GetAbilityInfoAbility::check_permission( array( 'ability_name' => 'test/exposure-invariant' ) );
+			ExecuteAbilityAbility::check_permission(
+				array(
+					'ability_name' => 'test/exposure-invariant',
+					'parameters'   => new \stdClass(),
+				)
+			);
+		} finally {
+			remove_filter( 'mcp_adapter_is_ability_exposed', $filter, 10 );
+		}
+
+		// All three exposure paths must have been recorded.
+		$this->assertArrayHasKey( McpAbilityExposureContext::PATH_DISCOVER, $captured );
+		$this->assertArrayHasKey( McpAbilityExposureContext::PATH_GET_INFO, $captured );
+		$this->assertArrayHasKey( McpAbilityExposureContext::PATH_EXECUTE, $captured );
+
+		// Each context is the value-object type and carries the expected path.
+		foreach ( $captured as $path => $context ) {
+			$this->assertInstanceOf( McpAbilityExposureContext::class, $context );
+			$this->assertSame( $path, $context->exposure_path );
+		}
+
+		// Non-path fields must be identical across the three tools —
+		// the request context is the same, only the exposure path differs.
+		$reference = $captured[ McpAbilityExposureContext::PATH_DISCOVER ];
+		foreach ( array( McpAbilityExposureContext::PATH_GET_INFO, McpAbilityExposureContext::PATH_EXECUTE ) as $other_path ) {
+			$other = $captured[ $other_path ];
+			$this->assertSame( $reference->server, $other->server, "server drifts between discover and {$other_path}" );
+			$this->assertSame( $reference->principal_id, $other->principal_id, "principal_id drifts between discover and {$other_path}" );
+			$this->assertSame( $reference->roles, $other->roles, "roles drifts between discover and {$other_path}" );
+			$this->assertSame( $reference->site_id, $other->site_id, "site_id drifts between discover and {$other_path}" );
+		}
+
+		// Sanity: the context reflects the actual authenticated user.
+		$this->assertSame( $this->user_id, $reference->principal_id );
+		$this->assertContains( 'administrator', $reference->roles );
+	}
+}

--- a/tests/phpunit/Unit/Core/McpAdapterCurrentServerTest.php
+++ b/tests/phpunit/Unit/Core/McpAdapterCurrentServerTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Tests for McpAdapter::set_current_server() / get_current_server().
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Core;
+
+use WP\MCP\Core\McpAdapter;
+use WP\MCP\Core\McpServer;
+use WP\MCP\Infrastructure\ErrorHandling\NullMcpErrorHandler;
+use WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler;
+use WP\MCP\Tests\TestCase;
+use WP\MCP\Transport\HttpTransport;
+
+/**
+ * Verifies the per-request "current server" accessor used to thread the
+ * MCP server context down to filters exposed by the built-in abilities.
+ */
+final class McpAdapterCurrentServerTest extends TestCase {
+
+	public function tear_down(): void {
+		McpAdapter::instance()->set_current_server( null );
+		parent::tear_down();
+	}
+
+	public function test_current_server_defaults_to_null(): void {
+		$this->assertNull( McpAdapter::instance()->get_current_server() );
+	}
+
+	public function test_set_and_get_current_server_round_trip(): void {
+		$server = new McpServer(
+			'test-current-server',
+			'wp-mcp/v1',
+			'current-server',
+			'Test Server',
+			'Test description',
+			'0.0.1',
+			array( HttpTransport::class ),
+			NullMcpErrorHandler::class,
+			NullMcpObservabilityHandler::class,
+			array(),
+			array(),
+			array()
+		);
+
+		McpAdapter::instance()->set_current_server( $server );
+		$this->assertSame( $server, McpAdapter::instance()->get_current_server() );
+	}
+
+	public function test_setting_null_clears_the_current_server(): void {
+		$server = new McpServer(
+			'test-clear-server',
+			'wp-mcp/v1',
+			'clear-server',
+			'Test Server',
+			'Test description',
+			'0.0.1',
+			array( HttpTransport::class ),
+			NullMcpErrorHandler::class,
+			NullMcpObservabilityHandler::class,
+			array(),
+			array(),
+			array()
+		);
+
+		McpAdapter::instance()->set_current_server( $server );
+		McpAdapter::instance()->set_current_server( null );
+		$this->assertNull( McpAdapter::instance()->get_current_server() );
+	}
+}


### PR DESCRIPTION
Closes #243.

## Summary

Adds a filter — `mcp_adapter_is_ability_exposed` — that lets integrators decide, per ability and per request context, whether the three built-in MCP tools (`discover-abilities`, `get-ability-info`, `execute-ability`) treat an ability as exposed. Default behavior is unchanged: the filter defaults to the ability's existing `meta.mcp.public` flag, so unpatched sites are unaffected.

## Motivation

Today the three built-in tools decide what a client is allowed to see or invoke by reading `meta.mcp.public` directly on each ability. That is a single global boolean baked into the ability, so exposure cannot vary by request context — most importantly, an ability cannot be visible on one MCP server and hidden on another.

See #243 for the full motivation and use cases.

## Filter shape

```php
apply_filters(
    'mcp_adapter_is_ability_exposed',
    bool                        $is_exposed,   // default: ability's meta.mcp.public
    \WP_Ability                 $ability,      // the ability being checked
    McpAbilityExposureContext   $context       // request context
);
```

`McpAbilityExposureContext` is an immutable value object with:

| field           | type                           | notes                                                        |
|-----------------|--------------------------------|--------------------------------------------------------------|
| `server`        | `McpServer\|null`              | Null when invoked outside an MCP request (WP-CLI, cron, direct execute) |
| `principal_id`  | `int`                          | 0 if unauthenticated                                         |
| `roles`         | `array<int, string>`           | Role slugs of the current user                               |
| `site_id`       | `int`                          | `get_current_blog_id()`                                      |
| `exposure_path` | `string` (PATH_* constant)     | `'discover'`, `'get_info'`, or `'execute'`                   |

Downstreams can differentiate exposure decisions by path — e.g. list an ability but block execution:

```php
add_filter( 'mcp_adapter_is_ability_exposed', function ( $is_exposed, $ability, $context ) {
    if ( ! $context->server ) {
        return $is_exposed; // outside an MCP request
    }
    if ( 'internal/delete-user' === $ability->get_name() ) {
        // Visible on the ops server for all paths; visible on the public
        // server for discovery only.
        if ( 'ops' === $context->server->get_server_id() ) {
            return true;
        }
        return McpAbilityExposureContext::PATH_DISCOVER === $context->exposure_path;
    }
    return $is_exposed;
}, 10, 3 );
```

## Design notes (why a context object, not positional args)

Ability callbacks only receive `$input` — that's core `WP_Ability::execute()` behavior — so the server can't be threaded through the ability call itself. Two things follow:

1. **Single point of context resolution.** A lightweight per-request holder on the existing `McpAdapter` singleton (`set_current_server()` / `get_current_server()`) is set by `ToolsHandler::call_tool()` on entry and cleared in `finally`. The trait's `build_exposure_context()` consumes that holder and the ambient user/site once, in one place. All three tools therefore see an identical context shape — no drift.
2. **Extensible surface.** New context fields (e.g. `transport`, `feature_flags`) can be added without changing the filter signature.

## Security contract (pinned in tests)

Two invariants are asserted by tests so future refactors can't silently break them:

- **Same helper, same context shape across the three tools.** `McpAbilityExposureInvariantsTest::test_exposure_filter_receives_identical_context_shape_across_all_three_tools()` registers one filter, invokes each of the three tools against the same ability, and asserts every non-path context field is identical.
- **Exposure is not authorization.** `ExecuteAbilityAbilityTest::test_exposure_filter_does_not_replace_ability_permission_check()` widens exposure with the filter but registers an ability whose `permission_callback` returns `WP_Error` — and asserts the execute path still rejects with the ability's error, not the exposure gate's.

The filter docblock also spells this out and calls out cache-key hygiene: if a downstream caches the exposure decision, the key must include the ability name, `exposure_path`, and every context field the callback reads. Missing dimensions cross-contaminate contexts.

## Backward compatibility

- The `ability_not_public_mcp` `WP_Error` code and message are preserved verbatim for clients catching them.
- The `meta.mcp.public` ability metadata key is unchanged (it's the static default the filter starts from).
- `mcp_adapter_is_ability_exposed` is new in this PR; no prior name shipped.

## Files

**Code (7 files)**
- `includes/Abilities/McpAbilityExposureContext.php` — new value object.
- `includes/Abilities/McpAbilityHelperTrait.php` — renamed helper, filter, `build_exposure_context()`.
- `includes/Abilities/DiscoverAbilitiesAbility.php` — passes `PATH_DISCOVER`.
- `includes/Abilities/GetAbilityInfoAbility.php` — passes `PATH_GET_INFO`.
- `includes/Abilities/ExecuteAbilityAbility.php` — passes `PATH_EXECUTE`.
- `includes/Core/McpAdapter.php` — `set_current_server()` / `get_current_server()`.
- `includes/Handlers/Tools/ToolsHandler.php` — set/clear the holder in `try/finally`.

**Tests (5 files)**
- `tests/phpunit/Unit/Core/McpAdapterCurrentServerTest.php` — accessor.
- `tests/phpunit/Unit/Abilities/McpAbilityExposureContextTest.php` — value object + path constants stability.
- `tests/phpunit/Unit/Abilities/McpAbilityExposureInvariantsTest.php` — SECURITY INVARIANT: same context shape across all three tools.
- `tests/phpunit/Unit/Abilities/ExecuteAbilityAbilityTest.php` — SECURITY INVARIANT: exposure ≠ authorization + renamed filter override test.
- `DiscoverAbilitiesAbilityTest.php`, `GetAbilityInfoAbilityTest.php` — renamed filter override tests asserting the context object shape.

## Verification

- `phpcs` (WPCS ruleset) clean on all modified `includes/` files.
- `phpstan --memory-limit=1G` clean on all modified `includes/` files.
- `php -l` clean on all touched files.
- PHPUnit not run locally (needs `wp-env`/Docker); will validate in CI.

## Non-goals

- No change to default behavior — the filter defaults to `meta.mcp.public`.
- No change to `*_capability` filters — capability gating stays orthogonal.
- No change to `WP_Ability::execute()` / core WP.
- Only `ToolsHandler` sets/clears the current-server holder in this PR. `ResourcesHandler` and `PromptsHandler` can adopt the same pattern in a follow-up if the built-in tools ever grow resource/prompt equivalents; the three built-in abilities today are tool-only.