### PR TITLE
fix: emit a mimeType as declared

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -319,7 +319,6 @@ Extended validation for MCP component data per the MCP 2025-11-25 specification:
 
 - `validate_name()` -- Name charset and length validation
 - `validate_resource_uri()` -- URI format per RFC 3986
-- `validate_mime_type()` -- MIME type format validation
 - `validate_icons_array()` -- Icon object validation (src, mimeType, sizes, theme)
 - `get_annotation_validation_errors()` -- Annotation field validation (audience, priority, lastModified)
 - `validate_base64()` -- Base64 content validation

--- a/includes/Domain/Prompts/McpPromptValidator.php
+++ b/includes/Domain/Prompts/McpPromptValidator.php
@@ -344,16 +344,11 @@ class McpPromptValidator {
 					);
 				}
 
+				// mimeType is required. Its value is not checked.
 				if ( empty( $content['mimeType'] ) || ! is_string( $content['mimeType'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
 						__( 'Message %d image content must have a mimeType field', 'mcp-adapter' ),
-						$message_index
-					);
-				} elseif ( ! McpValidator::validate_image_mime_type( $content['mimeType'] ) ) {
-					$errors[] = sprintf(
-					/* translators: %d: message index */
-						__( 'Message %d image content must have a valid image MIME type', 'mcp-adapter' ),
 						$message_index
 					);
 				}
@@ -374,16 +369,11 @@ class McpPromptValidator {
 					);
 				}
 
+				// mimeType is required. Its value is not checked.
 				if ( empty( $content['mimeType'] ) || ! is_string( $content['mimeType'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
 						__( 'Message %d audio content must have a mimeType field', 'mcp-adapter' ),
-						$message_index
-					);
-				} elseif ( ! McpValidator::validate_audio_mime_type( $content['mimeType'] ) ) {
-					$errors[] = sprintf(
-					/* translators: %d: message index */
-						__( 'Message %d audio content must have a valid audio MIME type', 'mcp-adapter' ),
 						$message_index
 					);
 				}
@@ -413,20 +403,12 @@ class McpPromptValidator {
 					);
 				}
 
