### PR TITLE
Feat/resource meta

### DIFF
--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -278,6 +278,7 @@ class ResourcesHandler {
 	private function create_content_dto( array $item, string $default_uri ) {
 		$item_uri  = $item['uri'] ?? $default_uri;
 		$mime_type = $item['mimeType'] ?? null;
+		$meta      = isset( $item['_meta'] ) && is_array( $item['_meta'] ) ? $item['_meta'] : null;
 
 		// If there's blob data, create BlobResourceContents.
 		if ( isset( $item['blob'] ) ) {
@@ -286,6 +287,7 @@ class ResourcesHandler {
 					'uri'      => $item_uri,
 					'blob'     => (string) $item['blob'],
 					'mimeType' => is_string( $mime_type ) ? $mime_type : null,
+					'_meta'    => $meta,
 				)
 			);
 		}
@@ -298,6 +300,7 @@ class ResourcesHandler {
 				'uri'      => $item_uri,
 				'text'     => (string) $text,
 				'mimeType' => is_string( $mime_type ) ? $mime_type : null,
+				'_meta'    => $meta,
 			)
 		);
 	}

--- a/tests/phpunit/Fixtures/DummyAbility.php
+++ b/tests/phpunit/Fixtures/DummyAbility.php
@@ -1154,6 +1154,66 @@ final class DummyAbility {
 			)
 		);
 
+		// Resource returning text content with _meta.
+		wp_register_ability(
+			'test/resource-text-with-meta',
+			array(
+				'label'               => 'Resource Text With Meta',
+				'description'         => 'A resource returning text content with _meta',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return array(
+						array(
+							'uri'      => 'WordPress://local/resource-text-with-meta',
+							'text'     => 'hello meta',
+							'mimeType' => 'text/plain',
+							'_meta'    => array( 'ui' => array( 'prefersBorder' => true ) ),
+						),
+					);
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'WordPress://local/resource-text-with-meta',
+					),
+				),
+			)
+		);
+
+		// Resource returning blob content with _meta.
+		wp_register_ability(
+			'test/resource-blob-with-meta',
+			array(
+				'label'               => 'Resource Blob With Meta',
+				'description'         => 'A resource returning blob content with _meta',
+				'category'            => 'test',
+				'execute_callback'    => static function () {
+					return array(
+						array(
+							'uri'      => 'WordPress://local/resource-blob-with-meta',
+							'blob'     => base64_encode( 'binary-with-meta' ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+							'mimeType' => 'application/octet-stream',
+							'_meta'    => array( 'checksum' => 'abc123' ),
+						),
+					);
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'WordPress://local/resource-blob-with-meta',
+					),
+				),
+			)
+		);
+
 		// =========================================================================
 		// Prompt Icons and _meta Test Abilities (MCP 2025-11-25)
 		// =========================================================================

--- a/tests/phpunit/Unit/Core/McpAdapterConfigTest.php
+++ b/tests/phpunit/Unit/Core/McpAdapterConfigTest.php
@@ -260,6 +260,8 @@ final class McpAdapterConfigTest extends TestCase {
 				'test/resource-multiple-contents',
 				'test/resource-text-with-mimetype',
 				'test/resource-plain-string',
+				'test/resource-text-with-meta',
+				'test/resource-blob-with-meta',
 			),
 			$received_config['resources']
 		);

--- a/tests/phpunit/Unit/Handlers/ResourcesHandlerReadTest.php
+++ b/tests/phpunit/Unit/Handlers/ResourcesHandlerReadTest.php
@@ -327,4 +327,50 @@ final class ResourcesHandlerReadTest extends TestCase {
 
 		remove_filter( 'mcp_adapter_resource_read_result', $filter );
 	}
+
+	public function test_read_resource_preserves_meta_on_text_content(): void {
+		wp_set_current_user( 1 );
+
+		$server  = $this->makeServer( array(), array( 'test/resource-text-with-meta' ) );
+		$handler = new ResourcesHandler( $server );
+
+		$result = $handler->read_resource(
+			array( 'params' => array( 'uri' => 'WordPress://local/resource-text-with-meta' ) )
+		);
+
+		$this->assertInstanceOf( ReadResourceResult::class, $result );
+
+		$contents = $result->getContents();
+		$this->assertNotEmpty( $contents );
+		$this->assertInstanceOf( TextResourceContents::class, $contents[0] );
+
+		// Verify _meta is preserved end-to-end.
+		$meta = $contents[0]->get_meta();
+		$this->assertIsArray( $meta, '_meta should be an array, not null.' );
+		$this->assertArrayHasKey( 'ui', $meta );
+		$this->assertTrue( $meta['ui']['prefersBorder'] );
+	}
+
+	public function test_read_resource_preserves_meta_on_blob_content(): void {
+		wp_set_current_user( 1 );
+
+		$server  = $this->makeServer( array(), array( 'test/resource-blob-with-meta' ) );
+		$handler = new ResourcesHandler( $server );
+
+		$result = $handler->read_resource(
+			array( 'params' => array( 'uri' => 'WordPress://local/resource-blob-with-meta' ) )
+		);
+
+		$this->assertInstanceOf( ReadResourceResult::class, $result );
+
+		$contents = $result->getContents();
+		$this->assertNotEmpty( $contents );
+		$this->assertInstanceOf( BlobResourceContents::class, $contents[0] );
+
+		// Verify _meta is preserved end-to-end.
+		$meta = $contents[0]->get_meta();
+		$this->assertIsArray( $meta, '_meta should be an array, not null.' );
+		$this->assertArrayHasKey( 'checksum', $meta );
+		$this->assertSame( 'abc123', $meta['checksum'] );
+	}
 }


### PR DESCRIPTION
## What?
Closes #245 

Preserve the MCP `_meta` field when building `resources/read` response contents, so metadata returned by resource ability callbacks is passed through to MCP clients.

## Why?

The MCP spec allows any resource content object to carry an optional `_meta` field for arbitrary client-side hints. Previously, `ResourcesHandler::create_content_dto()` never extracted `_meta` from the raw content item array, meaning it was silently dropped before the DTO was constructed and the response was serialised. This broke spec compliance and caused clients to lose metadata they depended on.

## How?

In `ResourcesHandler::create_content_dto()`, extract `_meta` from the raw content item and forward it into both `BlobResourceContents::fromArray()` and `TextResourceContents::fromArray()`.

The `is_array()` guard ensures a callback that returns a non-array `_meta` value still produces a well-typed `null` rather than crashing the DTO constructor.

### Use of AI Tools

AI assistance: Yes  
Tool(s): Antigravity
Model(s): Claude Sonnet 4.6  
Used for: Generating PHPUnit test stubs and drafting this PR description. The core bug fix in `ResourcesHandler.php`, fixture design, and final review were done by me.

## Testing Instructions

1. Check out this branch.
2. Start the test environment: `npm run wp-env:test -- start`
3. Run the full PHPUnit suite: `npm run test:php`
4. Confirm output ends with `OK (1011 tests, 3901 assertions)` and no failures.