### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Adapter
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2FWordPress%2Fmcp-adapter.svg)](https://mcptoplist.com/server/glama%2FWordPress%2Fmcp-adapter)
+
 Part of the [**AI Building Blocks for WordPress** initiative](https://make.wordpress.org/ai/2025/07/17/ai-building-blocks)
 
 The official WordPress package for MCP integration that exposes WordPress abilities as [Model Context Protocol (MCP)](https://modelcontextprotocol.io) tools, resources, and prompts for AI agents.


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,686 MCP servers across the major
registries, and **MCP Adapter** is currently ranked **#727**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2FWordPress%2Fmcp-adapter.svg)](https://mcptoplist.com/server/glama%2FWordPress%2Fmcp-adapter)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building MCP Adapter!
