### PR TITLE
Prepare the 0.6.0 release

### DIFF
--- a/includes/Abilities/McpAbilityExposure.php
+++ b/includes/Abilities/McpAbilityExposure.php
@@ -22,7 +22,7 @@ use WP_Ability;
  * last. Resolving from the stored ability instead happens after registration is
  * complete, so the metadata is final.
  *
- * @since n.e.x.t
+ * @since 0.6.0
  */
 final class McpAbilityExposure {
 
@@ -33,7 +33,7 @@ final class McpAbilityExposure {
 	 * inherited from the high-level `meta.public` flag. Malformed `meta.mcp`
 	 * fails closed.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param \WP_Ability $ability The ability to check.
 	 *
@@ -46,7 +46,7 @@ final class McpAbilityExposure {
 	/**
 	 * Determines whether ability metadata resolves to MCP exposure.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param array<string, mixed> $meta Ability metadata.
 	 *

--- a/includes/Core/McpAdapter.php
+++ b/includes/Core/McpAdapter.php
@@ -28,7 +28,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class McpAdapter {
 
-	public const VERSION = '0.5.0';
+	public const VERSION = '0.6.0';
 
 	/**
 	 * Registry instance

--- a/includes/Domain/Utils/AbilityArgumentNormalizer.php
+++ b/includes/Domain/Utils/AbilityArgumentNormalizer.php
@@ -45,7 +45,7 @@ class AbilityArgumentNormalizer {
 	 *
 	 * @return mixed Normalized parameters (null when no schema and params are empty; empty array when a schema is present and params are empty or null, unless the schema declares a top-level default or its type permits null, in which case null is returned).
 	 * @since 0.5.0
-	 * @since n.e.x.t Empty or null parameters for schema-defining abilities normalize to an empty array, except when the schema declares a top-level default (honored for both null and empty {} input) or its type explicitly permits null.
+	 * @since 0.6.0 Empty or null parameters for schema-defining abilities normalize to an empty array, except when the schema declares a top-level default (honored for both null and empty {} input) or its type explicitly permits null.
 	 */
 	public static function normalize( \WP_Ability $ability, $parameters ) {
 		$input_schema = $ability->get_input_schema();
@@ -93,7 +93,7 @@ class AbilityArgumentNormalizer {
 	 * @param array<string,mixed> $input_schema The ability input schema.
 	 *
 	 * @return bool True when null is a valid top-level value for the schema.
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 */
 	private static function schema_permits_null( array $input_schema ): bool {
 		$type = $input_schema['type'] ?? null;

--- a/includes/Domain/Utils/ContentBlockHelper.php
+++ b/includes/Domain/Utils/ContentBlockHelper.php
@@ -90,7 +90,7 @@ final class ContentBlockHelper {
 	 * wrapper's; `$resource_meta` sets the contents'. They are distinct fields in
 	 * the spec and are not interchangeable.
 	 *
-	 * @since n.e.x.t Added the optional $resource_meta parameter.
+	 * @since 0.6.0 Added the optional $resource_meta parameter.
 	 *
 	 * @param string $uri The URI of the resource.
 	 * @param string $text The text content of the resource.
@@ -138,7 +138,7 @@ final class ContentBlockHelper {
 	 * wrapper's; `$resource_meta` sets the contents'. They are distinct fields in
 	 * the spec and are not interchangeable.
 	 *
-	 * @since n.e.x.t Added the optional $resource_meta parameter.
+	 * @since 0.6.0 Added the optional $resource_meta parameter.
 	 *
 	 * @param string $uri The URI of the resource.
 	 * @param string $blob Base64-encoded binary data.

--- a/includes/Domain/Utils/McpValidator.php
+++ b/includes/Domain/Utils/McpValidator.php
@@ -26,7 +26,7 @@ class McpValidator {
 	 * Shared by URI validation and scheme folding so the two can never drift
 	 * apart on what counts as a scheme.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @var string
 	 */
@@ -444,7 +444,7 @@ class McpValidator {
 	 * Returns null rather than raising so an incorrectly shaped optional `_meta` does
 	 * not withhold the payload it accompanies.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param mixed $meta The raw `_meta` value.
 	 *
@@ -500,7 +500,7 @@ class McpValidator {
 	 * @param string $uri Resource URI.
 	 *
 	 * @return string Same URI with a lowercased scheme.
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 */
 	public static function fold_uri_scheme( string $uri ): string {
 		// On PCRE failure preg_replace_callback() returns null; keep the URI as-is.

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -535,7 +535,7 @@ class PromptsHandler {
 	 * not an array at all loses the whole prompt rather than the field. It is dropped so
 	 * that the message survives.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param array $content Content block as the prompt returned it.
 	 *

--- a/includes/Transport/Infrastructure/HttpSessionValidator.php
+++ b/includes/Transport/Infrastructure/HttpSessionValidator.php
@@ -37,7 +37,7 @@ class HttpSessionValidator {
 	/**
 	 * Validate a session and report storage failures to an error handler.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 * @internal
 	 *
 	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext                  $context       The HTTP request context.
@@ -100,7 +100,7 @@ class HttpSessionValidator {
 	/**
 	 * Create a session and report storage failures to an error handler.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 * @internal
 	 *
 	 * @param array                                                 $params        The client parameters from initialize request.
@@ -140,7 +140,7 @@ class HttpSessionValidator {
 	/**
 	 * Terminate a session and report storage failures to an error handler.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 * @internal
 	 *
 	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext                  $context       The HTTP request context.

--- a/includes/Transport/Infrastructure/SessionManager.php
+++ b/includes/Transport/Infrastructure/SessionManager.php
@@ -47,7 +47,7 @@ final class SessionManager {
 	 * back to the unsuffixed legacy key so reads/writes do not land under an
 	 * orphaned `mcp_adapter_sessions_0` row (see session_meta_key_for_blog()).
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 */
 	private static function session_meta_key(): string {
 		if ( ! is_multisite() ) {
@@ -60,7 +60,7 @@ final class SessionManager {
 	/**
 	 * Resolve the session meta key for a blog ID (multisite).
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param int $blog_id Blog ID; values below 1 use the unsuffixed legacy key.
 	 */
@@ -96,7 +96,7 @@ final class SessionManager {
 	/**
 	 * Maximum attempts for a concurrent session mutation.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @var int
 	 */
@@ -105,7 +105,7 @@ final class SessionManager {
 	/**
 	 * Create a new session for a user
 	 *
-	 * @since n.e.x.t Added the optional error handler.
+	 * @since 0.6.0 Added the optional error handler.
 	 *
 	 * @param int                                                   $user_id      The user ID.
 	 * @param array                                                 $params       Client parameters from initialize request.
@@ -169,7 +169,7 @@ final class SessionManager {
 	 * therefore still overwrite each other, but subsequent writes retry when the
 	 * previously read non-empty map has changed.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param int                                                   $user_id       The user ID.
 	 * @param callable                                              $mutation      Receives the latest sessions and returns the updated sessions.
@@ -376,7 +376,7 @@ final class SessionManager {
 	/**
 	 * Validate a session and update last activity
 	 *
-	 * @since n.e.x.t Added the optional error handler.
+	 * @since 0.6.0 Added the optional error handler.
 	 *
 	 * @param int                                                   $user_id      The user ID.
 	 * @param string                                                $session_id   The session ID.
@@ -424,7 +424,7 @@ final class SessionManager {
 	/**
 	 * Delete a specific session
 	 *
-	 * @since n.e.x.t Added the optional error handler.
+	 * @since 0.6.0 Added the optional error handler.
 	 *
 	 * @param int                                                   $user_id      The user ID.
 	 * @param string                                                $session_id   The session ID.

--- a/mcp-adapter.php
+++ b/mcp-adapter.php
@@ -11,7 +11,7 @@
  * Plugin Name:       MCP Adapter
  * Plugin URI:        https://github.com/WordPress/mcp-adapter
  * Description:       Adapter for Abilities API, letting the abilities to be used as MCP tools, resources or prompts.
- * Version:           0.5.0
+ * Version:           0.6.0
  * Requires at least: 6.9
  * Tested up to:      7.0
  * Requires PHP:      7.4
@@ -41,7 +41,7 @@ function constants(): void {
 	/**
 	 * Version of the plugin.
 	 */
-	define( 'WP_MCP_VERSION', '0.5.0' );
+	define( 'WP_MCP_VERSION', '0.6.0' );
 }
 
 constants();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags:              mcp, ai, abilities-api, model-context-protocol
 Requires at least: 6.9
 Tested up to:      7.0
 Requires PHP:      7.4
-Stable tag:        0.5.0
+Stable tag:        0.6.0
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -139,7 +139,7 @@ final class RequestRouterTest extends TestCase {
 	/**
 	 * Test exhausted session update retries are reported to the configured error handler.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 */
 	public function test_route_request_logs_exhausted_session_update_retries(): void {
 		$attempts              = 0;


### PR DESCRIPTION
## What?

Prepare the repository for the `0.6.0` release.

- Set the plugin header, `WP_MCP_VERSION`, `McpAdapter::VERSION`, and WordPress.org stable tag to `0.6.0`
- Replace all 22 `@since n.e.x.t` development placeholders with `@since 0.6.0`

## Why?

The release must expose one consistent version through WordPress, extension-facing constants, and WordPress.org metadata. Development placeholders also need their shipped version before the `v0.6.0` tag is created.

## How?

This is a metadata-only release preparation change. Historical `0.5.0` annotations, deprecation markers, runtime notice introduction versions, and the `v0.5.0` migration documentation remain unchanged.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Used for: Scoping the release version surfaces, applying the mechanical updates, running verification, and drafting this description.

## Testing Instructions

- `npm run lint:php` — 61 PHP files passed PHPCS
- `npm run lint:php:stan` — PHPStan completed with no errors
- `npm run wp-env:cli -- vendor/bin/phpunit -c phpunit.xml.dist` on WordPress 7.0.3 — 1,034 tests and 3,946 assertions passed; 1 test skipped
- Production dependency install plus `npm run plugin-zip` — archive built successfully and reported `0.6.0` in the plugin header, `WP_MCP_VERSION`, and stable tag
- `git diff --check` — passed
- Repository-wide placeholder check — no `n.e.x.t` occurrences remain outside ignored dependencies

## Changelog Entry

> Developer - Prepare version metadata and `@since` annotations for the 0.6.0 release.