### PR TITLE
Fix concurrent session overwrites

### DIFF
--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -21,7 +21,7 @@ use WP_Error;
 final class SessionManager {
 
 	/**
-	 * User meta key for storing sessions
+	 * User meta key for storing sessions.
 	 *
 	 * @var string
 	 */
@@ -79,21 +79,26 @@ final class SessionManager {
 				}
 			);
 
-			array_shift( $sessions );
+			$oldest_session_id = key( $sessions );
+			if ( is_string( $oldest_session_id ) ) {
+				self::delete_session( $user_id, $oldest_session_id );
+			}
 		}
 
 		// Create a new session
 		$session_id = wp_generate_uuid4();
 		$now        = time();
 
-		$sessions[ $session_id ] = array(
+		$session = array(
 			'created_at'    => $now,
 			'last_activity' => $now,
 			'client_params' => $params,
 		);
 
-		// Save sessions
-		update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
+		// Each session has its own row, so concurrent requests cannot overwrite siblings.
+		if ( false === add_user_meta( $user_id, self::SESSION_META_KEY, self::prepare_stored_session( $session_id, $session ) ) ) {
+			return false;
+		}
 
 		return $session_id;
 	}
@@ -123,17 +128,12 @@ final class SessionManager {
 				continue;
 			}
 