-				if ( isset( $content['mimeType'] ) ) {
-					if ( ! is_string( $content['mimeType'] ) ) {
-						$errors[] = sprintf(
-						/* translators: %d: message index */
-							__( 'Message %d resource_link content mimeType must be a string if provided', 'mcp-adapter' ),
-							$message_index
-						);
-					} elseif ( ! McpValidator::validate_mime_type( $content['mimeType'] ) ) {
-						$errors[] = sprintf(
-						/* translators: %d: message index */
-							__( 'Message %d resource_link content mimeType must be a valid MIME type format', 'mcp-adapter' ),
-							$message_index
-						);
-					}
+				if ( isset( $content['mimeType'] ) && ! is_string( $content['mimeType'] ) ) {
+					$errors[] = sprintf(
+					/* translators: %d: message index */
+						__( 'Message %d resource_link content mimeType must be a string if provided', 'mcp-adapter' ),
+						$message_index
+					);
 				}
 
 				if ( isset( $content['size'] ) && ! is_int( $content['size'] ) ) {

--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -149,10 +149,10 @@ final class McpResource implements McpComponentInterface {
 			$resource_data['description'] = $config['description'];
 		}
 
-		// Include mimeType only when valid.
+		// Include mimeType when non-empty. The value itself is not checked.
 		if ( isset( $config['mimeType'] ) ) {
 			$mime_type = trim( $config['mimeType'] );
-			if ( '' !== $mime_type && McpValidator::validate_mime_type( $mime_type ) ) {
+			if ( '' !== $mime_type ) {
 				$resource_data['mimeType'] = $mime_type;
 			}
 		}

--- a/includes/Domain/Resources/McpResourceValidator.php
+++ b/includes/Domain/Resources/McpResourceValidator.php
@@ -62,12 +62,6 @@ class McpResourceValidator {
 			$errors[] = __( 'Resource URI must be a valid URI string', 'mcp-adapter' );
 		}
 
-		// Validate the MIME type if present.
-		$mime_type = $resource_dto->getMimeType();
-		if ( $mime_type && ! McpValidator::validate_mime_type( $mime_type ) ) {
-			$errors[] = __( 'Resource MIME type is invalid', 'mcp-adapter' );
-		}
-
 		// Validate icons if present.
 		$icons = $resource_dto->getIcons();
 		if ( ! empty( $icons ) ) {
@@ -161,13 +155,9 @@ class McpResourceValidator {
 			$errors[] = __( 'Resource blob content must be valid base64-encoded data', 'mcp-adapter' );
 		}
 
-		// Validate mimeType if present (optional).
-		if ( isset( $resource_data['mimeType'] ) ) {
-			if ( ! is_string( $resource_data['mimeType'] ) ) {
-				$errors[] = __( 'Resource mimeType must be a string if provided', 'mcp-adapter' );
-			} elseif ( ! McpValidator::validate_mime_type( $resource_data['mimeType'] ) ) {
-				$errors[] = __( 'Resource mimeType must be a valid MIME type format', 'mcp-adapter' );
-			}
+		// mimeType is optional. Only its type is checked.
+		if ( isset( $resource_data['mimeType'] ) && ! is_string( $resource_data['mimeType'] ) ) {
+			$errors[] = __( 'Resource mimeType must be a string if provided', 'mcp-adapter' );
 		}
 
 		return $errors;

--- a/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -156,11 +156,13 @@ class RegisterAbilityAsMcpResource {
 			$resource_data['description'] = $description;
 		}
 
-		// Optional: mimeType from ability meta (with validation).
+		// Optional: mimeType from ability meta. MCP treats it as an opaque string, so the
+		// value is emitted unaltered once surrounding whitespace is trimmed off; only a
+		// non-empty result is required.
 		$mime_type = $this->get_mcp_meta( 'mimeType', 'string' );
 		if ( null !== $mime_type ) {
 			$mime_type = trim( $mime_type );
-			if ( McpValidator::validate_mime_type( $mime_type ) ) {
+			if ( '' !== $mime_type ) {
 				$resource_data['mimeType'] = $mime_type;
 			}
 		}

--- a/includes/Domain/Utils/McpValidator.php
+++ b/includes/Domain/Utils/McpValidator.php
@@ -146,7 +146,7 @@ class McpValidator {
 	 *
 	 * Validates icon fields per MCP 2025-11-25 specification:
 	 * - src (required): Valid URL or data: URI
-	 * - mimeType (optional): One of allowed image MIME types
+	 * - mimeType (optional): String emitted as declared
 	 * - sizes (optional): Array of size strings in WxH format or "any"
 	 * - theme (optional): "light" or "dark"
 	 *

--- a/includes/Domain/Utils/McpValidator.php
+++ b/includes/Domain/Utils/McpValidator.php
@@ -33,24 +33,6 @@ class McpValidator {
 	private const URI_SCHEME_PATTERN = '[a-zA-Z][a-zA-Z0-9+.-]*';
 
 	/**
-	 * Allowed MIME types for MCP icons per specification.
-	 *
-	 * MUST support: image/png, image/jpeg, image/jpg
-	 * SHOULD support: image/svg+xml, image/webp
-	 *
-	 * @since 0.5.0
-	 *
-	 * @var array<string>
-	 */
-	private static array $allowed_icon_mime_types = array(
-		'image/png',
-		'image/jpeg',
-		'image/jpg',
-		'image/svg+xml',
-		'image/webp',
-	);
-
-	/**
 	 * Validate an MCP component name.
 	 *
 	 * Validates that a name follows MCP naming conventions per MCP 2025-11-25 spec:
@@ -78,32 +60,6 @@ class McpValidator {
 
 		// Only allow letters, numbers, hyphens, underscores, and dots per MCP spec.
 		return (bool) preg_match( '/^[a-zA-Z0-9_.-]+$/', $name );
-	}
-
-	/**
-	 * Validate image MIME type.
-	 *
-	 * Checks if the MIME type is a valid image type according to MCP specification.
-	 *
-	 * @param string $mime_type The MIME type to validate.
-	 *
-	 * @return bool True if valid image MIME type, false otherwise.
-	 */
-	public static function validate_image_mime_type( string $mime_type ): bool {
-		return str_starts_with( strtolower( $mime_type ), 'image/' );
-	}
-
-	/**
-	 * Validate audio MIME type.
-	 *
-	 * Checks if the MIME type is a valid audio type according to MCP specification.
-	 *
-	 * @param string $mime_type The MIME type to validate.
-	 *
-	 * @return bool True if valid audio MIME type, false otherwise.
-	 */
-	public static function validate_audio_mime_type( string $mime_type ): bool {
-		return str_starts_with( strtolower( $mime_type ), 'audio/' );
 	}
 
 	/**
@@ -212,17 +168,9 @@ class McpValidator {
 			$errors[] = __( 'Icon src must be a valid URL (http/https) or data: URI', 'mcp-adapter' );
 		}
 
-		// mimeType is optional but must be valid if present.
-		if ( isset( $icon['mimeType'] ) ) {
-			if ( ! is_string( $icon['mimeType'] ) ) {
-				$errors[] = __( 'Icon mimeType must be a string', 'mcp-adapter' );
-			} elseif ( ! self::validate_icon_mime_type( $icon['mimeType'] ) ) {
-				$errors[] = sprintf(
-				/* translators: %s: comma-separated list of allowed MIME types */
-					__( 'Icon mimeType must be one of: %s', 'mcp-adapter' ),
-					implode( ', ', self::$allowed_icon_mime_types )
-				);
-			}
+		// mimeType is optional. Only its type is checked.
+		if ( isset( $icon['mimeType'] ) && ! is_string( $icon['mimeType'] ) ) {
+			$errors[] = __( 'Icon mimeType must be a string', 'mcp-adapter' );
 		}
 
 		// sizes is optional but must be valid if present.
@@ -292,22 +240,6 @@ class McpValidator {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Validate an icon MIME type.
-	 *
-	 * Per MCP spec, clients MUST support image/png, image/jpeg (and image/jpg).
-	 * Clients SHOULD support image/svg+xml, image/webp.
-	 *
-	 * @param string $mime_type The MIME type to validate.
-	 *
-	 * @return bool True if valid icon MIME type, false otherwise.
-	 * @since 0.5.0
-	 *
-	 */
-	public static function validate_icon_mime_type( string $mime_type ): bool {
-		return in_array( strtolower( trim( $mime_type ) ), self::$allowed_icon_mime_types, true );
 	}
 
 	/**
@@ -547,21 +479,5 @@ class McpValidator {
 			static fn( array $matches ): string => strtolower( $matches[1] ) . ':',
 			$uri
 		) ?? $uri;
-	}
-
-	/**
-	 * Validate general MIME type format.
-	 *
-	 * Validates that a MIME type follows the standard format: type/subtype
-	 * where both type and subtype contain valid characters.
-	 *
-	 * @param string $mime_type The MIME type to validate.
-	 *
-	 * @return bool True if valid MIME type format, false otherwise.
-	 */
-	public static function validate_mime_type( string $mime_type ): bool {
-		// RFC 2045 compliant: allows +, ., and other valid MIME type characters.
-		// Examples: image/svg+xml, application/vnd.api+json, text/plain.
-		return (bool) preg_match( '/^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*$/', $mime_type );
 	}
 }

--- a/tests/phpunit/Fixtures/DummyAbility.php
+++ b/tests/phpunit/Fixtures/DummyAbility.php
@@ -913,12 +913,12 @@ final class DummyAbility {
 			)
 		);
 
-		// Resource with invalid mimeType - should silently skip mimeType
+		// Resource with a parameterized mimeType - should emit it as declared.
 		wp_register_ability(
-			'test/resource-invalid-mimetype',
+			'test/resource-parameterized-mimetype',
 			array(
-				'label'               => 'Resource Invalid MimeType',
-				'description'         => 'A resource with invalid mimeType for testing validation',
+				'label'               => 'Resource Parameterized MimeType',
+				'description'         => 'A resource with a parameterized mimeType for testing pass-through behavior',
 				'category'            => 'test',
 				'execute_callback'    => static function () {
 					return 'content';
@@ -930,8 +930,8 @@ final class DummyAbility {
 					'mcp' => array(
 						'public'   => true,
 						'type'     => 'resource',
-						'uri'      => 'WordPress://local/resource-invalid-mimetype',
-						'mimeType' => 'not//valid',  // Invalid mime type.
+						'uri'      => 'WordPress://local/resource-parameterized-mimetype',
+						'mimeType' => 'text/html;profile=mcp-app',
 					),
 				),
 			)

--- a/tests/phpunit/Unit/Core/McpAdapterConfigTest.php
+++ b/tests/phpunit/Unit/Core/McpAdapterConfigTest.php
@@ -251,7 +251,7 @@ final class McpAdapterConfigTest extends TestCase {
 				'test/resource',
 				'test/resource-new-meta',
 				'test/resource-invalid-uri',
-				'test/resource-invalid-mimetype',
+				'test/resource-parameterized-mimetype',
 				'test/resource-with-size',
 				'test/resource-with-icons',
 				'test/resource-missing-uri',

--- a/tests/phpunit/Unit/Domain/Prompts/McpPromptValidatorTest.php
+++ b/tests/phpunit/Unit/Domain/Prompts/McpPromptValidatorTest.php
@@ -474,21 +474,35 @@ final class McpPromptValidatorTest extends TestCase {
 		$this->assertEmpty( $errors );
 	}
 
-	public function test_validate_prompt_messages_with_invalid_image_mime_type(): void {
+	public function test_validate_prompt_messages_accepts_any_image_mime_type(): void {
 		$messages = array(
 			array(
 				'role'    => 'user',
 				'content' => array(
 					'type'     => 'image',
 					'data'     => base64_encode( 'image-data' ),
-					'mimeType' => 'text/plain', // Invalid for image
+					'mimeType' => 'text/plain',
+				),
+			),
+		);
+
+		$this->assertSame( array(), McpPromptValidator::validate_prompt_messages( $messages ) );
+	}
+
+	public function test_validate_prompt_messages_with_missing_image_mime_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'image',
+					'data' => base64_encode( 'image-data' ),
 				),
 			),
 		);
 
 		$errors = McpPromptValidator::validate_prompt_messages( $messages );
 		$this->assertNotEmpty( $errors );
-		$this->assertStringContainsString( 'image content must have a valid image MIME type', $errors[0] );
+		$this->assertStringContainsString( 'image content must have a mimeType field', $errors[0] );
 	}
 
 	public function test_validate_prompt_messages_with_valid_audio_content(): void {
@@ -507,21 +521,35 @@ final class McpPromptValidatorTest extends TestCase {
 		$this->assertEmpty( $errors );
 	}
 
-	public function test_validate_prompt_messages_with_invalid_audio_mime_type(): void {
+	public function test_validate_prompt_messages_accepts_any_audio_mime_type(): void {
 		$messages = array(
 			array(
 				'role'    => 'user',
 				'content' => array(
 					'type'     => 'audio',
 					'data'     => base64_encode( 'audio-data' ),
-					'mimeType' => 'text/plain', // Invalid for audio
+					'mimeType' => 'text/plain',
+				),
+			),
+		);
+
+		$this->assertSame( array(), McpPromptValidator::validate_prompt_messages( $messages ) );
+	}
+
+	public function test_validate_prompt_messages_with_missing_audio_mime_type(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => array(
+					'type' => 'audio',
+					'data' => base64_encode( 'audio-data' ),
 				),
 			),
 		);
 
 		$errors = McpPromptValidator::validate_prompt_messages( $messages );
 		$this->assertNotEmpty( $errors );
-		$this->assertStringContainsString( 'audio content must have a valid audio MIME type', $errors[0] );
+		$this->assertStringContainsString( 'audio content must have a mimeType field', $errors[0] );
 	}
 
 	public function test_validate_prompt_messages_with_valid_resource_content(): void {
@@ -929,7 +957,7 @@ final class McpPromptValidatorTest extends TestCase {
 		$this->assertStringContainsString( 'resource_link content mimeType must be a string', implode( ' ', $errors ) );
 	}
 
-	public function test_validate_prompt_messages_with_resource_link_invalid_mime_type_format(): void {
+	public function test_validate_prompt_messages_accepts_any_resource_link_mime_type_string(): void {
 		$messages = array(
 			array(
 				'role'    => 'assistant',
@@ -942,9 +970,7 @@ final class McpPromptValidatorTest extends TestCase {
 			),
 		);
 
-		$errors = McpPromptValidator::validate_prompt_messages( $messages );
-		$this->assertNotEmpty( $errors );
-		$this->assertStringContainsString( 'resource_link content mimeType must be a valid MIME type format', implode( ' ', $errors ) );
+		$this->assertSame( array(), McpPromptValidator::validate_prompt_messages( $messages ) );
 	}
 
 	public function test_validate_prompt_messages_with_resource_link_invalid_size(): void {

--- a/tests/phpunit/Unit/Domain/Resources/McpResourceValidatorTest.php
+++ b/tests/phpunit/Unit/Domain/Resources/McpResourceValidatorTest.php
@@ -45,7 +45,7 @@ final class McpResourceValidatorTest extends TestCase {
 		$this->assertStringContainsString( 'URI must be a valid URI', $result->get_error_message() );
 	}
 
-	public function test_validate_resource_dto_rejects_invalid_mime_type(): void {
+	public function test_validate_resource_dto_accepts_any_mime_type_string(): void {
 		$resource = ResourceDto::fromArray(
 			array(
 				'uri'      => 'test://resource',
@@ -54,9 +54,7 @@ final class McpResourceValidatorTest extends TestCase {
 			)
 		);
 
-		$result = McpResourceValidator::validate_resource_dto( $resource );
-		$this->assertWPError( $result );
-		$this->assertStringContainsString( 'MIME type is invalid', $result->get_error_message() );
+		$this->assertTrue( McpResourceValidator::validate_resource_dto( $resource ) );
 	}
 
 	public function test_validate_resource_dto_accepts_valid_mime_type(): void {
@@ -299,16 +297,14 @@ final class McpResourceValidatorTest extends TestCase {
 		$this->assertStringContainsString( 'mimeType must be a string', $errors[0] );
 	}
 
-	public function test_get_validation_errors_with_invalid_mime_type_format(): void {
+	public function test_get_validation_errors_accepts_any_mime_type_string(): void {
 		$resource_data = array(
 			'uri'      => 'test://resource',
 			'text'     => 'Content',
 			'mimeType' => 'invalid-mime',
 		);
 
-		$errors = McpResourceValidator::get_validation_errors( $resource_data );
-		$this->assertNotEmpty( $errors );
-		$this->assertStringContainsString( 'mimeType must be a valid MIME type format', $errors[0] );
+		$this->assertSame( array(), McpResourceValidator::get_validation_errors( $resource_data ) );
 	}
 
 	public function test_get_validation_errors_with_valid_mime_type(): void {
@@ -329,12 +325,12 @@ final class McpResourceValidatorTest extends TestCase {
 	public function test_get_validation_errors_reports_multiple_errors(): void {
 		$resource_data = array(
 			'uri'      => 'invalid uri',
-			'mimeType' => 'invalid-mime',
+			'mimeType' => 123, // Not a string.
 			// Missing text/blob content
 		);
 
 		$errors = McpResourceValidator::get_validation_errors( $resource_data );
-		$this->assertCount( 3, $errors, 'Should report all validation errors: invalid URI, invalid mimeType, and missing content' );
+		$this->assertCount( 3, $errors, 'Should report all validation errors: invalid URI, non-string mimeType, and missing content' );
 	}
 
 	public function test_get_validation_errors_allows_empty_string_text(): void {

--- a/tests/phpunit/Unit/Domain/Utils/McpValidatorTest.php
+++ b/tests/phpunit/Unit/Domain/Utils/McpValidatorTest.php
@@ -188,163 +188,6 @@ final class McpValidatorTest extends TestCase {
 		$this->assertFalse( McpValidator::validate_name( 'namespace/tool' ) );
 	}
 
-	// MIME Type Validation Tests
-
-	public function test_validate_mime_type_with_valid_types(): void {
-		$valid_types = array(
-			'text/plain',
-			'application/json',
-			'image/png',
-			'audio/mpeg',
-			'video/mp4',
-			'application/xml',
-		);
-
-		foreach ( $valid_types as $type ) {
-			$this->assertTrue( McpValidator::validate_mime_type( $type ), "MIME type '{$type}' should be valid" );
-		}
-	}
-
-	public function test_validate_mime_type_rejects_invalid_format(): void {
-		$invalid_types = array(
-			'invalid',
-			'text',
-			'/plain',
-			'text/',
-			'',
-			'text plain',
-			'text@plain',
-		);
-
-		foreach ( $invalid_types as $type ) {
-			$this->assertFalse( McpValidator::validate_mime_type( $type ), "MIME type '{$type}' should be invalid" );
-		}
-	}
-
-	public function test_validate_mime_type_with_structured_syntax_suffix(): void {
-		// RFC 6839: Structured syntax suffixes like +json, +xml are valid.
-		$valid_suffix_types = array(
-			'application/vnd.api+json',
-			'image/svg+xml',
-			'application/atom+xml',
-			'application/hal+json',
-		);
-
-		foreach ( $valid_suffix_types as $type ) {
-			$this->assertTrue( McpValidator::validate_mime_type( $type ), "MIME type '{$type}' should be valid" );
-		}
-	}
-
-	public function test_validate_mime_type_with_vendor_types(): void {
-		// RFC 2045: Vendor-specific types with dots and other characters.
-		$valid_vendor_types = array(
-			'application/vnd.ms-excel',
-			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-			'text/vnd.example.custom',
-		);
-
-		foreach ( $valid_vendor_types as $type ) {
-			$this->assertTrue( McpValidator::validate_mime_type( $type ), "MIME type '{$type}' should be valid" );
-		}
-	}
-
-	public function test_validate_mime_type_rejects_parameters(): void {
-		// MIME type parameters (after ;) are not supported by the validator.
-		$types_with_parameters = array(
-			'text/html; charset=utf-8',
-			'text/plain; format=flowed',
-		);
-
-		foreach ( $types_with_parameters as $type ) {
-			$this->assertFalse( McpValidator::validate_mime_type( $type ), "MIME type with parameter '{$type}' should be rejected" );
-		}
-	}
-
-	// Image MIME Type Validation Tests
-
-	public function test_validate_image_mime_type_with_valid_types(): void {
-		$valid_image_types = array(
-			'image/jpeg',
-			'image/jpg',
-			'image/png',
-			'image/gif',
-			'image/webp',
-			'image/bmp',
-			'image/svg+xml',
-			'image/avif',
-			'image/heic',
-			'image/tiff',
-		);
-
-		foreach ( $valid_image_types as $type ) {
-			$this->assertTrue( McpValidator::validate_image_mime_type( $type ), "Image MIME type '{$type}' should be valid" );
-		}
-	}
-
-	public function test_validate_image_mime_type_case_insensitive(): void {
-		$this->assertTrue( McpValidator::validate_image_mime_type( 'IMAGE/PNG' ) );
-		$this->assertTrue( McpValidator::validate_image_mime_type( 'Image/Jpeg' ) );
-	}
-
-	public function test_validate_image_mime_type_rejects_invalid(): void {
-		$invalid_types = array(
-			'text/plain',
-			'application/json',
-			'audio/mp3',
-			'video/mp4',
-			'',
-			'not-an-image',
-			'image',           // Missing subtype
-			'images/png',      // Wrong prefix
-		);
-
-		foreach ( $invalid_types as $type ) {
-			$this->assertFalse( McpValidator::validate_image_mime_type( $type ), "Type '{$type}' should not be a valid image MIME type" );
-		}
-	}
-
-	// Audio MIME Type Validation Tests
-
-	public function test_validate_audio_mime_type_with_valid_types(): void {
-		$valid_audio_types = array(
-			'audio/wav',
-			'audio/mp3',
-			'audio/mpeg',
-			'audio/ogg',
-			'audio/webm',
-			'audio/aac',
-			'audio/flac',
-			'audio/opus',
-			'audio/m4a',
-		);
-
-		foreach ( $valid_audio_types as $type ) {
-			$this->assertTrue( McpValidator::validate_audio_mime_type( $type ), "Audio MIME type '{$type}' should be valid" );
-		}
-	}
-
-	public function test_validate_audio_mime_type_case_insensitive(): void {
-		$this->assertTrue( McpValidator::validate_audio_mime_type( 'AUDIO/MP3' ) );
-		$this->assertTrue( McpValidator::validate_audio_mime_type( 'Audio/Mpeg' ) );
-	}
-
-	public function test_validate_audio_mime_type_rejects_invalid(): void {
-		$invalid_types = array(
-			'text/plain',
-			'application/json',
-			'image/jpeg',
-			'video/mp4',
-			'',
-			'not-an-audio',
-			'audio',           // Missing subtype
-			'audios/mp3',      // Wrong prefix
-		);
-
-		foreach ( $invalid_types as $type ) {
-			$this->assertFalse( McpValidator::validate_audio_mime_type( $type ), "Type '{$type}' should not be a valid audio MIME type" );
-		}
-	}
-
 	// Base64 Validation Tests
 
 	public function test_validate_base64_with_valid_content(): void {
@@ -680,35 +523,6 @@ final class McpValidatorTest extends TestCase {
 		$this->assertFalse( McpValidator::validate_icon_src( 'data:image/png' ) );
 	}
 
-	// Icon MIME Type Validation Tests
-
-	public function test_validate_icon_mime_type_with_required_types(): void {
-		// MUST support per MCP spec.
-		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/png' ) );
-		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/jpeg' ) );
-		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/jpg' ) );
-	}
-
-	public function test_validate_icon_mime_type_with_recommended_types(): void {
-		// SHOULD support per MCP spec.
-		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/svg+xml' ) );
-		$this->assertTrue( McpValidator::validate_icon_mime_type( 'image/webp' ) );
-	}
-
-	public function test_validate_icon_mime_type_case_insensitive(): void {
-		$this->assertTrue( McpValidator::validate_icon_mime_type( 'IMAGE/PNG' ) );
-		$this->assertTrue( McpValidator::validate_icon_mime_type( 'Image/Jpeg' ) );
-		$this->assertTrue( McpValidator::validate_icon_mime_type( 'IMAGE/SVG+XML' ) );
-	}
-
-	public function test_validate_icon_mime_type_rejects_unsupported_types(): void {
-		$this->assertFalse( McpValidator::validate_icon_mime_type( 'image/gif' ) );
-		$this->assertFalse( McpValidator::validate_icon_mime_type( 'image/bmp' ) );
-		$this->assertFalse( McpValidator::validate_icon_mime_type( 'image/tiff' ) );
-		$this->assertFalse( McpValidator::validate_icon_mime_type( 'text/plain' ) );
-		$this->assertFalse( McpValidator::validate_icon_mime_type( 'application/json' ) );
-	}
-
 	// Icon Size Validation Tests
 
 	public function test_validate_icon_size_with_valid_sizes(): void {
@@ -846,14 +660,24 @@ final class McpValidatorTest extends TestCase {
 		$this->assertStringContainsString( 'string', $errors[0] );
 	}
 
-	public function test_get_icon_validation_errors_invalid_mime_type(): void {
+	public function test_get_icon_validation_errors_accepts_any_mime_type_string(): void {
 		$icon = array(
 			'src'      => 'https://example.com/icon.gif',
-			'mimeType' => 'image/gif', // Not in allowed list.
+			'mimeType' => 'image/gif',
+		);
+
+		$this->assertSame( array(), McpValidator::get_icon_validation_errors( $icon ) );
+	}
+
+	public function test_get_icon_validation_errors_rejects_non_string_mime_type(): void {
+		$icon = array(
+			'src'      => 'https://example.com/icon.png',
+			'mimeType' => 123,
 		);
 
 		$errors = McpValidator::get_icon_validation_errors( $icon );
 		$this->assertNotEmpty( $errors );
+		$this->assertStringContainsString( 'Icon mimeType must be a string', implode( ' ', $errors ) );
 	}
 
 	public function test_get_icon_validation_errors_invalid_sizes_not_array(): void {

--- a/tests/phpunit/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
+++ b/tests/phpunit/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
@@ -212,9 +212,9 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$this->assertSame( 'resource_uri_invalid', $resource->get_error_code() );
 	}
 
-	public function test_unusual_mimetype_is_emitted_as_declared(): void {
-		$ability = wp_get_ability( 'test/resource-invalid-mimetype' );
-		$this->assertNotNull( $ability, 'Ability test/resource-invalid-mimetype should be registered' );
+	public function test_parameterized_mimetype_is_emitted_as_declared(): void {
+		$ability = wp_get_ability( 'test/resource-parameterized-mimetype' );
+		$this->assertNotNull( $ability, 'Ability test/resource-parameterized-mimetype should be registered' );
 
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
@@ -223,7 +223,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 
 		// The descriptor carries whatever the author declared.
 		$this->assertArrayHasKey( 'mimeType', $arr );
-		$this->assertSame( 'not//valid', $arr['mimeType'] );
+		$this->assertSame( 'text/html;profile=mcp-app', $arr['mimeType'] );
 	}
 
 	public function test_size_field_is_included(): void {

--- a/tests/phpunit/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
+++ b/tests/phpunit/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
@@ -212,7 +212,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$this->assertSame( 'resource_uri_invalid', $resource->get_error_code() );
 	}
 
-	public function test_invalid_mimetype_is_silently_skipped(): void {
+	public function test_unusual_mimetype_is_emitted_as_declared(): void {
 		$ability = wp_get_ability( 'test/resource-invalid-mimetype' );
 		$this->assertNotNull( $ability, 'Ability test/resource-invalid-mimetype should be registered' );
 
@@ -221,8 +221,9 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 
 		$arr = $resource->toArray();
 
-		// mimeType should NOT be present (invalid format was skipped).
-		$this->assertArrayNotHasKey( 'mimeType', $arr );
+		// The descriptor carries whatever the author declared.
+		$this->assertArrayHasKey( 'mimeType', $arr );
+		$this->assertSame( 'not//valid', $arr['mimeType'] );
 	}
 
 	public function test_size_field_is_included(): void {


### PR DESCRIPTION
## What?

See #245.

Emit `mimeType` as declared. MCP places no format constraint on `mimeType` on any object that carries one, so presence and type are the only checks that apply.

- remove `validate_mime_type()`, `validate_image_mime_type()`, `validate_audio_mime_type()`, `validate_icon_mime_type()` and the icon MIME allow-list, with their call sites
- keep a `mimeType` when it is a non-empty string and emit the value as written
- `image` and `audio` content blocks still require a `mimeType`, which the schema marks required there

First of three stacked PRs splitting #260, which carries the same change as one branch.
Review order is #262 → #263 → #264. To exercise all three together, test #260.

## Why?

The adapter validated `mimeType` against an RFC 2045 pattern that rejects parameters, and icons against a fixed allow-list. Neither constraint comes from MCP, which types `mimeType` as a plain string everywhere it appears.

The pattern drops any media type carrying a parameter. `text/html;profile=mcp-app` is the media type an MCP Apps UI template declares, so a UI resource never reached the `resources/list` descriptor with the type that identifies it.

## How?

The four validators are removed rather than relaxed: with the format constraint gone, each reduces to `is_string()`, which the call sites already do.

Icon `mimeType` keeps its type check and loses the allow-list. The spec states which types a *client* must support; it does not restrict what a server may declare, and an icon a given client cannot render is that client's decision to make.

`McpResource` and `RegisterAbilityAsMcpResource` keep the `'' !== $mime_type` guard, so an empty or whitespace-only value is still omitted rather than emitted as an empty string.

### Behaviour changes

- a `mimeType` carrying RFC 2045 parameters, such as `text/html;profile=mcp-app`, reaches the `resources/list` descriptor instead of being dropped
- any `mimeType` string now survives to the wire as written, on every object that carries one
- an icon declaring a MIME type outside the previous allow-list is kept rather than skipped
- prompt message `image` and `audio` blocks no longer require the type to start with `image/` or `audio/`; a `mimeType` is still required
- four `public static` methods are removed from `McpValidator`

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code, Codex CLI
Model(s): Claude Opus 5, Claude Fable 5, GPT-5.6 Sol
Used for: Implementation and review. Every change was verified manually by me.

## Testing Instructions

1. Register a resource ability with `meta.mcp.mimeType` set to `text/html;profile=mcp-app` and confirm `resources/list` carries that exact string on the descriptor, unaltered.
2. Register a component with an icon whose `mimeType` is `image/avif` and confirm the icon is kept rather than skipped.
3. Return a prompt message `image` block with `mimeType` set to `application/octet-stream` and confirm the message renders rather than failing validation. Remove `mimeType` entirely and confirm it still fails.
4. Run `composer test`, `composer lint` and `composer phpstan`.

## Changelog Entry

> Fixed - Emit `mimeType` as declared, so a media type carrying parameters such as `text/html;profile=mcp-app` reaches the client unaltered.
