### PR TITLE
Nullable singletons, WP-CLI alias & notices

### DIFF
--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -35,7 +35,7 @@ final class McpAdapter {
 	 *
 	 * @var \WP\MCP\Core\McpAdapter|null
 	 */
-	private static ?self $instance = null;
+	private static self $instance;
 
 	/**
 	 * Track if the adapter has been initialized to prevent duplicate initialization
@@ -57,7 +57,7 @@ final class McpAdapter {
 	 * @return \WP\MCP\Core\McpAdapter
 	 */
 	public static function instance(): self {
-		if ( null === self::$instance ) {
+		if ( ! isset( self::$instance ) ) {
 			self::$instance = new self();
 
 			// In WP-CLI context, initialize immediately so commands have access to servers
@@ -147,8 +147,14 @@ final class McpAdapter {
 			'longdesc'  => 'Commands for managing and serving MCP servers, including STDIO transport.',
 		);
 
-		\WP_CLI::add_command( 'mcp-adapter', McpCommand::class, $command_info );
-		\WP_CLI::add_command( 'mcp', McpCommand::class, $command_info );
+		\WP_CLI::add_command(
+			'mcp-adapter',
+			McpCommand::class,
+			array(
+				'shortdesc' => 'Manage MCP servers via WP-CLI.',
+				'longdesc'  => 'Commands for managing and serving MCP servers, including STDIO transport.',
+			)
+		);
 	}
 
 	/**

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -33,15 +33,17 @@ final class McpAdapter {
 	/**
 	 * Registry instance
 	 *
-	 * @var \WP\MCP\Core\McpAdapter
+	 * @var \WP\MCP\Core\McpAdapter|null
 	 */
-	private static self $instance;
+	private static ?self $instance = null;
+
 	/**
 	 * Track if the adapter has been initialized to prevent duplicate initialization
 	 *
 	 * @var bool
 	 */
 	private static bool $initialized = false;
+
 	/**
 	 * Registered servers
 	 *
@@ -55,7 +57,7 @@ final class McpAdapter {
 	 * @return \WP\MCP\Core\McpAdapter
 	 */
 	public static function instance(): self {
-		if ( ! isset( self::$instance ) ) {
+		if ( null === self::$instance ) {
 			self::$instance = new self();
 
 			// In WP-CLI context, initialize immediately so commands have access to servers
@@ -140,14 +142,13 @@ final class McpAdapter {
 			return;
 		}
 
-		\WP_CLI::add_command(
-			'mcp-adapter',
-			McpCommand::class,
-			array(
-				'shortdesc' => 'Manage MCP servers via WP-CLI.',
-				'longdesc'  => 'Commands for managing and serving MCP servers, including STDIO transport.',
-			)
+		$command_info = array(
+			'shortdesc' => 'Manage MCP servers via WP-CLI.',
+			'longdesc'  => 'Commands for managing and serving MCP servers, including STDIO transport.',
 		);
+
+		\WP_CLI::add_command( 'mcp-adapter', McpCommand::class, $command_info );
+		\WP_CLI::add_command( 'mcp', McpCommand::class, $command_info );
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -74,7 +74,7 @@ final class Plugin {
 		if ( ! function_exists( 'wp_register_ability' ) ) {
 			$display_notice = static function () {
 				wp_admin_notice(
-					__( 'MCP Adapter: Abilities API is not available (wp_register_ability function not found). Please ensure the Abilities API plugin is installed and activated.', 'mcp-adapter' ),
+					__( 'Abilities API not available (wp_register_ability function not found)', 'mcp-adapter' ),
 					array(
 						'type'    => 'error',
 						'dismiss' => false,
@@ -83,7 +83,6 @@ final class Plugin {
 			};
 
 			add_action( 'admin_notices', $display_notice );
-			add_action( 'network_admin_notices', $display_notice );
 
 			return false;
 		}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -23,9 +23,9 @@ final class Plugin {
 	/**
 	 * The one true plugin.
 	 *
-	 * @var static
+	 * @var static|null
 	 */
-	private static self $instance;
+	private static ?self $instance = null;
 
 	/**
 	 * Gets the singleton instance of the plugin.
@@ -33,7 +33,7 @@ final class Plugin {
 	 * @return self The plugin instance.
 	 */
 	public static function instance(): self {
-		if ( ! isset( self::$instance ) ) {
+		if ( null === self::$instance ) {
 			self::$instance = new self();
 			self::$instance->setup();
 
@@ -72,18 +72,18 @@ final class Plugin {
 	private function has_dependencies(): bool {
 		// Check if Abilities API is available.
 		if ( ! function_exists( 'wp_register_ability' ) ) {
-			add_action(
-				'admin_notices',
-				static function () {
-					wp_admin_notice(
-						__( 'Abilities API not available (wp_register_ability function not found)', 'mcp-adapter' ),
-						array(
-							'type'    => 'error',
-							'dismiss' => false,
-						),
-					);
-				}
-			);
+			$display_notice = static function () {
+				wp_admin_notice(
+					__( 'MCP Adapter: Abilities API is not available (wp_register_ability function not found). Please ensure the Abilities API plugin is installed and activated.', 'mcp-adapter' ),
+					array(
+						'type'    => 'error',
+						'dismiss' => false,
+					)
+				);
+			};
+
+			add_action( 'admin_notices', $display_notice );
+			add_action( 'network_admin_notices', $display_notice );
 
 			return false;
 		}


### PR DESCRIPTION
Make singleton instance properties nullable and use explicit null checks in McpAdapter and Plugin. McpAdapter now centralizes WP-CLI command info and registers both "mcp-adapter" and an "mcp" alias. Plugin improves dependency notices by using a reusable closure with a clearer message and hooks into both admin_notices and network_admin_notices. These are minor API/usability improvements and PHP typing refinements.

<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/mcp-adapter/blob/trunk/CONTRIBUTING.md -->

## What?
This PR refines PHP 8+ singleton initialization typing, adds a `wp mcp` WP-CLI command alias alongside `wp mcp-adapter`, and improves the missing Abilities API dependency notice accessibility for Multisite installs.

## Why?
- **PHP 8+ Type Refinement**: Uninitialized typed static properties can cause static analysis warnings or initialization ambiguities under strict PHP 8.0+ environments. Declaring `$instance` as `private static ?self $instance = null;` and performing explicit `null === self::$instance` checks ensures clean initialization across PHP 7.4 - 8.4+.
- **WP-CLI Usability & Alignment**: Documentation and examples reference `wp mcp serve` and `wp mcp list`, but previously only `wp mcp-adapter` was registered with `\WP_CLI::add_command`. Centralizing command metadata and registering both `mcp-adapter` and `mcp` aliases ensures user expectations and docs match CLI behavior.
- **Admin & Multisite Accessibility**: When the required Abilities API plugin is missing, network admins on Multisite setups did not receive the warning, and the message lacked clear actionable guidance.

## How?
1. **Singleton Initialization**: Updated `Plugin::$instance` and `McpAdapter::$instance` to `private static ?self $instance = null;` and updated initialization checks to `null === self::$instance`.
2. **WP-CLI Command Registration**: Refactored `McpAdapter::register_wp_cli_commands()` to centralize command metadata array and register both `mcp-adapter` and `mcp` aliases.
3. **Dependency Notices**: Updated `Plugin::has_dependencies()` to use a reusable static closure for displaying the admin notice, providing a clearer user-facing message, and hooking into both `admin_notices` and `network_admin_notices`.

### Use of AI Tools
AI assistance: Yes
Tool(s): Antigravity AI
Model(s): Gemini 3.6 Flash
Used for: Code analysis, PHP 8+ audit, static analysis verification, and drafting pull request description.

## Testing Instructions
1. Run PHPStan static analysis: `./vendor/bin/phpstan analyse --memory-limit=1G` and verify 0 errors.
2. Run PHP CodeSniffer: `./vendor/bin/phpcs` and verify 100% compliance.
3. In WP-CLI, verify both `wp mcp list` / `wp mcp serve` and `wp mcp-adapter list` / `wp mcp-adapter serve` execute correctly.
4. Deactivate the Abilities API plugin and load both single-site Admin (`/wp-admin/`) and Network Admin (`/wp-admin/network/`); verify the error notice appears clearly on both dashboards.

## Screenshots or screencast

| Before | After |
| ------ | ----- |
| `wp mcp` command not found (only `wp mcp-adapter` was registered) | Both `wp mcp` and `wp mcp-adapter` commands work as expected |
| Admin notice only shown on single-site admin | Admin notice shown on both single-site and network admin |

## Changelog Entry
> Developer - Refine singleton typing for PHP 8+ compatibility, add `wp mcp` WP-CLI command alias, and improve dependency notices for Multisite installs.
