### PR TITLE
fix(deps-dev): update websocket-driver to 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26267,9 +26267,9 @@
 			}
 		},
 		"node_modules/websocket-driver": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-			"integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+			"integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {


### PR DESCRIPTION
## What?

Updates the npm lockfile to resolve the development-only `websocket-driver` dependency to 0.7.5 instead of 0.7.4. No production plugin files change.

## Why?

Versions earlier than 0.7.5 are affected by two reviewed advisories:

- [CVE-2026-54466 / GHSA-xv26-6w52-cph6](https://github.com/advisories/GHSA-xv26-6w52-cph6), which can corrupt message parsing through legacy WebSocket length headers.
- [CVE-2026-54490 / GHSA-mp7j-qc5w-4988](https://github.com/advisories/GHSA-mp7j-qc5w-4988), which can bypass message-size limits when compression is enabled.

In this repository, the package is present only through development tooling and is not part of the PHP HTTP or STDIO MCP runtime. The installed Node dependency tree is also excluded from the plugin release artifact. This is preventative development-tooling remediation rather than evidence of exposed WordPress MCP installations.

## How?

The dependency path is `@wordpress/scripts` → `webpack-dev-server` → `sockjs` → `websocket-driver`. The existing `sockjs` constraint accepts `websocket-driver ^0.7.4`, so 0.7.5 satisfies the current dependency graph. This PR changes only the resolved version, tarball URL, and registry-verified integrity value in `package-lock.json`.

### Use of AI Tools

AI assistance: Yes  
Tool(s): OpenAI Codex, Claude Code  
Model(s): GPT-5.6 Sol, Fable  
Used for: Dependency investigation, the lockfile-only update, and verification. The contributor reviewed the final diff and verification results before submission.

### Verified locally

- A clean `npm ci --ignore-scripts --no-audit --fund=false --prefer-offline` completed successfully.
- `npm ls websocket-driver --all` resolves every path to 0.7.5.
- The full npm audit no longer reports `websocket-driver` or either advisory.
- `npm audit --omit=dev --json` reports zero production-dependency findings.
- `git diff --check` passes, and only `package-lock.json` is modified.

## Testing Instructions

1. Run `npm ci --ignore-scripts --no-audit`.
2. Run `npm ls websocket-driver --all` and confirm every path resolves to 0.7.5.
3. Run `npm audit --omit=dev --json` and confirm the production dependency audit remains clear.
4. Run `npm audit --json` and confirm it no longer reports `websocket-driver`, CVE-2026-54466, GHSA-xv26-6w52-cph6, CVE-2026-54490, or GHSA-mp7j-qc5w-4988. The command still exits nonzero because unrelated, pre-existing development-dependency findings remain.

This PR is intentionally limited to the two `websocket-driver` advisories fixed by the same patch release.

## Changelog Entry

> Developer - Update the npm lockfile to use `websocket-driver` 0.7.5.