-			// Session is inactive - remove it
-			unset( $sessions[ $session_id ] );
-			++$removed;
-		}
-
-		if ( $removed > 0 ) {
-			if ( empty( $sessions ) ) {
-				delete_user_meta( $user_id, self::SESSION_META_KEY );
-			} else {
-				update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
+			// Session is inactive - remove its independent meta row.
+			if ( ! self::delete_stored_session( $user_id, $session_id, $session ) ) {
+				continue;
 			}
+
+			++$removed;
 		}
 
 		return $removed;
@@ -151,13 +151,106 @@ final class SessionManager {
 			return array();
 		}
 
-		$sessions = get_user_meta( $user_id, self::SESSION_META_KEY, true );
+		$stored_sessions = get_user_meta( $user_id, self::SESSION_META_KEY, false );
+		self::migrate_legacy_sessions( $user_id, $stored_sessions );
 
-		if ( ! is_array( $sessions ) ) {
-			return array();
+		return self::get_sessions_from_stored_values( get_user_meta( $user_id, self::SESSION_META_KEY, false ) );
+	}
+
+	/**
+	 * Migrate the released collection-based storage to independent session rows.
+	 *
+	 * The exact legacy map value is deleted after its independent records are
+	 * added, so a concurrent new session row is never removed.
+	 *
+	 * @param int $user_id The user ID.
+	 * @param array $stored_sessions Stored meta values.
+	 *
+	 * @return void
+	 */
+	private static function migrate_legacy_sessions( int $user_id, array $stored_sessions ): void {
+		foreach ( $stored_sessions as $legacy_sessions ) {
+			if ( ! self::is_legacy_session_map( $legacy_sessions ) ) {
+				continue;
+			}
+
+			foreach ( $legacy_sessions as $session_id => $session ) {
+				add_user_meta( $user_id, self::SESSION_META_KEY, self::prepare_stored_session( $session_id, $session ) );
+			}
+
+			delete_user_meta( $user_id, self::SESSION_META_KEY, $legacy_sessions );
+		}
+	}
+
+	/**
+	 * Determine whether a stored value is a released collection-based session map.
+	 *
+	 * @param mixed $stored_session Stored meta value.
+	 *
+	 * @return bool
+	 */
+	private static function is_legacy_session_map( $stored_session ): bool {
+		if ( ! is_array( $stored_session ) || isset( $stored_session['session_id'] ) ) {
+			return false;
+		}
+
+		foreach ( $stored_session as $session_id => $session ) {
+			if ( ! is_string( $session_id ) || '' === $session_id || ! is_array( $session ) ) {
+				return false;
+			}
+		}
+
+		return ! empty( $stored_session );
+	}
+
+	/**
+	 * Convert stored session rows to the public session collection shape.
+	 *
+	 * @param array $stored_sessions Stored meta values.
+	 *
+	 * @return array
+	 */
+	private static function get_sessions_from_stored_values( array $stored_sessions ): array {
+		$sessions = array();
+
+		foreach ( $stored_sessions as $stored_session ) {
+			if ( ! is_array( $stored_session ) || ! isset( $stored_session['session_id'] ) || ! is_string( $stored_session['session_id'] ) ) {
+				continue;
+			}
+
+			$session_id = $stored_session['session_id'];
+			unset( $stored_session['session_id'] );
+			$sessions[ $session_id ] = $stored_session;
 		}
 
 		return $sessions;
+	}
+
+	/**
+	 * Add the internal session ID required to target a single meta row.
+	 *
+	 * @param string $session_id Session ID.
+	 * @param array  $session Session data.
+	 *
+	 * @return array
+	 */
+	private static function prepare_stored_session( string $session_id, array $session ): array {
+		$session['session_id'] = $session_id;
+
+		return $session;
+	}
+
+	/**
+	 * Delete a session by matching its complete stored meta value.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $session_id Session ID.
+	 * @param array  $session Session data.
+	 *
+	 * @return bool
+	 */
+	private static function delete_stored_session( int $user_id, string $session_id, array $session ): bool {
+		return delete_user_meta( $user_id, self::SESSION_META_KEY, self::prepare_stored_session( $session_id, $session ) );
 	}
 
 	/**
@@ -259,13 +352,11 @@ final class SessionManager {
 	 */
 	private static function clear_session( int $user_id, string $session_id ): void {
 		$sessions = self::get_all_user_sessions( $user_id );
-
 		if ( ! isset( $sessions[ $session_id ] ) ) {
 			return;
 		}
 
-		unset( $sessions[ $session_id ] );
-		update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
+		self::delete_stored_session( $user_id, $session_id, $sessions[ $session_id ] );
 	}
 
 	/**
@@ -301,8 +392,8 @@ final class SessionManager {
 		// Throttle last_activity writes to reduce write amplification
 		$activity_update_interval = $config['activity_update_interval'];
 		if ( time() - $session['last_activity'] >= $activity_update_interval ) {
-			$sessions[ $session_id ]['last_activity'] = time();
-			update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
+			$session['last_activity'] = time();
+			update_user_meta( $user_id, self::SESSION_META_KEY, self::prepare_stored_session( $session_id, $session ), self::prepare_stored_session( $session_id, $sessions[ $session_id ] ) );
 		}
 
 		return true;
@@ -322,18 +413,11 @@ final class SessionManager {
 		}
 
 		$sessions = self::get_all_user_sessions( $user_id );
-
 		if ( ! isset( $sessions[ $session_id ] ) ) {
 			return false;
 		}
 
-		unset( $sessions[ $session_id ] );
-
-		if ( empty( $sessions ) ) {
-			delete_user_meta( $user_id, self::SESSION_META_KEY );
-		} else {
-			update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
-		}
+		self::delete_stored_session( $user_id, $session_id, $sessions[ $session_id ] );
 
 		return true;
 	}

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -79,7 +79,7 @@ final class SessionManager {
 				}
 			);
 
-			$oldest_session_id = key( $sessions );
+			$oldest_session_id = array_key_first( $sessions );
 			if ( is_string( $oldest_session_id ) ) {
 				self::delete_session( $user_id, $oldest_session_id );
 			}
@@ -152,9 +152,11 @@ final class SessionManager {
 		}
 
 		$stored_sessions = get_user_meta( $user_id, self::SESSION_META_KEY, false );
-		self::migrate_legacy_sessions( $user_id, $stored_sessions );
+		if ( self::migrate_legacy_sessions( $user_id, $stored_sessions ) ) {
+			$stored_sessions = get_user_meta( $user_id, self::SESSION_META_KEY, false );
+		}
 
-		return self::get_sessions_from_stored_values( get_user_meta( $user_id, self::SESSION_META_KEY, false ) );
+		return self::get_sessions_from_stored_values( $stored_sessions );
 	}
 
 	/**
@@ -166,20 +168,41 @@ final class SessionManager {
 	 * @param int $user_id The user ID.
 	 * @param array $stored_sessions Stored meta values.
 	 *
-	 * @return void
+	 * @return bool Whether any legacy sessions were migrated.
 	 */
-	private static function migrate_legacy_sessions( int $user_id, array $stored_sessions ): void {
+	private static function migrate_legacy_sessions( int $user_id, array $stored_sessions ): bool {
+		$stored_session_ids = array();
+		foreach ( $stored_sessions as $stored_session ) {
+			if ( ! is_array( $stored_session ) || ! isset( $stored_session['session_id'] ) || ! is_string( $stored_session['session_id'] ) ) {
+				continue;
+			}
+
+			$stored_session_ids[ $stored_session['session_id'] ] = true;
+		}
+
+		$migrated = false;
 		foreach ( $stored_sessions as $legacy_sessions ) {
 			if ( ! self::is_legacy_session_map( $legacy_sessions ) ) {
 				continue;
 			}
 
 			foreach ( $legacy_sessions as $session_id => $session ) {
-				add_user_meta( $user_id, self::SESSION_META_KEY, self::prepare_stored_session( $session_id, $session ) );
+				if ( isset( $stored_session_ids[ $session_id ] ) ) {
+					continue;
+				}
+
+				if ( false === add_user_meta( $user_id, self::SESSION_META_KEY, self::prepare_stored_session( $session_id, $session ) ) ) {
+					continue 2;
+				}
+
+				$stored_session_ids[ $session_id ] = true;
 			}
 
 			delete_user_meta( $user_id, self::SESSION_META_KEY, $legacy_sessions );
+			$migrated = true;
 		}
+
+		return $migrated;
 	}
 
 	/**
@@ -417,8 +440,6 @@ final class SessionManager {
 			return false;
 		}
 
-		self::delete_stored_session( $user_id, $session_id, $sessions[ $session_id ] );
-
-		return true;
+		return self::delete_stored_session( $user_id, $session_id, $sessions[ $session_id ] );
 	}
 }

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
@@ -22,6 +22,7 @@ use WP\MCP\Tests\TestCase;
 use WP\MCP\Transport\Infrastructure\HttpRequestContext;
 use WP\MCP\Transport\Infrastructure\HttpRequestHandler;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
+use WP\MCP\Transport\Infrastructure\SessionManager;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -496,8 +497,8 @@ final class HttpRequestHandlerTest extends TestCase {
 		$this->assertArrayHasKey( 'result', $data, 'Initialize must succeed' );
 
 		// The session header is set via a rest_post_dispatch filter which doesn't
-		// fire in unit tests. Read the session ID directly from user meta instead.
-		$sessions = get_user_meta( get_current_user_id(), 'mcp_adapter_sessions', true );
+		// fire in unit tests. Read the session ID through the storage abstraction.
+		$sessions = SessionManager::get_all_user_sessions( get_current_user_id() );
 		$this->assertNotEmpty( $sessions, 'Initialize must create a session in user meta' );
 
 		// Return the most recently created session ID.

--- a/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -106,7 +106,7 @@ final class RequestRouterTest extends TestCase {
 		$this->assertNotEmpty( $request_event );
 		$first_request = reset( $request_event );
 		$this->assertNotNull( $first_request['duration_ms'] );
-		$this->assertGreaterThan( 0, $first_request['duration_ms'] );
+		$this->assertGreaterThanOrEqual( 0, $first_request['duration_ms'] );
 	}
 
 	public function test_route_request_initialize_with_session(): void {
@@ -284,7 +284,7 @@ final class RequestRouterTest extends TestCase {
 		$this->assertNotEmpty( $success_event );
 		$first_success = reset( $success_event );
 		$this->assertNotNull( $first_success['duration_ms'] );
-		$this->assertGreaterThan( 0, $first_success['duration_ms'] );
+		$this->assertGreaterThanOrEqual( 0, $first_success['duration_ms'] );
 
 		// Verify tags are included
 		$this->assertArrayHasKey( 'tags', $first_success );

--- a/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
+++ b/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
@@ -57,6 +57,25 @@ final class McpSessionManagerTest extends TestCase {
 	}
 
 	/**
+	 * Set a session's last activity directly, without rewriting its siblings.
+	 *
+	 * @param string $session_id Session ID.
+	 * @param int    $last_activity Unix timestamp.
+	 *
+	 * @return void
+	 */
+	private function set_session_last_activity( string $session_id, int $last_activity ): void {
+		$session                  = SessionManager::get_session( $this->test_user_id, $session_id );
+		$stored_session           = $session;
+		$stored_session['session_id'] = $session_id;
+		$session['last_activity'] = $last_activity;
+		$updated_session           = $session;
+		$updated_session['session_id'] = $session_id;
+
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $updated_session, $stored_session );
+	}
+
+	/**
 	 * Test successful session creation
 	 */
 	public function test_create_session_success(): void {
@@ -216,10 +235,8 @@ final class McpSessionManagerTest extends TestCase {
 		$this->assertIsString( $session_id_1 );
 		$this->assertIsString( $session_id_2 );
 
-		// Manually modify one session to be expired
-		$sessions                                   = SessionManager::get_all_user_sessions( $this->test_user_id );
-		$sessions[ $session_id_1 ]['last_activity'] = time() - ( DAY_IN_SECONDS + 3600 ); // Over 24 hours ago
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		// Manually modify one session to be expired.
+		$this->set_session_last_activity( $session_id_1, time() - ( DAY_IN_SECONDS + 3600 ) );
 
 		// Run cleanup
 		$removed = SessionManager::cleanup_expired_sessions( $this->test_user_id );
@@ -268,11 +285,9 @@ final class McpSessionManagerTest extends TestCase {
 		$session_id = SessionManager::create_session( $this->test_user_id, array() );
 		$this->assertIsString( $session_id );
 
-		// Directly update the timestamp to simulate time passing beyond throttle window
-		$sessions                                 = \WP\MCP\Transport\Infrastructure\SessionManager::get_all_user_sessions( $this->test_user_id );
-		$old_timestamp                            = time() - 61;
-		$sessions[ $session_id ]['last_activity'] = $old_timestamp;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		// Directly update the timestamp to simulate time passing beyond throttle window.
+		$old_timestamp = time() - 61;
+		$this->set_session_last_activity( $session_id, $old_timestamp );
 
 		// Validate session (should update last_activity)
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $session_id );
@@ -314,10 +329,8 @@ final class McpSessionManagerTest extends TestCase {
 		); // 1 second
 
 		$short_session = SessionManager::create_session( $this->test_user_id, array() );
-		// Manually expire the session by backdating its last_activity
-		$sessions                                    = SessionManager::get_all_user_sessions( $this->test_user_id );
-		$sessions[ $short_session ]['last_activity'] = time() - 3;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		// Manually expire the session by backdating its last_activity.
+		$this->set_session_last_activity( $short_session, time() - 3 );
 
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $short_session );
 		$this->assertFalse( $is_valid ); // Should be expired
@@ -355,10 +368,8 @@ final class McpSessionManagerTest extends TestCase {
 		$this->assertIsString( $valid_session_id );
 		$this->assertIsString( $expired_session_id );
 
-		// Backdate one session to make it expired
-		$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
-		$sessions[ $expired_session_id ]['last_activity'] = time() - ( DAY_IN_SECONDS + 3600 );
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		// Backdate one session to make it expired.
+		$this->set_session_last_activity( $expired_session_id, time() - ( DAY_IN_SECONDS + 3600 ) );
 
 		// Validate the valid session
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $valid_session_id );
@@ -384,10 +395,9 @@ final class McpSessionManagerTest extends TestCase {
 		$session_id = SessionManager::create_session( $this->test_user_id, array() );
 		$this->assertIsString( $session_id );
 
-		// Backdate last_activity by 16s (more than half of 30s timeout = clamped interval of 15s)
-		$sessions                                 = SessionManager::get_all_user_sessions( $this->test_user_id );
-		$sessions[ $session_id ]['last_activity'] = time() - 16;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		// Backdate last_activity by 16s (more than half of 30s timeout = clamped interval of 15s).
+		$old_activity = time() - 16;
+		$this->set_session_last_activity( $session_id, $old_activity );
 
 		// Validate — should succeed AND update last_activity because 16s > clamped interval (15s)
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $session_id );
@@ -395,10 +405,82 @@ final class McpSessionManagerTest extends TestCase {
 
 		$sessions_after = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$this->assertGreaterThan(
-			$sessions[ $session_id ]['last_activity'],
+			$old_activity,
 			$sessions_after[ $session_id ]['last_activity']
 		);
 
 		remove_all_filters( 'mcp_adapter_session_inactivity_timeout' );
+	}
+
+	/**
+	 * Test legacy collection sessions migrate without invalidating active clients.
+	 */
+	public function test_legacy_sessions_migrate_and_remain_valid(): void {
+		$session_id = 'd1b2c3d4-e5f6-4789-abcd-0123456789ab';
+		$session    = array(
+			'created_at'    => time() - 10,
+			'last_activity' => time() - 10,
+			'client_params' => array( 'name' => 'released-client' ),
+		);
+
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', array( $session_id => $session ) );
+
+		$this->assertTrue( SessionManager::validate_session( $this->test_user_id, $session_id ) );
+		$this->assertSame( $session, SessionManager::get_session( $this->test_user_id, $session_id ) );
+		$stored_sessions = get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', false );
+		$this->assertCount( 1, $stored_sessions );
+		$this->assertSame( $session_id, $stored_sessions[0]['session_id'] );
+	}
+
+	/**
+	 * Test legacy migration removes only the legacy map, not sibling rows.
+	 */
+	public function test_legacy_migration_preserves_independent_session_rows(): void {
+		$legacy_session_id = 'd1b2c3d4-e5f6-4789-abcd-0123456789ab';
+		$new_session_id    = 'e1b2c3d4-e5f6-4789-abcd-0123456789ab';
+		$legacy_session    = array(
+			'created_at'    => time() - 10,
+			'last_activity' => time() - 10,
+			'client_params' => array( 'name' => 'released-client' ),
+		);
+		$new_session       = array(
+			'session_id'    => $new_session_id,
+			'created_at'    => time() - 10,
+			'last_activity' => time() - 10,
+			'client_params' => array( 'name' => 'new-client' ),
+		);
+
+		add_user_meta( $this->test_user_id, 'mcp_adapter_sessions', array( $legacy_session_id => $legacy_session ) );
+		add_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $new_session );
+
+		$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
+		$this->assertArrayHasKey( $legacy_session_id, $sessions );
+		$this->assertArrayHasKey( $new_session_id, $sessions );
+		$this->assertSame( $new_session['client_params'], $sessions[ $new_session_id ]['client_params'] );
+	}
+
+	/**
+	 * Test mutations of one session preserve every sibling session.
+	 */
+	public function test_session_mutations_preserve_siblings(): void {
+		$expired_session_id = SessionManager::create_session( $this->test_user_id, array( 'name' => 'expired' ) );
+		$updated_session_id = SessionManager::create_session( $this->test_user_id, array( 'name' => 'updated' ) );
+		$sibling_session_id = SessionManager::create_session( $this->test_user_id, array( 'name' => 'sibling' ) );
+		$this->assertIsString( $expired_session_id );
+		$this->assertIsString( $updated_session_id );
+		$this->assertIsString( $sibling_session_id );
+		$this->assertCount( 3, get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', false ) );
+
+		$sibling = SessionManager::get_session( $this->test_user_id, $sibling_session_id );
+		$this->set_session_last_activity( $expired_session_id, time() - DAY_IN_SECONDS - 1 );
+		$this->set_session_last_activity( $updated_session_id, time() - 61 );
+
+		$this->assertSame( 1, SessionManager::cleanup_expired_sessions( $this->test_user_id ) );
+		$this->assertTrue( SessionManager::validate_session( $this->test_user_id, $updated_session_id ) );
+		$this->assertTrue( SessionManager::delete_session( $this->test_user_id, $updated_session_id ) );
+
+		$this->assertFalse( SessionManager::get_session( $this->test_user_id, $expired_session_id ) );
+		$this->assertFalse( SessionManager::get_session( $this->test_user_id, $updated_session_id ) );
+		$this->assertSame( $sibling, SessionManager::get_session( $this->test_user_id, $sibling_session_id ) );
 	}
 }

--- a/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
+++ b/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
@@ -460,6 +460,50 @@ final class McpSessionManagerTest extends TestCase {
 	}
 
 	/**
+	 * Test legacy migration reuses rows created before a previous migration completed.
+	 */
+	public function test_legacy_migration_does_not_duplicate_existing_session_rows(): void {
+		$session_id = 'd1b2c3d4-e5f6-4789-abcd-0123456789ab';
+		$session    = array(
+			'created_at'    => time() - 10,
+			'last_activity' => time() - 10,
+			'client_params' => array( 'name' => 'released-client' ),
+		);
+
+		add_user_meta( $this->test_user_id, 'mcp_adapter_sessions', array( $session_id => $session ) );
+		add_user_meta( $this->test_user_id, 'mcp_adapter_sessions', array_merge( array( 'session_id' => $session_id ), $session ) );
+
+		$this->assertSame( array( $session_id => $session ), SessionManager::get_all_user_sessions( $this->test_user_id ) );
+		$this->assertCount( 1, get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', false ) );
+	}
+
+	/**
+	 * Test deletion reports a targeted mutation failure.
+	 */
+	public function test_delete_session_returns_false_when_targeted_delete_fails(): void {
+		$session_id = SessionManager::create_session( $this->test_user_id, array() );
+		$this->assertIsString( $session_id );
+
+		add_filter(
+			'delete_user_metadata',
+			static function ( $check, $user_id, $meta_key ) {
+				if ( 'mcp_adapter_sessions' === $meta_key ) {
+					return false;
+				}
+
+				return $check;
+			},
+			10,
+			3
+		);
+
+		$this->assertFalse( SessionManager::delete_session( $this->test_user_id, $session_id ) );
+		$this->assertArrayHasKey( $session_id, SessionManager::get_all_user_sessions( $this->test_user_id ) );
+
+		remove_all_filters( 'delete_user_metadata' );
+	}
+
+	/**
 	 * Test mutations of one session preserve every sibling session.
 	 */
 	public function test_session_mutations_preserve_siblings(): void {


### PR DESCRIPTION
Closes #239.

## Summary

- Store each MCP session in an independent `mcp_adapter_sessions` user-meta row instead of rewriting one serialized map containing every session.
- Target activity updates, cleanup, eviction, and deletion to one session row using its complete previous value.
- Lazily migrate the released serialized-map format to independent rows while preserving active session IDs.
- Add regression coverage for independent persistence, legacy migration, and sibling preservation across cleanup, update, and deletion.

## Why

Concurrent `initialize` requests currently perform an unlocked read-modify-write of the same user-meta value. Both requests can return valid session IDs, after which the later write removes the earlier session. The affected client then fails its first session-bearing request, commonly `tools/list`.

Independent metadata rows make session creation an append operation. Mutating one session no longer replaces a collection snapshot containing its siblings.

## Backward compatibility

- Public `SessionManager` methods and returned session shapes are unchanged.
- Existing `mcp_adapter_sessions` map values are persisted user state, so they are detected and migrated on first read rather than invalidated.
- Session limits, FIFO eviction, inactivity cleanup, and activity-write throttling retain their existing behavior.
- The user-meta representation is internal but changes from one collection row to multiple per-session rows. Integrations reading this private storage directly must use the public `SessionManager` API instead.

## How to test

1. Check out this branch on a fresh clone.
2. Run `npm ci && composer install --no-interaction`.
3. Start the test environment with `npm run wp-env:test -- start`.
4. Run `npm run test:php`.
5. Run `composer lint`.
6. Run `composer phpstan`.
7. Confirm `McpSessionManagerTest` covers four independent sessions, legacy migration, and targeted cleanup/update/delete without losing siblings.

## Verification

- `composer lint`: passed.
- `composer phpstan`: passed with no errors.
- `git diff --check`: passed.
- Transactional WordPress runtime proof: four sessions persisted, legacy migration succeeded, targeted cleanup/deletion preserved all siblings, and fixture state rolled back.
- Supplementary WPCOM sandbox proof using the same regression fixture:
  - Released collection storage: expected failure, 2 tests / 2 failures.
  - This change: passed, 2 tests / 22 assertions.

The WPCOM sandbox result is supplementary foreign-environment evidence. The primary test procedure above uses this repository's own tooling and is runnable from a fresh checkout.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6-sol
- **Used for:** Reproduction analysis, implementation and regression-test drafting, review, and verification. Chris reviewed and owns the submitted change.
