### PR TITLE
Prevent concurrent MCP session overwrites

### DIFF
--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -198,7 +198,7 @@ class HttpRequestHandler {
 
 		// Validate session for all requests except initialize (router will handle initialize session creation)
 		if ( 'initialize' !== $method ) {
-			$session_validation = HttpSessionValidator::validate_session( $context );
+			$session_validation = HttpSessionValidator::validate_session_with_error_handler( $context, $this->transport_context->error_handler );
 			if ( true !== $session_validation ) {
 				return JsonRpcResponseBuilder::create_error_response( $request_id, $session_validation['error'] ?? $session_validation );
 			}
@@ -325,7 +325,7 @@ class HttpRequestHandler {
 	 * @return \WP_REST_Response Termination response.
 	 */
 	private function handle_session_termination( HttpRequestContext $context ): \WP_REST_Response {
-		$result = HttpSessionValidator::terminate_session( $context );
+		$result = HttpSessionValidator::terminate_session_with_error_handler( $context, $this->transport_context->error_handler );
 
 		if ( true !== $result ) {
 			$http_status = McpErrorFactory::get_http_status_for_error( $result );

--- a/includes/Transport/Infrastructure/HttpSessionValidator.php
+++ b/includes/Transport/Infrastructure/HttpSessionValidator.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Transport\Infrastructure;
 
+use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 
 /**
@@ -30,6 +31,21 @@ class HttpSessionValidator {
 	 * @return array|true Returns true if valid, error array if invalid.
 	 */
 	public static function validate_session( HttpRequestContext $context ) {
+		return self::validate_session_with_error_handler( $context, null );
+	}
+
+	/**
+	 * Validate a session and report storage failures to an error handler.
+	 *
+	 * @since n.e.x.t
+	 * @internal
+	 *
+	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext                  $context       The HTTP request context.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Error handler for reporting storage failures.
+	 *
+	 * @return array|true Returns true if valid, error array if invalid.
+	 */
+	public static function validate_session_with_error_handler( HttpRequestContext $context, ?McpErrorHandlerInterface $error_handler ) {
 		// Check session header presence
 		$session_id = $context->session_id;
 		if ( ! $session_id ) {
@@ -43,7 +59,7 @@ class HttpSessionValidator {
 		}
 
 		// Validate session using SessionManager
-		if ( ! SessionManager::validate_session( $user_id, $session_id ) ) {
+		if ( ! SessionManager::validate_session( $user_id, $session_id, $error_handler ) ) {
 			return McpErrorFactory::session_not_found( null, 'Invalid or expired session' )->toArray();
 		}
 
@@ -78,12 +94,27 @@ class HttpSessionValidator {
 	 * @return string|array Session ID on success, error array on failure.
 	 */
 	public static function create_session( array $params = array() ) {
+		return self::create_session_with_error_handler( $params, null );
+	}
+
+	/**
+	 * Create a session and report storage failures to an error handler.
+	 *
+	 * @since n.e.x.t
+	 * @internal
+	 *
+	 * @param array                                                 $params        The client parameters from initialize request.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Error handler for reporting storage failures.
+	 *
+	 * @return string|array Session ID on success, error array on failure.
+	 */
+	public static function create_session_with_error_handler( array $params, ?McpErrorHandlerInterface $error_handler ) {
 		$user_id = get_current_user_id();
 		if ( ! $user_id ) {
 			return McpErrorFactory::unauthorized( null, 'User authentication required for session creation' )->toArray();
 		}
 
-		$session_id = SessionManager::create_session( $user_id, $params );
+		$session_id = SessionManager::create_session( $user_id, $params, $error_handler );
 
 		if ( ! $session_id ) {
 			return McpErrorFactory::internal_error( null, 'Failed to create session' )->toArray();
@@ -103,6 +134,21 @@ class HttpSessionValidator {
 	 * @return array|true Returns true on success, error array on failure.
 	 */
 	public static function terminate_session( HttpRequestContext $context ) {
+		return self::terminate_session_with_error_handler( $context, null );
+	}
+
+	/**
+	 * Terminate a session and report storage failures to an error handler.
+	 *
+	 * @since n.e.x.t
+	 * @internal
+	 *
+	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext                  $context       The HTTP request context.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Error handler for reporting storage failures.
+	 *
+	 * @return array|true Returns true on success, error array on failure.
+	 */
+	public static function terminate_session_with_error_handler( HttpRequestContext $context, ?McpErrorHandlerInterface $error_handler ) {
 		// Validate session header
 		$session_id = $context->session_id;
 		if ( ! $session_id ) {
@@ -116,7 +162,7 @@ class HttpSessionValidator {
 		}
 
 		// Terminate the session
-		SessionManager::delete_session( $user_id, $session_id );
+		SessionManager::delete_session( $user_id, $session_id, $error_handler );
 
 		return true;
 	}

--- a/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/Transport/Infrastructure/RequestRouter.php
@@ -325,7 +325,7 @@ class RequestRouter {
 		// Handle session creation if HTTP context is provided.
 		// InitializeResult DTO never has errors - errors would be thrown as exceptions.
 		if ( $http_context && ! $http_context->session_id ) {
-			$session_result = HttpSessionValidator::create_session( $params );
+			$session_result = HttpSessionValidator::create_session_with_error_handler( $params, $this->context->error_handler );
 
 			if ( is_array( $session_result ) ) {
 				$error = $session_result['error'] ?? array();

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -17,6 +17,10 @@ use WP_Error;
  *
  * Handles session creation, validation, and cleanup using user meta storage.
  * Sessions are tied to authenticated users to prevent anonymous session flooding.
+ * MCP protocol revisions that do not negotiate session IDs should bypass this
+ * compatibility storage entirely.
+ * Established session maps use compare-and-swap semantics. An older
+ * unconditional writer can still overwrite a concurrent newer writer.
  */
 final class SessionManager {
 
@@ -49,6 +53,15 @@ final class SessionManager {
 	private const DEFAULT_ACTIVITY_UPDATE_INTERVAL = 60;
 
 	/**
+	 * Maximum attempts for a concurrent session mutation.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var int
+	 */
+	private const MAX_UPDATE_ATTEMPTS = 5;
+
+	/**
 	 * Create a new session for a user
 	 *
 	 * @param int $user_id The user ID.
@@ -61,41 +74,79 @@ final class SessionManager {
 			return false;
 		}
 
-		// Cleanup inactive sessions first
-		self::cleanup_expired_sessions( $user_id );
-
-		// Get current sessions
-		$sessions = self::get_all_user_sessions( $user_id );
-
-		// Check session limit - remove oldest if over limit
-		$config       = self::get_config();
-		$max_sessions = $config['max_sessions'];
-		if ( count( $sessions ) >= $max_sessions ) {
-			// Remove oldest session (FIFO) - sort by created_at and remove first
-			uasort(
-				$sessions,
-				static function ( $a, $b ) {
-					return $a['created_at'] <=> $b['created_at'];
-				}
-			);
-
-			array_shift( $sessions );
-		}
-
-		// Create a new session
 		$session_id = wp_generate_uuid4();
 		$now        = time();
+		$config     = self::get_config();
 
-		$sessions[ $session_id ] = array(
-			'created_at'    => $now,
-			'last_activity' => $now,
-			'client_params' => $params,
+		$created = self::mutate_sessions(
+			$user_id,
+			static function ( array $sessions ) use ( $config, $now, $params, $session_id ): array {
+				foreach ( $sessions as $stored_session_id => $session ) {
+					if ( $session['last_activity'] + $config['inactivity_timeout'] >= $now ) {
+						continue;
+					}
+
+					unset( $sessions[ $stored_session_id ] );
+				}
+
+				if ( count( $sessions ) >= $config['max_sessions'] ) {
+					uasort(
+						$sessions,
+						static function ( $a, $b ) {
+							return $a['created_at'] <=> $b['created_at'];
+						}
+					);
+
+					array_shift( $sessions );
+				}
+
+				$sessions[ $session_id ] = array(
+					'created_at'    => $now,
+					'last_activity' => $now,
+					'client_params' => $params,
+				);
+
+				return $sessions;
+			}
 		);
 
-		// Save sessions
-		update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
+		if ( ! $created ) {
+			return false;
+		}
 
 		return $session_id;
+	}
+
+	/**
+	 * Apply a session mutation without overwriting an established session map.
+	 *
+	 * WordPress ignores an empty $prev_value. Concurrent first connections may
+	 * therefore still overwrite each other, but subsequent writes retry when the
+	 * previously read non-empty map has changed.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param int      $user_id  The user ID.
+	 * @param callable $mutation Receives the latest sessions and returns the updated sessions.
+	 * @return bool True when the mutation was stored, false after repeated conflicts.
+	 */
+	private static function mutate_sessions( int $user_id, callable $mutation ): bool {
+		for ( $attempt = 0; $attempt < self::MAX_UPDATE_ATTEMPTS; ++$attempt ) {
+			wp_cache_delete( $user_id, 'user_meta' );
+			$previous_sessions = self::get_all_user_sessions( $user_id );
+			$updated_sessions  = $mutation( $previous_sessions );
+
+			if ( $updated_sessions === $previous_sessions ) {
+				return true;
+			}
+
+			$updated = update_user_meta( $user_id, self::SESSION_META_KEY, $updated_sessions, $previous_sessions );
+			if ( false !== $updated ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -110,33 +161,30 @@ final class SessionManager {
 			return 0;
 		}
 
-		$sessions = self::get_all_user_sessions( $user_id );
-		$now      = time();
-		$removed  = 0;
-
+		$now                = time();
+		$removed            = 0;
 		$config             = self::get_config();
 		$inactivity_timeout = $config['inactivity_timeout'];
 
-		foreach ( $sessions as $session_id => $session ) {
-			// Check if still active - skip if valid
-			if ( $session['last_activity'] + $inactivity_timeout >= $now ) {
-				continue;
+		$stored = self::mutate_sessions(
+			$user_id,
+			static function ( array $sessions ) use ( $inactivity_timeout, $now, &$removed ): array {
+				$removed = 0;
+
+				foreach ( $sessions as $session_id => $session ) {
+					if ( $session['last_activity'] + $inactivity_timeout >= $now ) {
+						continue;
+					}
+
+					unset( $sessions[ $session_id ] );
+					++$removed;
+				}
+
+				return $sessions;
 			}
+		);
 
-			// Session is inactive - remove it
-			unset( $sessions[ $session_id ] );
-			++$removed;
-		}
-
-		if ( $removed > 0 ) {
-			if ( empty( $sessions ) ) {
-				delete_user_meta( $user_id, self::SESSION_META_KEY );
-			} else {
-				update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
-			}
-		}
-
-		return $removed;
+		return $stored ? $removed : 0;
 	}
 
 	/**
@@ -258,14 +306,14 @@ final class SessionManager {
 	 * @return void
 	 */
 	private static function clear_session( int $user_id, string $session_id ): void {
-		$sessions = self::get_all_user_sessions( $user_id );
+		self::mutate_sessions(
+			$user_id,
+			static function ( array $sessions ) use ( $session_id ): array {
+				unset( $sessions[ $session_id ] );
 
-		if ( ! isset( $sessions[ $session_id ] ) ) {
-			return;
-		}
-
-		unset( $sessions[ $session_id ] );
-		update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
+				return $sessions;
+			}
+		);
 	}
 
 	/**
@@ -281,31 +329,35 @@ final class SessionManager {
 			return false;
 		}
 
-		$sessions = self::get_all_user_sessions( $user_id );
+		$config   = self::get_config();
+		$now      = time();
+		$is_valid = false;
 
-		if ( ! isset( $sessions[ $session_id ] ) ) {
-			return false;
-		}
+		$stored = self::mutate_sessions(
+			$user_id,
+			static function ( array $sessions ) use ( $config, $now, $session_id, &$is_valid ): array {
+				if ( ! isset( $sessions[ $session_id ] ) ) {
+					$is_valid = false;
+					return $sessions;
+				}
 
-		$session = $sessions[ $session_id ];
+				if ( $sessions[ $session_id ]['last_activity'] + $config['inactivity_timeout'] < $now ) {
+					$is_valid = false;
+					unset( $sessions[ $session_id ] );
 
-		// Check inactivity timeout
-		$config             = self::get_config();
-		$inactivity_timeout = $config['inactivity_timeout'];
-		if ( $session['last_activity'] + $inactivity_timeout < time() ) {
-			self::clear_session( $user_id, $session_id );
+					return $sessions;
+				}
 
-			return false;
-		}
+				$is_valid = true;
+				if ( $now - $sessions[ $session_id ]['last_activity'] >= $config['activity_update_interval'] ) {
+					$sessions[ $session_id ]['last_activity'] = $now;
+				}
 
-		// Throttle last_activity writes to reduce write amplification
-		$activity_update_interval = $config['activity_update_interval'];
-		if ( time() - $session['last_activity'] >= $activity_update_interval ) {
-			$sessions[ $session_id ]['last_activity'] = time();
-			update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
-		}
+				return $sessions;
+			}
+		);
 
-		return true;
+		return $stored && $is_valid;
 	}
 
 	/**
@@ -321,20 +373,22 @@ final class SessionManager {
 			return false;
 		}
 
-		$sessions = self::get_all_user_sessions( $user_id );
+		$session_found = false;
+		$stored        = self::mutate_sessions(
+			$user_id,
+			static function ( array $sessions ) use ( $session_id, &$session_found ): array {
+				if ( ! isset( $sessions[ $session_id ] ) ) {
+					$session_found = false;
+					return $sessions;
+				}
 
-		if ( ! isset( $sessions[ $session_id ] ) ) {
-			return false;
-		}
+				$session_found = true;
+				unset( $sessions[ $session_id ] );
 
-		unset( $sessions[ $session_id ] );
+				return $sessions;
+			}
+		);
 
-		if ( empty( $sessions ) ) {
-			delete_user_meta( $user_id, self::SESSION_META_KEY );
-		} else {
-			update_user_meta( $user_id, self::SESSION_META_KEY, $sessions );
-		}
-
-		return true;
+		return $stored && $session_found;
 	}
 }

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -10,6 +10,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Transport\Infrastructure;
 
+use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
+use WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler;
 use WP_Error;
 
 /**
@@ -64,12 +66,15 @@ final class SessionManager {
 	/**
 	 * Create a new session for a user
 	 *
-	 * @param int $user_id The user ID.
-	 * @param array $params Client parameters from initialize request.
+	 * @since n.e.x.t Added the optional error handler.
+	 *
+	 * @param int                                                   $user_id      The user ID.
+	 * @param array                                                 $params       Client parameters from initialize request.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Error handler for reporting storage failures. Defaults to the standard error-log handler.
 	 *
 	 * @return string|false The session ID on success, false on failure.
 	 */
-	public static function create_session( int $user_id, array $params = array() ) {
+	public static function create_session( int $user_id, array $params = array(), ?McpErrorHandlerInterface $error_handler = null ) {
 		if ( ! $user_id || ! get_user_by( 'id', $user_id ) ) {
 			return false;
 		}
@@ -107,7 +112,8 @@ final class SessionManager {
 				);
 
 				return $sessions;
-			}
+			},
+			$error_handler
 		);
 
 		if ( ! $created ) {
@@ -126,11 +132,12 @@ final class SessionManager {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param int      $user_id  The user ID.
-	 * @param callable $mutation Receives the latest sessions and returns the updated sessions.
+	 * @param int                                                   $user_id       The user ID.
+	 * @param callable                                              $mutation      Receives the latest sessions and returns the updated sessions.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Error handler for reporting storage failures. Defaults to the standard error-log handler.
 	 * @return bool True when the mutation was stored, false after repeated conflicts.
 	 */
-	private static function mutate_sessions( int $user_id, callable $mutation ): bool {
+	private static function mutate_sessions( int $user_id, callable $mutation, ?McpErrorHandlerInterface $error_handler = null ): bool {
 		for ( $attempt = 0; $attempt < self::MAX_UPDATE_ATTEMPTS; ++$attempt ) {
 			wp_cache_delete( $user_id, 'user_meta' );
 			$previous_sessions = self::get_all_user_sessions( $user_id );
@@ -145,6 +152,17 @@ final class SessionManager {
 				return true;
 			}
 		}
+
+		$error_handler = $error_handler ?? new ErrorLogMcpErrorHandler();
+		$error_handler->log(
+			'Failed to persist MCP sessions after exhausting update retries.',
+			array(
+				'component' => self::class,
+				'method'    => 'mutate_sessions',
+				'user_id'   => $user_id,
+				'attempts'  => self::MAX_UPDATE_ATTEMPTS,
+			)
+		);
 
 		return false;
 	}
@@ -319,12 +337,15 @@ final class SessionManager {
 	/**
 	 * Validate a session and update last activity
 	 *
-	 * @param int $user_id The user ID.
-	 * @param string $session_id The session ID.
+	 * @since n.e.x.t Added the optional error handler.
+	 *
+	 * @param int                                                   $user_id      The user ID.
+	 * @param string                                                $session_id   The session ID.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Error handler for reporting storage failures. Defaults to the standard error-log handler.
 	 *
 	 * @return bool True if valid, false otherwise.
 	 */
-	public static function validate_session( int $user_id, string $session_id ): bool {
+	public static function validate_session( int $user_id, string $session_id, ?McpErrorHandlerInterface $error_handler = null ): bool {
 		if ( ! $user_id || ! $session_id ) {
 			return false;
 		}
@@ -354,7 +375,8 @@ final class SessionManager {
 				}
 
 				return $sessions;
-			}
+			},
+			$error_handler
 		);
 
 		return $stored && $is_valid;
@@ -363,12 +385,15 @@ final class SessionManager {
 	/**
 	 * Delete a specific session
 	 *
-	 * @param int $user_id The user ID.
-	 * @param string $session_id The session ID.
+	 * @since n.e.x.t Added the optional error handler.
+	 *
+	 * @param int                                                   $user_id      The user ID.
+	 * @param string                                                $session_id   The session ID.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Error handler for reporting storage failures. Defaults to the standard error-log handler.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
-	public static function delete_session( int $user_id, string $session_id ): bool {
+	public static function delete_session( int $user_id, string $session_id, ?McpErrorHandlerInterface $error_handler = null ): bool {
 		if ( ! $user_id || ! $session_id ) {
 			return false;
 		}
@@ -386,7 +411,8 @@ final class SessionManager {
 				unset( $sessions[ $session_id ] );
 
 				return $sessions;
-			}
+			},
+			$error_handler
 		);
 
 		return $stored && $session_found;

--- a/tests/phpunit/Fixtures/ConcurrentSessionWorker.php
+++ b/tests/phpunit/Fixtures/ConcurrentSessionWorker.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Worker used by the session concurrency integration test.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+use WP\MCP\Transport\Infrastructure\SessionManager;
+
+require dirname( __DIR__ ) . '/bootstrap.php';
+
+$wp_mcp_test_user_id     = isset( $argv[1] ) ? (int) $argv[1] : 0;
+$wp_mcp_test_barrier_dir = isset( $argv[2] ) ? $argv[2] : '';
+$wp_mcp_test_worker_id   = isset( $argv[3] ) ? $argv[3] : '';
+$wp_mcp_test_result_file = $wp_mcp_test_barrier_dir . '/result-' . $wp_mcp_test_worker_id . '.json';
+
+try {
+	add_filter(
+		'update_user_metadata',
+		static function ( $check, $object_id, $meta_key ) use ( $wp_mcp_test_barrier_dir, $wp_mcp_test_user_id, $wp_mcp_test_worker_id ) {
+			if ( $wp_mcp_test_user_id !== $object_id || 'mcp_adapter_sessions' !== $meta_key ) {
+				return $check;
+			}
+
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Test-owned synchronization file under the system temporary directory.
+			file_put_contents( $wp_mcp_test_barrier_dir . '/ready-' . $wp_mcp_test_worker_id, '' );
+			$deadline = microtime( true ) + 10;
+
+			while ( ! file_exists( $wp_mcp_test_barrier_dir . '/go' ) ) {
+				if ( microtime( true ) >= $deadline ) {
+					throw new \RuntimeException( 'Timed out waiting for the concurrency barrier.' );
+				}
+
+				usleep( 1000 );
+			}
+
+			return $check;
+		},
+		10,
+		3
+	);
+
+	$wp_mcp_test_session_id = SessionManager::create_session( $wp_mcp_test_user_id, array( 'worker' => $wp_mcp_test_worker_id ) );
+	// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Test-owned result file under the system temporary directory.
+	file_put_contents(
+		$wp_mcp_test_result_file,
+		wp_json_encode(
+			array(
+				'session_id' => $wp_mcp_test_session_id,
+				'error'      => null,
+			)
+		)
+	);
+} catch ( \Throwable $wp_mcp_test_throwable ) {
+	// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Test-owned result file under the system temporary directory.
+	file_put_contents(
+		$wp_mcp_test_result_file,
+		wp_json_encode(
+			array(
+				'session_id' => false,
+				'error'      => $wp_mcp_test_throwable->getMessage(),
+			)
+		)
+	);
+	exit( 1 );
+}

--- a/tests/phpunit/Integration/Transport/McpSessionManagerConcurrencyTest.php
+++ b/tests/phpunit/Integration/Transport/McpSessionManagerConcurrencyTest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Integration tests for concurrent MCP session mutations.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Integration\Transport;
+
+use WP\MCP\Tests\TestCase;
+use WP\MCP\Transport\Infrastructure\SessionManager;
+
+/**
+ * Test session writes from independent PHP processes.
+ */
+final class McpSessionManagerConcurrencyTest extends TestCase {
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private int $test_user_id;
+
+	/**
+	 * Create the test user.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->test_user_id = self::factory()->user->create();
+	}
+
+	/**
+	 * Delete the test user.
+	 */
+	public function tear_down(): void {
+		wp_delete_user( $this->test_user_id );
+		self::commit_transaction();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test concurrent creation preserves every session in an established map.
+	 */
+	public function test_concurrent_session_creation_preserves_every_session(): void {
+		if ( ! function_exists( 'proc_open' ) ) {
+			$this->markTestSkipped( 'proc_open() is required for the concurrency integration test.' );
+		}
+
+		$existing_session_id = SessionManager::create_session( $this->test_user_id, array( 'worker' => 'existing' ) );
+		$this->assertIsString( $existing_session_id );
+		self::commit_transaction();
+
+		$worker_count = 4;
+		$barrier_dir  = sys_get_temp_dir() . '/mcp-session-concurrency-' . wp_generate_uuid4();
+		$this->assertTrue( wp_mkdir_p( $barrier_dir ) );
+
+		$worker_script = dirname( __DIR__, 2 ) . '/Fixtures/ConcurrentSessionWorker.php';
+		$processes     = array();
+		$environment   = getenv();
+		if ( ! is_array( $environment ) ) {
+			$environment = array();
+		}
+		$environment['WP_TESTS_SKIP_INSTALL'] = '1';
+
+		try {
+			for ( $worker_id = 0; $worker_id < $worker_count; ++$worker_id ) {
+				$command = sprintf(
+					'%s %s %d %s %d',
+					escapeshellarg( PHP_BINARY ),
+					escapeshellarg( $worker_script ),
+					$this->test_user_id,
+					escapeshellarg( $barrier_dir ),
+					$worker_id
+				);
+
+				$pipes = array();
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open -- Independent PHP processes are the behavior under test.
+				$process = proc_open(
+					$command,
+					array(
+						0 => array( 'pipe', 'r' ),
+						1 => array( 'pipe', 'w' ),
+						2 => array( 'pipe', 'w' ),
+					),
+					$pipes,
+					null,
+					$environment
+				);
+
+				$this->assertIsResource( $process );
+				fclose( $pipes[0] );
+				$processes[] = array(
+					'process' => $process,
+					'stdout'  => $pipes[1],
+					'stderr'  => $pipes[2],
+				);
+			}
+
+			$deadline           = microtime( true ) + 10;
+			$ready_workers      = glob( $barrier_dir . '/ready-*' ) ?: array();
+			$ready_worker_count = count( $ready_workers );
+			while ( $ready_worker_count < $worker_count && microtime( true ) < $deadline ) {
+				usleep( 1000 );
+				$ready_workers      = glob( $barrier_dir . '/ready-*' ) ?: array();
+				$ready_worker_count = count( $ready_workers );
+			}
+
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Test-owned synchronization file under the system temporary directory.
+			file_put_contents( $barrier_dir . '/go', '' );
+			$this->assertCount( $worker_count, $ready_workers, 'Not every worker reached the write barrier.' );
+
+			foreach ( $processes as &$worker_process ) {
+				$stdout = stream_get_contents( $worker_process['stdout'] );
+				$stderr = stream_get_contents( $worker_process['stderr'] );
+				fclose( $worker_process['stdout'] );
+				fclose( $worker_process['stderr'] );
+				$exit_code                 = proc_close( $worker_process['process'] );
+				$worker_process['process'] = null;
+				$worker_process['stdout']  = null;
+				$worker_process['stderr']  = null;
+
+				$this->assertSame( 0, $exit_code, $stdout . $stderr );
+			}
+			unset( $worker_process );
+
+			$session_ids = array();
+			for ( $worker_id = 0; $worker_id < $worker_count; ++$worker_id ) {
+				$result_file = $barrier_dir . '/result-' . $worker_id . '.json';
+				// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- Reads a local test result file.
+				$result = json_decode( (string) file_get_contents( $result_file ), true );
+
+				$this->assertNull( $result['error'] );
+				$this->assertIsString( $result['session_id'] );
+				$session_ids[] = $result['session_id'];
+			}
+
+			wp_cache_delete( $this->test_user_id, 'user_meta' );
+			$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
+
+			$this->assertCount( $worker_count + 1, $sessions );
+			$this->assertArrayHasKey( $existing_session_id, $sessions );
+			foreach ( $session_ids as $session_id ) {
+				$this->assertArrayHasKey( $session_id, $sessions );
+			}
+			$this->assertCount( 1, get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', false ) );
+		} finally {
+			if ( ! file_exists( $barrier_dir . '/go' ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Releases test-owned worker processes during cleanup.
+				file_put_contents( $barrier_dir . '/go', '' );
+			}
+
+			foreach ( $processes as $worker_process ) {
+				if ( is_resource( $worker_process['process'] ) ) {
+					$status = proc_get_status( $worker_process['process'] );
+					if ( $status['running'] ) {
+						proc_terminate( $worker_process['process'] );
+					}
+				}
+				if ( is_resource( $worker_process['stdout'] ) ) {
+					fclose( $worker_process['stdout'] );
+				}
+				if ( is_resource( $worker_process['stderr'] ) ) {
+					fclose( $worker_process['stderr'] );
+				}
+				if ( ! is_resource( $worker_process['process'] ) ) {
+					continue;
+				}
+
+				proc_close( $worker_process['process'] );
+			}
+
+			foreach ( glob( $barrier_dir . '/*' ) ?: array() as $temporary_file ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink -- Removes a test-owned temporary file.
+				unlink( $temporary_file );
+			}
+			if ( is_dir( $barrier_dir ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir -- Removes the test-owned empty temporary directory.
+				rmdir( $barrier_dir );
+			}
+		}
+	}
+}

--- a/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -22,6 +22,7 @@ use WP\MCP\Tests\TestCase;
 use WP\MCP\Transport\Infrastructure\HttpRequestContext;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
 use WP\MCP\Transport\Infrastructure\RequestRouter;
+use WP\MCP\Transport\Infrastructure\SessionManager;
 use WP\McpSchema\Common\McpConstants;
 use WP_REST_Request;
 
@@ -133,6 +134,56 @@ final class RequestRouterTest extends TestCase {
 		// Should have session ID for HTTP context
 		$this->assertArrayHasKey( '_session_id', $result );
 		$this->assertIsString( $result['_session_id'] );
+	}
+
+	/**
+	 * Test exhausted session update retries are reported to the configured error handler.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_route_request_logs_exhausted_session_update_retries(): void {
+		$attempts              = 0;
+		$block_session_updates = static function ( $check, $object_id, $meta_key ) use ( &$attempts ) {
+			if ( 'mcp_adapter_sessions' !== $meta_key ) {
+				return $check;
+			}
+
+			++$attempts;
+
+			return false;
+		};
+
+		add_filter( 'update_user_metadata', $block_session_updates, 10, 3 );
+
+		$request      = new WP_REST_Request( 'POST', '/test-mcp' );
+		$http_context = new HttpRequestContext( $request );
+		$result       = $this->router->route_request(
+			'initialize',
+			array( 'protocolVersion' => '2025-11-25' ),
+			1,
+			'test-transport',
+			$http_context
+		);
+
+		remove_filter( 'update_user_metadata', $block_session_updates, 10 );
+
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertSame( 5, $attempts );
+		$this->assertSame(
+			array(
+				array(
+					'message' => 'Failed to persist MCP sessions after exhausting update retries.',
+					'context' => array(
+						'component' => SessionManager::class,
+						'method'    => 'mutate_sessions',
+						'user_id'   => $this->test_user_id,
+						'attempts'  => 5,
+					),
+					'type'    => 'error',
+				),
+			),
+			DummyErrorHandler::$logs
+		);
 	}
 
 	public function test_route_request_tools_list(): void {

--- a/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
+++ b/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
@@ -157,6 +157,8 @@ final class McpSessionManagerTest extends TestCase {
 		// Verify session is gone
 		$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$this->assertCount( 0, $sessions );
+		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions' ) );
+		$this->assertSame( array(), get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', true ) );
 	}
 
 	/**


### PR DESCRIPTION
Closes https://github.com/WordPress/mcp-adapter/issues/239.

## Summary

- Protect updates to the existing `mcp_adapter_sessions` user-meta map with `update_user_meta( ..., $prev_value )` and bounded retries.
- Keep the current single-meta storage format and all existing public session behavior.
- Preserve an empty array after the final session is deleted.
- Report exhausted retries through the configured MCP error handler, with a standard error-log fallback.
- Add real multi-process concurrency coverage and failure-observability coverage.

## Why

Session mutations currently perform an unconditional read-modify-write. Two requests can read the same session map and then overwrite one another, dropping sessions.

Instead of changing the storage model to one user-meta row per session, as explored in #246, this uses WordPress's existing previous-value comparison as a small compare-and-swap loop. It does not add custom SQL, database locks, lock metadata, or a storage migration.

## Compatibility and tradeoff

The existing `mcp_adapter_sessions` key and serialized map remain unchanged. Existing `HttpSessionValidator` public method signatures are preserved, while optional trailing handler arguments on the final `SessionManager` class remain backward compatible.

WordPress ignores an empty `$prev_value`, so simultaneous first connections for a user, or simultaneous connections immediately after the map becomes empty, can still race. This is an intentional tradeoff: the common established-session case is protected without introducing a more complex locking or storage system. MCP protocol revisions that do not negotiate session IDs continue to bypass this compatibility storage.

Retry-exhaustion logs contain only the component, method, user ID, and attempt count. They do not include session IDs, client parameters, headers, or stored payloads.

## Validation

- `npm run test:php` — 1,011 tests, 3,920 assertions
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyze --memory-limit=1G --no-progress`
- Four independent PHP worker processes synchronize at the user-meta update boundary and verify that every concurrent session survives.

### Live concurrency testing

Tested against real deployments, changing only `SessionManager.php` between control and patched runs:

- With sessions already stored, the current code lost 7 of 18 and 9 of 18 sessions across two servers; patched runs lost none.
- With the meta row deleted before every round, the current code lost 20 of 36 sessions; the patch lost 0 of 114 sessions at up to 12 concurrent clients.
- Across all patched runs, 0 of 186 sessions were lost.

The known first-write limitation remains: WordPress ignores an empty `$prev_value`, so the initial write cannot be protected by this compare-and-swap mechanism. I could not reproduce a lost session in that case, so I can call this a good trade-off. 