### PR TITLE
chore(deps): bump wordpress/php-mcp-schema to v0.1.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -72,16 +72,16 @@
         },
         {
             "name": "wordpress/php-mcp-schema",
-            "version": "v0.1.2",
+            "version": "v0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-mcp-schema",
-                "reference": "95df8a50a3bd54f6b7c4869c6e2185db380d4d63"
+                "reference": "b2fcf97aa023ce46e9f03493c194a72d5a46bea2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/95df8a50a3bd54f6b7c4869c6e2185db380d4d63",
-                "reference": "95df8a50a3bd54f6b7c4869c6e2185db380d4d63",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/b2fcf97aa023ce46e9f03493c194a72d5a46bea2",
+                "reference": "b2fcf97aa023ce46e9f03493c194a72d5a46bea2",
                 "shasum": ""
             },
             "require": {
@@ -115,7 +115,7 @@
                 "php",
                 "schema"
             ],
-            "time": "2026-06-05T08:26:32+00:00"
+            "time": "2026-08-10T09:12:14+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/phpunit/Unit/Tools/McpToolTest.php
+++ b/tests/phpunit/Unit/Tools/McpToolTest.php
@@ -229,12 +229,12 @@ final class McpToolTest extends TestCase {
 		$this->assertSame( 'A comprehensive test tool', $dto->getDescription() );
 
 		// Check input schema
-		$input_schema = $dto->getInputSchema()->toArray();
-		$this->assertSame( 'object', $input_schema['type'] );
-		$this->assertArrayHasKey( 'text', $input_schema['properties'] );
-		$this->assertContains( 'text', $input_schema['required'] );
-		$this->assertSame( 'string', $input_schema['$defs']['text']['type'] );
-		$this->assertSame( '#/$defs/text', ( (array) $input_schema['properties']['text'] )['$ref'] );
+		$this->assertArrayHasKey( 'inputSchema', $data );
+		$this->assertSame( 'object', $data['inputSchema']['type'] );
+		$this->assertArrayHasKey( 'text', $data['inputSchema']['properties'] );
+		$this->assertContains( 'text', $data['inputSchema']['required'] );
+		$this->assertSame( 'string', $data['inputSchema']['$defs']['text']['type'] );
+		$this->assertSame( '#/$defs/text', ( (array) $data['inputSchema']['properties']['text'] )['$ref'] );
 
 		// Check output schema
 		$this->assertArrayHasKey( 'outputSchema', $data );

--- a/tests/phpunit/Unit/Tools/McpToolTest.php
+++ b/tests/phpunit/Unit/Tools/McpToolTest.php
@@ -198,15 +198,21 @@ final class McpToolTest extends TestCase {
 				'description'  => 'A comprehensive test tool',
 				'inputSchema'  => array(
 					'type'       => 'object',
-					'properties' => array(
+					'$defs'      => array(
 						'text' => array( 'type' => 'string' ),
+					),
+					'properties' => array(
+						'text' => array( '$ref' => '#/$defs/text' ),
 					),
 					'required'   => array( 'text' ),
 				),
 				'outputSchema' => array(
 					'type'       => 'object',
-					'properties' => array(
+					'$defs'      => array(
 						'result' => array( 'type' => 'string' ),
+					),
+					'properties' => array(
+						'result' => array( '$ref' => '#/$defs/result' ),
 					),
 				),
 				'meta'         => array( 'custom_key' => 'custom_value' ),
@@ -227,9 +233,13 @@ final class McpToolTest extends TestCase {
 		$this->assertSame( 'object', $input_schema['type'] );
 		$this->assertArrayHasKey( 'text', $input_schema['properties'] );
 		$this->assertContains( 'text', $input_schema['required'] );
+		$this->assertSame( 'string', $input_schema['$defs']['text']['type'] );
+		$this->assertSame( '#/$defs/text', ( (array) $input_schema['properties']['text'] )['$ref'] );
 
 		// Check output schema
 		$this->assertArrayHasKey( 'outputSchema', $data );
+		$this->assertSame( 'string', $data['outputSchema']['$defs']['result']['type'] );
+		$this->assertSame( '#/$defs/result', ( (array) $data['outputSchema']['properties']['result'] )['$ref'] );
 
 		// Check custom meta preserved
 		$this->assertArrayHasKey( '_meta', $data );


### PR DESCRIPTION
## What?

See WordPress/php-mcp-schema#8.

Updates the locked `wordpress/php-mcp-schema` dependency from `v0.1.2` to `v0.1.3`. Extends the existing tool DTO test to cover `$defs` and `$ref` round trips in both input and output schemas.

## Why?

`v0.1.3` preserves unrecognized fields on open MCP schema types. Without this update, valid JSON Schema keywords such as `$defs` are discarded when tool schemas pass through `fromArray()` and `toArray()`.

## How?

The Composer lockfile now resolves `wordpress/php-mcp-schema` to `v0.1.3`; the existing `^0.1.0` constraint remains unchanged. Regression assertions verify that definitions and references survive the adapter's tool DTO serialization path.

### Use of AI Tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-5  
Used for: Updating the dependency, extending regression coverage, running verification, and drafting this pull request.

## Testing Instructions

- `npm run test:php -- --filter test_fromArray_with_all_options` — 2 tests, 22 assertions passed.
- `npm run test:php` — 1,009 tests and 3,895 assertions passed; 1 test skipped.
- `npm run lint:php` — passed.
- `npm run lint:php:stan` — passed with no errors.
- `composer validate --strict` — passed.

## Changelog Entry

> Fixed - Preserve open JSON Schema keywords such as `$defs` when tool input and output schemas round-trip through MCP DTOs.
