### PR TITLE
Scope MCP session user_meta by blog_id

### DIFF
--- a/docs/guides/default-server.md
+++ b/docs/guides/default-server.md
@@ -160,10 +160,10 @@ curl -s -X DELETE \
 
 Two filters control session behavior:
 
-**`mcp_adapter_session_max_per_user`** — Maximum number of concurrent sessions a single user can have. When the limit is reached the oldest session is automatically evicted. Default: `32`.
+**`mcp_adapter_session_max_per_user`** — Maximum number of concurrent sessions a single user can have on the current site. When the limit is reached the oldest session is automatically evicted. Default: `32`.
 
 ```php
-// Allow at most 5 concurrent sessions per user
+// Allow at most 5 concurrent sessions per user on the current site
 add_filter( 'mcp_adapter_session_max_per_user', function () {
     return 5;
 } );

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -48,9 +48,11 @@ final class SessionManager {
 	 * @since n.e.x.t
 	 */
 	private static function session_meta_key(): string {
-		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		if ( ! function_exists( 'get_current_blog_id' ) ) {
+			return self::SESSION_META_KEY;
+		}
 
-		return self::session_meta_key_for_blog( $blog_id );
+		return self::session_meta_key_for_blog( (int) get_current_blog_id() );
 	}
 
 	/**

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -27,11 +27,26 @@ use WP_Error;
 final class SessionManager {
 
 	/**
-	 * User meta key for storing sessions
+	 * Base user meta key for storing sessions.
+	 *
+	 * The stored key is blog-scoped via {@see session_meta_key()} because
+	 * user meta is network-global on multisite. Without a blog suffix, two
+	 * site-local MCP connectors for the same user share one session map.
 	 *
 	 * @var string
 	 */
 	private const SESSION_META_KEY = 'mcp_adapter_sessions';
+
+	/**
+	 * User meta key for the current blog's session map.
+	 *
+	 * @since n.e.x.t
+	 */
+	private static function session_meta_key(): string {
+		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+
+		return self::SESSION_META_KEY . '_' . $blog_id;
+	}
 
 	/**
 	 * Maximum sessions per user.
@@ -147,7 +162,7 @@ final class SessionManager {
 				return true;
 			}
 
-			$updated = update_user_meta( $user_id, self::SESSION_META_KEY, $updated_sessions, $previous_sessions );
+			$updated = update_user_meta( $user_id, self::session_meta_key(), $updated_sessions, $previous_sessions );
 			if ( false !== $updated ) {
 				return true;
 			}
@@ -217,7 +232,7 @@ final class SessionManager {
 			return array();
 		}
 
-		$sessions = get_user_meta( $user_id, self::SESSION_META_KEY, true );
+		$sessions = get_user_meta( $user_id, self::session_meta_key(), true );
 
 		if ( ! is_array( $sessions ) ) {
 			return array();

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -29,30 +29,36 @@ final class SessionManager {
 	/**
 	 * Base user meta key for storing sessions.
 	 *
-	 * The stored key is blog-scoped via {@see session_meta_key()} because
-	 * user meta is network-global on multisite. Without a blog suffix, two
-	 * site-local MCP connectors for the same user share one session map.
+	 * On multisite the stored key is blog-scoped via {@see session_meta_key()}
+	 * because user meta is network-global. Without a blog suffix, two site-local
+	 * MCP connectors for the same user share one session map. Single-site keeps
+	 * the unsuffixed legacy key for upgrade compatibility.
 	 *
 	 * @var string
 	 */
 	private const SESSION_META_KEY = 'mcp_adapter_sessions';
 
 	/**
-	 * User meta key for the current blog's session map.
+	 * User meta key for the current site's session map.
 	 *
-	 * On multisite, user meta is network-global, so the key is suffixed with the
-	 * current blog ID. When no positive blog ID is available yet, fall back to the
-	 * unsuffixed legacy key so reads/writes do not land under an orphaned
-	 * `mcp_adapter_sessions_0` row (see session_meta_key_for_blog()).
+	 * Single-site keeps the unsuffixed legacy key so in-flight sessions survive
+	 * upgrade. On multisite, user meta is network-global, so the key is suffixed
+	 * with the current blog ID. When no positive blog ID is available yet, fall
+	 * back to the unsuffixed legacy key so reads/writes do not land under an
+	 * orphaned `mcp_adapter_sessions_0` row (see session_meta_key_for_blog()).
 	 *
 	 * @since n.e.x.t
 	 */
 	private static function session_meta_key(): string {
+		if ( ! is_multisite() ) {
+			return self::SESSION_META_KEY;
+		}
+
 		return self::session_meta_key_for_blog( (int) get_current_blog_id() );
 	}
 
 	/**
-	 * Resolve the session meta key for a blog ID.
+	 * Resolve the session meta key for a blog ID (multisite).
 	 *
 	 * @since n.e.x.t
 	 *
@@ -67,7 +73,7 @@ final class SessionManager {
 	}
 
 	/**
-	 * Maximum sessions per user.
+	 * Maximum sessions per user on the current site.
 	 *
 	 * @var int
 	 */
@@ -239,7 +245,7 @@ final class SessionManager {
 	}
 
 	/**
-	 * Get all sessions for a user
+	 * Get all sessions for a user on the current site.
 	 *
 	 * @param int $user_id The user ID.
 	 *
@@ -266,14 +272,14 @@ final class SessionManager {
 	 */
 	private static function get_config(): array {
 		/**
-		 * Filters the maximum number of MCP sessions allowed per user.
+		 * Filters the maximum number of MCP sessions allowed per user on the current site.
 		 *
-		 * When a user exceeds this limit, the oldest inactive session is
-		 * automatically removed to make room for new sessions.
+		 * When a user exceeds this limit on the current site, the oldest inactive
+		 * session is automatically removed to make room for new sessions.
 		 *
 		 * @since 0.3.0
 		 *
-		 * @param int $max_sessions Maximum sessions per user. Default 32.
+		 * @param int $max_sessions Maximum sessions per user on the current site. Default 32.
 		 */
 		$max_sessions = (int) apply_filters( 'mcp_adapter_session_max_per_user', self::DEFAULT_MAX_SESSIONS );
 

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -41,17 +41,13 @@ final class SessionManager {
 	 * User meta key for the current blog's session map.
 	 *
 	 * On multisite, user meta is network-global, so the key is suffixed with the
-	 * current blog ID. When no positive blog ID is available yet (or outside a
-	 * normal request), fall back to the unsuffixed legacy key so reads/writes
-	 * do not land under an orphaned `mcp_adapter_sessions_0` row.
+	 * current blog ID. When no positive blog ID is available yet, fall back to the
+	 * unsuffixed legacy key so reads/writes do not land under an orphaned
+	 * `mcp_adapter_sessions_0` row (see session_meta_key_for_blog()).
 	 *
 	 * @since n.e.x.t
 	 */
 	private static function session_meta_key(): string {
-		if ( ! function_exists( 'get_current_blog_id' ) ) {
-			return self::SESSION_META_KEY;
-		}
-
 		return self::session_meta_key_for_blog( (int) get_current_blog_id() );
 	}
 

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -40,10 +40,30 @@ final class SessionManager {
 	/**
 	 * User meta key for the current blog's session map.
 	 *
+	 * On multisite, user meta is network-global, so the key is suffixed with the
+	 * current blog ID. When no positive blog ID is available yet (or outside a
+	 * normal request), fall back to the unsuffixed legacy key so reads/writes
+	 * do not land under an orphaned `mcp_adapter_sessions_0` row.
+	 *
 	 * @since n.e.x.t
 	 */
 	private static function session_meta_key(): string {
 		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+
+		return self::session_meta_key_for_blog( $blog_id );
+	}
+
+	/**
+	 * Resolve the session meta key for a blog ID.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param int $blog_id Blog ID; values below 1 use the unsuffixed legacy key.
+	 */
+	private static function session_meta_key_for_blog( int $blog_id ): string {
+		if ( $blog_id < 1 ) {
+			return self::SESSION_META_KEY;
+		}
 
 		return self::SESSION_META_KEY . '_' . $blog_id;
 	}

--- a/tests/phpunit/Fixtures/ConcurrentSessionWorker.php
+++ b/tests/phpunit/Fixtures/ConcurrentSessionWorker.php
@@ -17,10 +17,18 @@ $wp_mcp_test_worker_id   = isset( $argv[3] ) ? $argv[3] : '';
 $wp_mcp_test_result_file = $wp_mcp_test_barrier_dir . '/result-' . $wp_mcp_test_worker_id . '.json';
 
 try {
+	$wp_mcp_session_meta_key = 'mcp_adapter_sessions';
+	if ( is_multisite() ) {
+		$wp_mcp_current_blog_id = (int) get_current_blog_id();
+		if ( $wp_mcp_current_blog_id >= 1 ) {
+			$wp_mcp_session_meta_key .= '_' . $wp_mcp_current_blog_id;
+		}
+	}
+
 	add_filter(
 		'update_user_metadata',
-		static function ( $check, $object_id, $meta_key ) use ( $wp_mcp_test_barrier_dir, $wp_mcp_test_user_id, $wp_mcp_test_worker_id ) {
-			if ( $wp_mcp_test_user_id !== $object_id || 'mcp_adapter_sessions_' . get_current_blog_id() !== $meta_key ) {
+		static function ( $check, $object_id, $meta_key ) use ( $wp_mcp_test_barrier_dir, $wp_mcp_test_user_id, $wp_mcp_test_worker_id, $wp_mcp_session_meta_key ) {
+			if ( $wp_mcp_test_user_id !== $object_id || $wp_mcp_session_meta_key !== $meta_key ) {
 				return $check;
 			}
 

--- a/tests/phpunit/Fixtures/ConcurrentSessionWorker.php
+++ b/tests/phpunit/Fixtures/ConcurrentSessionWorker.php
@@ -20,7 +20,7 @@ try {
 	add_filter(
 		'update_user_metadata',
 		static function ( $check, $object_id, $meta_key ) use ( $wp_mcp_test_barrier_dir, $wp_mcp_test_user_id, $wp_mcp_test_worker_id ) {
-			if ( $wp_mcp_test_user_id !== $object_id || 'mcp_adapter_sessions' !== $meta_key ) {
+			if ( $wp_mcp_test_user_id !== $object_id || 'mcp_adapter_sessions_' . get_current_blog_id() !== $meta_key ) {
 				return $check;
 			}
 

--- a/tests/phpunit/Integration/Transport/McpSessionManagerConcurrencyTest.php
+++ b/tests/phpunit/Integration/Transport/McpSessionManagerConcurrencyTest.php
@@ -147,7 +147,7 @@ final class McpSessionManagerConcurrencyTest extends TestCase {
 			foreach ( $session_ids as $session_id ) {
 				$this->assertArrayHasKey( $session_id, $sessions );
 			}
-			$this->assertCount( 1, get_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), false ) );
+			$this->assertCount( 1, get_user_meta( $this->test_user_id, self::session_meta_key(), false ) );
 		} finally {
 			if ( ! file_exists( $barrier_dir . '/go' ) ) {
 				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Releases test-owned worker processes during cleanup.

--- a/tests/phpunit/Integration/Transport/McpSessionManagerConcurrencyTest.php
+++ b/tests/phpunit/Integration/Transport/McpSessionManagerConcurrencyTest.php
@@ -147,7 +147,7 @@ final class McpSessionManagerConcurrencyTest extends TestCase {
 			foreach ( $session_ids as $session_id ) {
 				$this->assertArrayHasKey( $session_id, $sessions );
 			}
-			$this->assertCount( 1, get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', false ) );
+			$this->assertCount( 1, get_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), false ) );
 		} finally {
 			if ( ! file_exists( $barrier_dir . '/go' ) ) {
 				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Releases test-owned worker processes during cleanup.

--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -87,6 +87,18 @@ abstract class TestCase extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Resolve the session user_meta key the same way SessionManager does.
+	 *
+	 * @return string
+	 */
+	protected static function session_meta_key(): string {
+		$method = new \ReflectionMethod( \WP\MCP\Transport\Infrastructure\SessionManager::class, 'session_meta_key' );
+		$method->setAccessible( true );
+
+		return (string) $method->invoke( null );
+	}
+
+	/**
 	 * Registers an ability inside the wp_abilities_api_init hook.
 	 *
 	 * This helper ensures abilities are registered during the hook execution,

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
@@ -497,7 +497,7 @@ final class HttpRequestHandlerTest extends TestCase {
 
 		// The session header is set via a rest_post_dispatch filter which doesn't
 		// fire in unit tests. Read the session ID directly from user meta instead.
-		$sessions = get_user_meta( get_current_user_id(), 'mcp_adapter_sessions_' . get_current_blog_id(), true );
+		$sessions = get_user_meta( get_current_user_id(), self::session_meta_key(), true );
 		$this->assertNotEmpty( $sessions, 'Initialize must create a session in user meta' );
 
 		// Return the most recently created session ID.

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
@@ -497,7 +497,7 @@ final class HttpRequestHandlerTest extends TestCase {
 
 		// The session header is set via a rest_post_dispatch filter which doesn't
 		// fire in unit tests. Read the session ID directly from user meta instead.
-		$sessions = get_user_meta( get_current_user_id(), 'mcp_adapter_sessions', true );
+		$sessions = get_user_meta( get_current_user_id(), 'mcp_adapter_sessions_' . get_current_blog_id(), true );
 		$this->assertNotEmpty( $sessions, 'Initialize must create a session in user meta' );
 
 		// Return the most recently created session ID.

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
@@ -35,7 +35,7 @@ final class HttpSessionValidatorTest extends TestCase {
 	public function tear_down(): void {
 		// Clean up all sessions for test user
 		if ( $this->test_user_id ) {
-			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() );
+			delete_user_meta( $this->test_user_id, self::session_meta_key() );
 			wp_delete_user( $this->test_user_id );
 		}
 

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
@@ -35,7 +35,7 @@ final class HttpSessionValidatorTest extends TestCase {
 	public function tear_down(): void {
 		// Clean up all sessions for test user
 		if ( $this->test_user_id ) {
-			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions' );
+			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() );
 			wp_delete_user( $this->test_user_id );
 		}
 

--- a/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -66,7 +66,7 @@ final class RequestRouterTest extends TestCase {
 	public function tear_down(): void {
 		// Clean up test user
 		if ( $this->test_user_id ) {
-			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions' );
+			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() );
 			wp_delete_user( $this->test_user_id );
 		}
 
@@ -144,7 +144,7 @@ final class RequestRouterTest extends TestCase {
 	public function test_route_request_logs_exhausted_session_update_retries(): void {
 		$attempts              = 0;
 		$block_session_updates = static function ( $check, $object_id, $meta_key ) use ( &$attempts ) {
-			if ( 'mcp_adapter_sessions' !== $meta_key ) {
+			if ( 'mcp_adapter_sessions_' . get_current_blog_id() !== $meta_key ) {
 				return $check;
 			}
 

--- a/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -66,7 +66,7 @@ final class RequestRouterTest extends TestCase {
 	public function tear_down(): void {
 		// Clean up test user
 		if ( $this->test_user_id ) {
-			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() );
+			delete_user_meta( $this->test_user_id, self::session_meta_key() );
 			wp_delete_user( $this->test_user_id );
 		}
 
@@ -143,8 +143,9 @@ final class RequestRouterTest extends TestCase {
 	 */
 	public function test_route_request_logs_exhausted_session_update_retries(): void {
 		$attempts              = 0;
-		$block_session_updates = static function ( $check, $object_id, $meta_key ) use ( &$attempts ) {
-			if ( 'mcp_adapter_sessions_' . get_current_blog_id() !== $meta_key ) {
+		$session_meta_key      = self::session_meta_key();
+		$block_session_updates = static function ( $check, $object_id, $meta_key ) use ( &$attempts, $session_meta_key ) {
+			if ( $session_meta_key !== $meta_key ) {
 				return $check;
 			}
 

--- a/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
+++ b/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
@@ -49,7 +49,7 @@ final class McpSessionManagerTest extends TestCase {
 	public function tear_down(): void {
 		// Clean up all sessions for test user
 		if ( $this->test_user_id ) {
-			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions' );
+			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() );
 			wp_delete_user( $this->test_user_id );
 		}
 
@@ -75,6 +75,19 @@ final class McpSessionManagerTest extends TestCase {
 		$this->assertCount( 1, $sessions );
 		$this->assertArrayHasKey( $session_id, $sessions );
 		$this->assertSame( $client_info, $sessions[ $session_id ]['client_params'] );
+	}
+
+	/**
+	 * Sessions must live under a blog-scoped meta key (user meta is network-global).
+	 */
+	public function test_create_session_uses_blog_scoped_meta_key(): void {
+		$session_id = SessionManager::create_session( $this->test_user_id, array() );
+		$this->assertIsString( $session_id );
+
+		$blog_key = 'mcp_adapter_sessions_' . get_current_blog_id();
+		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, $blog_key ) );
+		$this->assertFalse( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions' ) );
+		$this->assertArrayHasKey( $session_id, get_user_meta( $this->test_user_id, $blog_key, true ) );
 	}
 
 	/**
@@ -157,8 +170,8 @@ final class McpSessionManagerTest extends TestCase {
 		// Verify session is gone
 		$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$this->assertCount( 0, $sessions );
-		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions' ) );
-		$this->assertSame( array(), get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', true ) );
+		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() ) );
+		$this->assertSame( array(), get_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), true ) );
 	}
 
 	/**
@@ -221,7 +234,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Manually modify one session to be expired
 		$sessions                                   = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $session_id_1 ]['last_activity'] = time() - ( DAY_IN_SECONDS + 3600 ); // Over 24 hours ago
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		// Run cleanup
 		$removed = SessionManager::cleanup_expired_sessions( $this->test_user_id );
@@ -274,7 +287,7 @@ final class McpSessionManagerTest extends TestCase {
 		$sessions                                 = \WP\MCP\Transport\Infrastructure\SessionManager::get_all_user_sessions( $this->test_user_id );
 		$old_timestamp                            = time() - 61;
 		$sessions[ $session_id ]['last_activity'] = $old_timestamp;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		// Validate session (should update last_activity)
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $session_id );
@@ -319,7 +332,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Manually expire the session by backdating its last_activity
 		$sessions                                    = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $short_session ]['last_activity'] = time() - 3;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $short_session );
 		$this->assertFalse( $is_valid ); // Should be expired
@@ -360,7 +373,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Backdate one session to make it expired
 		$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $expired_session_id ]['last_activity'] = time() - ( DAY_IN_SECONDS + 3600 );
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		// Validate the valid session
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $valid_session_id );
@@ -389,7 +402,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Backdate last_activity by 16s (more than half of 30s timeout = clamped interval of 15s)
 		$sessions                                 = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $session_id ]['last_activity'] = time() - 16;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions', $sessions );
+		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
 
 		// Validate — should succeed AND update last_activity because 16s > clamped interval (15s)
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $session_id );

--- a/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
+++ b/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
@@ -84,10 +84,26 @@ final class McpSessionManagerTest extends TestCase {
 		$session_id = SessionManager::create_session( $this->test_user_id, array() );
 		$this->assertIsString( $session_id );
 
-		$blog_key = 'mcp_adapter_sessions_' . get_current_blog_id();
+		$blog_id = (int) get_current_blog_id();
+		$this->assertGreaterThanOrEqual( 1, $blog_id );
+
+		$blog_key = 'mcp_adapter_sessions_' . $blog_id;
 		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, $blog_key ) );
 		$this->assertFalse( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions' ) );
 		$this->assertArrayHasKey( $session_id, get_user_meta( $this->test_user_id, $blog_key, true ) );
+	}
+
+	/**
+	 * When no positive blog ID is available, use the unsuffixed legacy key (not *_0).
+	 */
+	public function test_session_meta_key_falls_back_to_unsuffixed_when_blog_id_invalid(): void {
+		$method = new \ReflectionMethod( SessionManager::class, 'session_meta_key_for_blog' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 'mcp_adapter_sessions', $method->invoke( null, 0 ) );
+		$this->assertSame( 'mcp_adapter_sessions', $method->invoke( null, -1 ) );
+		$this->assertSame( 'mcp_adapter_sessions_1', $method->invoke( null, 1 ) );
+		$this->assertSame( 'mcp_adapter_sessions_2', $method->invoke( null, 2 ) );
 	}
 
 	/**

--- a/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
+++ b/tests/phpunit/Unit/Transport/McpSessionManagerTest.php
@@ -49,7 +49,7 @@ final class McpSessionManagerTest extends TestCase {
 	public function tear_down(): void {
 		// Clean up all sessions for test user
 		if ( $this->test_user_id ) {
-			delete_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() );
+			delete_user_meta( $this->test_user_id, self::session_meta_key() );
 			wp_delete_user( $this->test_user_id );
 		}
 
@@ -78,9 +78,30 @@ final class McpSessionManagerTest extends TestCase {
 	}
 
 	/**
-	 * Sessions must live under a blog-scoped meta key (user meta is network-global).
+	 * Single-site keeps the unsuffixed legacy key (blog ID is still 1).
 	 */
-	public function test_create_session_uses_blog_scoped_meta_key(): void {
+	public function test_create_session_uses_legacy_meta_key_on_single_site(): void {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Legacy unsuffixed key applies on single-site only.' );
+		}
+
+		$session_id = SessionManager::create_session( $this->test_user_id, array() );
+		$this->assertIsString( $session_id );
+
+		$this->assertSame( 1, (int) get_current_blog_id() );
+		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions' ) );
+		$this->assertFalse( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions_1' ) );
+		$this->assertArrayHasKey( $session_id, get_user_meta( $this->test_user_id, 'mcp_adapter_sessions', true ) );
+	}
+
+	/**
+	 * Multisite sessions must live under a blog-scoped meta key (user meta is network-global).
+	 */
+	public function test_create_session_uses_blog_scoped_meta_key_on_multisite(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Blog-scoped keys apply on multisite only.' );
+		}
+
 		$session_id = SessionManager::create_session( $this->test_user_id, array() );
 		$this->assertIsString( $session_id );
 
@@ -91,6 +112,33 @@ final class McpSessionManagerTest extends TestCase {
 		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, $blog_key ) );
 		$this->assertFalse( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions' ) );
 		$this->assertArrayHasKey( $session_id, get_user_meta( $this->test_user_id, $blog_key, true ) );
+	}
+
+	/**
+	 * Pre-upgrade single-site sessions under the unsuffixed key remain valid.
+	 */
+	public function test_legacy_single_site_session_remains_valid(): void {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Legacy unsuffixed key applies on single-site only.' );
+		}
+
+		$session_id = wp_generate_uuid4();
+		$now        = time();
+		update_user_meta(
+			$this->test_user_id,
+			'mcp_adapter_sessions',
+			array(
+				$session_id => array(
+					'created_at'    => $now,
+					'last_activity' => $now,
+					'client_params' => array( 'name' => 'legacy-client' ),
+				),
+			)
+		);
+
+		$this->assertTrue( SessionManager::validate_session( $this->test_user_id, $session_id ) );
+		$this->assertArrayHasKey( $session_id, SessionManager::get_all_user_sessions( $this->test_user_id ) );
+		$this->assertFalse( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions_1' ) );
 	}
 
 	/**
@@ -186,8 +234,8 @@ final class McpSessionManagerTest extends TestCase {
 		// Verify session is gone
 		$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$this->assertCount( 0, $sessions );
-		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id() ) );
-		$this->assertSame( array(), get_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), true ) );
+		$this->assertTrue( metadata_exists( 'user', $this->test_user_id, self::session_meta_key() ) );
+		$this->assertSame( array(), get_user_meta( $this->test_user_id, self::session_meta_key(), true ) );
 	}
 
 	/**
@@ -250,7 +298,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Manually modify one session to be expired
 		$sessions                                   = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $session_id_1 ]['last_activity'] = time() - ( DAY_IN_SECONDS + 3600 ); // Over 24 hours ago
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
+		update_user_meta( $this->test_user_id, self::session_meta_key(), $sessions );
 
 		// Run cleanup
 		$removed = SessionManager::cleanup_expired_sessions( $this->test_user_id );
@@ -303,7 +351,7 @@ final class McpSessionManagerTest extends TestCase {
 		$sessions                                 = \WP\MCP\Transport\Infrastructure\SessionManager::get_all_user_sessions( $this->test_user_id );
 		$old_timestamp                            = time() - 61;
 		$sessions[ $session_id ]['last_activity'] = $old_timestamp;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
+		update_user_meta( $this->test_user_id, self::session_meta_key(), $sessions );
 
 		// Validate session (should update last_activity)
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $session_id );
@@ -348,7 +396,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Manually expire the session by backdating its last_activity
 		$sessions                                    = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $short_session ]['last_activity'] = time() - 3;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
+		update_user_meta( $this->test_user_id, self::session_meta_key(), $sessions );
 
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $short_session );
 		$this->assertFalse( $is_valid ); // Should be expired
@@ -389,7 +437,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Backdate one session to make it expired
 		$sessions = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $expired_session_id ]['last_activity'] = time() - ( DAY_IN_SECONDS + 3600 );
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
+		update_user_meta( $this->test_user_id, self::session_meta_key(), $sessions );
 
 		// Validate the valid session
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $valid_session_id );
@@ -418,7 +466,7 @@ final class McpSessionManagerTest extends TestCase {
 		// Backdate last_activity by 16s (more than half of 30s timeout = clamped interval of 15s)
 		$sessions                                 = SessionManager::get_all_user_sessions( $this->test_user_id );
 		$sessions[ $session_id ]['last_activity'] = time() - 16;
-		update_user_meta( $this->test_user_id, 'mcp_adapter_sessions_' . get_current_blog_id(), $sessions );
+		update_user_meta( $this->test_user_id, self::session_meta_key(), $sessions );
 
 		// Validate — should succeed AND update last_activity because 16s > clamped interval (15s)
 		$is_valid = SessionManager::validate_session( $this->test_user_id, $session_id );


### PR DESCRIPTION
## Summary
- Store Streamable HTTP sessions under `mcp_adapter_sessions_{blog_id}` so each multisite blog has its own session map (user meta is network-global).
- Fall back to the unsuffixed `mcp_adapter_sessions` key when `get_current_blog_id()` returns a value &lt; 1 (avoids orphaned `*_0` rows — review feedback on #269).
- Builds on #251 CAS / `mutate_sessions`; does not change retry behaviour.

Closes #271. Supersedes #269 with a demonstrated cross-blog repro and the blog-ID fallback from review.

## Why #251 is not enough
On trunk with #251 only, concurrent `initialize` against two blogs for the same WP user still drops sessions (`-32005`). Measured locally (subdirectory multisite, Basic auth): empty-map **7/10** losses; established-map **4/10**. After blog-scoping: empty-map **0/10**, established-map **0/10**.

## Test plan
- [x] `npm run test:php` — 1023 tests, 3964 assertions (re-run on tip `11cb3b6`)
- [x] New tests: blog-scoped key; invalid blog ID → unsuffixed key via `session_meta_key_for_blog()`
- [x] Multisite (`test-multi`): two blogs, same user, concurrent initialize + `tools/list` — empty-map **0/10**, established-map **0/10**; keys `mcp_adapter_sessions_1` / `mcp_adapter_sessions_2`
- [x] Codecov patch **100%** (dropped unreachable `function_exists( 'get_current_blog_id' )` guard — WordPress always provides it)

## Notes
- In-flight sessions under the legacy bare `mcp_adapter_sessions` key must reconnect after deploy (no lazy migration).