### PR TITLE
Scope MCP session user_meta by blog_id

### DIFF
--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -27,11 +27,26 @@ use WP_Error;
 final class SessionManager {
 
 	/**
-	 * User meta key for storing sessions
+	 * Base user meta key for storing sessions.
+	 *
+	 * The stored key is blog-scoped via {@see session_meta_key()} because
+	 * user meta is network-global on multisite. Without a blog suffix, two
+	 * site-local MCP connectors for the same user share one session map.
 	 *
 	 * @var string
 	 */
 	private const SESSION_META_KEY = 'mcp_adapter_sessions';
+
+	/**
+	 * User meta key for the current blog's session map.
+	 *
+	 * @since n.e.x.t
+	 */
+	private static function session_meta_key(): string {
+		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+
+		return self::SESSION_META_KEY . '_' . $blog_id;
+	}
 
 	/**
 	 * Maximum sessions per user.
@@ -147,7 +162,7 @@ final class SessionManager {
 				return true;
 			}
 
-			$updated = update_user_meta( $user_id, self::SESSION_META_KEY, $updated_sessions, $previous_sessions );
+			$updated = update_user_meta( $user_id, self::session_meta_key(), $updated_sessions, $previous_sessions );
 			if ( false !== $updated ) {
 				return true;
 			}
@@ -217,7 +232,7 @@ final class SessionManager {
 			return array();
 		}
 
-		$sessions = get_user_meta( $user_id, self::SESSION_META_KEY, true );
+		$sessions = get_user_meta( $user_id, self::session_meta_key(), true );
 
 		if ( ! is_array( $sessions ) ) {
 			return array();

--- a/tests/phpunit/Fixtures/ConcurrentSessionWorker.php
+++ b/tests/phpunit/Fixtures/ConcurrentSessionWorker.php
@@ -20,7 +20,7 @@ try {
 	add_filter(
 		'update_user_metadata',
 		static function ( $check, $object_id, $meta_key ) use ( $wp_mcp_test_barrier_dir, $wp_mcp_test_user_id, $wp_mcp_test_worker_id ) {
-			if ( $wp_mcp_test_user_id !== $object_id || 'mcp_adapter_sessions' !== $meta_key ) {
+			if ( $wp_mcp_test_user_id !== $object_id || 'mcp_adapter_sessions_' . get_current_blog_id() !== $meta_key ) {
 				return $check;
 			}
 

--- a/tests/phpunit/Integration/Transport/McpSessionManagerConcurrencyTest.php
+++ b/tests/phpunit/Integration/Transport/McpSessionManagerConcurrencyTest.php
@@ -147,7 +147,7 @@ final class McpSessionManagerConcurrencyTest extends TestCase {
 			foreach ( $session_ids as $session_id ) {
 				$this->assertArrayHasKey( $session_id, $sessions );
 			}
-			$this->assertCount( 1, get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', false ) );
+			$this->assertCount( 1, get_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), false ) );
 		} finally {
 			if ( ! file_exists( $barrier_dir . '/go' ) ) {
 				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Releases test-owned worker processes during cleanup.

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
@@ -497,7 +497,7 @@ final class HttpRequestHandlerTest extends TestCase {
 
 		// The session header is set via a rest_post_dispatch filter which doesn't
 		// fire in unit tests. Read the session ID directly from user meta instead.
-		$sessions = get_user_meta( get_current_user_id(), 'mcp_adapter_sessions', true );
+		$sessions = get_user_meta( get_current_user_id(), 'mcp_adapter_sessions_' . get_current_blog_id(), true );
 		$this->assertNotEmpty( $sessions, 'Initialize must create a session in user meta' );
 
 		// Return the most recently created session ID.

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
@@ -35,7 +35,7 @@ final class HttpSessionValidatorTest extends TestCase {
 	public function tear_down(): void {
 		// Clean up all sessions for test user
 		if ( $this->test_user_id ) {
-			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions' );
+			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() );
 			wp_delete_user( $this->test_user_id );
 		}
 

--- a/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -66,7 +66,7 @@ final class RequestRouterTest extends TestCase {
 	public function tear_down(): void {
 		// Clean up test user
 		if ( $this->test_user_id ) {
-			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions' );
+			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() );
 			wp_delete_user( $this->test_user_id );
 		}
 
@@ -144,7 +144,7 @@ final class RequestRouterTest extends TestCase {
 	public function test_route_request_logs_exhausted_session_update_retries(): void {
 		$attempts              = 0;
 		$block_session_updates = static function ( $check, $object_id, $meta_key ) use ( &$attempts ) {
-			if ( 'mcp_adapter_sessions' !== $meta_key ) {
+			if ( 'mcp_adapter_sessions_' . get_current_blog_id() !== $meta_key ) {
 				return $check;
 			}
 

--- a/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
+++ b/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
@@ -49,7 +49,7 @@ final class McpSessionManagerTest extends TestCase {
 	public function tear_down(): void {
 		// Clean up all sessions for test user
 		if ( $this->test_user_id ) {
-			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions' );
+			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() );
 			wp_delete_user( $this->test_user_id );
 		}
 
@@ -75,6 +75,19 @@ final class McpSessionManagerTest extends TestCase {
 		$this->assertCount( 1, $sessions );
 		$this->assertArrayHasKey( $session_id, $sessions );
 		$this->assertSame( $client_info, $sessions[ $session_id ]['client_params'] );
+	}
+
+	/**
+	 * Sessions must live under a blog-scoped meta key (user meta is network-global).
+	 */
+	public function test_create_session_uses_blog_scoped_meta_key(): void {
+		$session_id = SessionManager::create_session( $this->test_user_id, array() );
+		$this->assertIsString( $session_id );
+
+		$blog_key = 'mcp_adapter_sessions_' . get_current_blog_id();
+		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, $blog_key ) );
+		$this->assertFalse( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions' ) );
+		$this->assertArrayHasKey( $session_id, get_user_meta( $this->test_user_id, $blog_key, true ) );
 	}
 
 	/**
@@ -157,8 +170,8 @@ final class McpSessionManagerTest extends TestCase {
 		// Verify session is gone
 		$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$this->assertCount( 0, $sessions );
-		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions' ) );
-		$this->assertSame( array(), get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', true ) );
+		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() ) );
+		$this->assertSame( array(), get_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), true ) );
 	}
 
 	/**
@@ -221,7 +234,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Manually modify one session to be expired
 		$sessions                                   = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $session_id_1 ]['last_activity'] = time() - ( DAY_IN_SECONDS + 3600 ); // Over 24 hours ago
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		// Run cleanup
 		$removed = SessionManager::cleanup_expired_sessions( $this->test_user_id );
@@ -274,7 +287,7 @@ final class McpSessionManagerTest extends TestCase {
 		$sessions                                 = \WP\MCP\Transport\Infrastructure\SessionManager::get_all_user_sessions( $this->test_user_id );
 		$old_timestamp                            = time() - 61;
 		$sessions[ $session_id ]['last_activity'] = $old_timestamp;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		// Validate session (should update last_activity)
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $session_id );
@@ -319,7 +332,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Manually expire the session by backdating its last_activity
 		$sessions                                    = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $short_session ]['last_activity'] = time() - 3;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $short_session );
 		$this->assertFalse( $is_valid ); // Should be expired
@@ -360,7 +373,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Backdate one session to make it expired
 		$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $expired_session_id ]['last_activity'] = time() - ( DAY_IN_SECONDS + 3600 );
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		// Validate the valid session
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $valid_session_id );
@@ -389,7 +402,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Backdate last_activity by 16s (more than half of 30s timeout = clamped interval of 15s)
 		$sessions                                 = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $session_id ]['last_activity'] = time() - 16;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		// Validate — should succeed AND update last_activity because 16s > clamped interval (15s)
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $session_id );


### PR DESCRIPTION
## Summary
- Store Streamable HTTP sessions under `mcp_adapter_sessions_{blog_id}` instead of a single network-global `mcp_adapter_sessions` user_meta map.
- On WordPress multisite, user meta is shared across the network; without a blog suffix, two site-local MCP connectors for the same WP user share one session map and can still collide even after #251 CAS retries (especially on first concurrent `initialize` when `$prev_value` is empty).
- Builds on #251; does not change CAS / `mutate_sessions` behaviour.

Related: WordPress/mcp-adapter#239 / #251.
