### PR TITLE
Add exact descriptor-backed dual MCP revision support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The official WordPress package for MCP integration that exposes WordPress abilit
 
 ## Overview
 
-This adapter bridges WordPress's Abilities API with the [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/), providing a standardized way for AI agents to interact with WordPress functionality. It includes HTTP and STDIO transport support, comprehensive error handling, and an extensible architecture for custom integrations.
+This adapter bridges WordPress's Abilities API with the Model Context Protocol, providing a standardized way for AI agents to interact with WordPress functionality. It supports the exact [2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/) and [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/) protocol revisions over HTTP and STDIO, with comprehensive error handling and an extensible architecture for custom integrations.
 
 ## Features
 
@@ -17,7 +17,7 @@ This adapter bridges WordPress's Abilities API with the [MCP specification](http
 - **Ability-to-MCP Conversion**: Automatically converts WordPress abilities into MCP tools, resources, and prompts
 - **Multi-Server Management**: Create and manage multiple MCP servers with unique configurations
 - **Extensible Transport Layer**:
-    - **HTTP Transport**: Unified transport implementing [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports) for HTTP-based communication
+    - **HTTP Transport**: Unified transport for session-based MCP 2025-11-25 and stateless MCP 2026-07-28 requests
     - **STDIO Transport**: Process-based communication via standard input/output for local development and CLI integration
     - **Custom Transport Support**: Implement `McpTransportInterface` to create specialized communication protocols
     - **Multi-Transport Configuration**: Configure servers with multiple transport methods simultaneously
@@ -35,10 +35,10 @@ This adapter bridges WordPress's Abilities API with the [MCP specification](http
 
 ### MCP Component Support
 
-- **[Tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools.md)**: Convert WordPress abilities into executable MCP tools for AI agent interactions
-- **[Resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources.md)**: Expose WordPress data as MCP resources for contextual information access
-- **[Prompts](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts.md)**: Transform abilities into structured MCP prompts for AI guidance and templates
-- **Server Discovery**: Automatic registration and discovery of MCP servers following MCP protocol standards
+- **[Tools](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)**: Convert WordPress abilities into executable MCP tools for AI agent interactions
+- **[Resources](https://modelcontextprotocol.io/specification/2025-11-25/server/resources)**: Expose WordPress data as MCP resources for contextual information access
+- **[Prompts](https://modelcontextprotocol.io/specification/2025-11-25/server/prompts)**: Transform abilities into structured MCP prompts for AI guidance and templates
+- **Server Discovery**: Advertise supported revisions and capabilities through stateless MCP 2026-07-28 `server/discover`
 - **Built-in Abilities**: Core WordPress abilities for system introspection and ability management
 - **CLI Integration**: WP-CLI commands supporting STDIO transport as defined in MCP specification
 
@@ -50,7 +50,7 @@ For a full breakdown of the component structure, see the [Architecture Overview]
 
 - **PHP**: >= 7.4
 - **WordPress**: >= 6.9 (includes the [Abilities API](https://developer.wordpress.org/news/2025/11/introducing-the-wordpress-abilities-api/) in core — no separate plugin)
-- **[php-mcp-schema](https://github.com/WordPress/php-mcp-schema)** (`^0.1.0`): Typed DTOs for MCP protocol types — installed automatically via Composer
+- **[php-mcp-schema](https://github.com/WordPress/php-mcp-schema)**: Descriptor-backed records for exact MCP request validation and wire serialization, plus narrow legacy namespace facades for public compatibility — installed automatically via Composer
 
 ## Installation
 
@@ -119,6 +119,7 @@ add_action( 'plugins_loaded', function() {
 The MCP Adapter automatically creates a default server that exposes registered WordPress abilities through a layered architecture. This provides immediate MCP functionality without requiring manual server configuration.
 
 **How it works:**
+
 - WordPress abilities registered via `wp_register_ability()` with `meta.public` set to `true` are discoverable and executable on the default server via its built-in adapter tools
 - Set `meta.mcp.public` explicitly to override the high-level setting for MCP only; `false` opts a public ability out, while `true` exposes an otherwise private ability to MCP
 - On the default server, public abilities are accessed through `mcp-adapter/discover-abilities`, `mcp-adapter/get-ability-info`, and `mcp-adapter/execute-ability` rather than being auto-registered individually in `tools/list`
@@ -127,6 +128,8 @@ The MCP Adapter automatically creates a default server that exposes registered W
 - Built-in error handling and observability are included
 - Access via HTTP: `/wp-json/mcp/mcp-adapter-default-server`
 - Access via STDIO: `wp mcp-adapter serve --server=mcp-adapter-default-server`
+
+See [Protocol versions](docs/guides/protocol-versions.md) for the different lifecycle, metadata, and method requirements of MCP 2025-11-25 and MCP 2026-07-28.
 
 <details>
 <summary><strong>Create a new ability (click to expand)</strong></summary>
@@ -216,11 +219,12 @@ For local development and testing, you can interact directly with MCP servers us
 # List all available MCP servers
 wp mcp-adapter list
 
-# Test the discover abilities tool to see all available WordPress abilities
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"mcp-adapter-discover-abilities","arguments":{}}}' | wp mcp-adapter serve --user=admin --server=mcp-adapter-default-server
-
-# Test listing available tools
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | wp mcp-adapter serve --user=admin --server=mcp-adapter-default-server
+# Initialize a legacy connection, then list tools in the same process
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"shell-client","version":"1.0.0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | wp mcp-adapter serve --user=admin --server=mcp-adapter-default-server
 ```
 
 #### MCP Client Configuration
@@ -332,7 +336,6 @@ The MCP Adapter includes production-ready HTTP transports. For specialized requi
 
 See the [Custom Transports Guide](docs/guides/custom-transports.md) for detailed implementation instructions.
 
-
 ### Custom Transport Permissions
 
 The MCP Adapter supports custom authentication logic through transport permission callbacks. Instead of the default `is_user_logged_in()` check, you can implement custom authentication for your MCP servers.
@@ -357,4 +360,5 @@ See the [Observability Guide](docs/guides/observability.md) for detailed metrics
 - [Migration Guide: v0.3.0](docs/migration/v0.3.0.md) — Transport, observability, and hook name changes
 
 ## License
+
 [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"automattic/jetpack-autoloader": "^5.0",
-		"wordpress/php-mcp-schema": "^0.1.0",
+		"wordpress/php-mcp-schema": "dev-try/descriptor-backed-generic-record-model",
 		"ext-json": "*"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfa32ba59be79ad50b3c83430daa6a4d",
+    "content-hash": "d0b20959c7c9d3e9e1393ec1a1370917",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -72,16 +72,16 @@
         },
         {
             "name": "wordpress/php-mcp-schema",
-            "version": "v0.1.3",
+            "version": "dev-try/descriptor-backed-generic-record-model",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-mcp-schema",
-                "reference": "b2fcf97aa023ce46e9f03493c194a72d5a46bea2"
+                "reference": "78514f25a769903fea6858f5db1a1bb01a23e1cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/b2fcf97aa023ce46e9f03493c194a72d5a46bea2",
-                "reference": "b2fcf97aa023ce46e9f03493c194a72d5a46bea2",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/78514f25a769903fea6858f5db1a1bb01a23e1cf",
+                "reference": "78514f25a769903fea6858f5db1a1bb01a23e1cf",
                 "shasum": ""
             },
             "require": {
@@ -106,16 +106,16 @@
                     "homepage": "https://wordpress.org"
                 }
             ],
-            "description": "PHP DTOs for the Model Context Protocol (MCP) specification",
+            "description": "Descriptor-backed PHP records for explicit Model Context Protocol revisions",
             "homepage": "https://github.com/WordPress/php-mcp-schema",
             "keywords": [
-                "dto",
                 "mcp",
                 "model-context-protocol",
                 "php",
+                "record",
                 "schema"
             ],
-            "time": "2026-08-10T09:12:14+00:00"
+            "time": "2026-08-13T07:53:16+00:00"
         }
     ],
     "packages-dev": [
@@ -3250,7 +3250,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "wordpress/php-mcp-schema": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -76,12 +76,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-mcp-schema",
-                "reference": "78514f25a769903fea6858f5db1a1bb01a23e1cf"
+                "reference": "9c5ca956f9d87c49b80daddaf7cd064fcf62b641"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/78514f25a769903fea6858f5db1a1bb01a23e1cf",
-                "reference": "78514f25a769903fea6858f5db1a1bb01a23e1cf",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/9c5ca956f9d87c49b80daddaf7cd064fcf62b641",
+                "reference": "9c5ca956f9d87c49b80daddaf7cd064fcf62b641",
                 "shasum": ""
             },
             "require": {

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -4,7 +4,7 @@ This document explains how the MCP Adapter transforms WordPress abilities into M
 
 ## Directory structure
 
-```
+```text
 includes/
 │
 ├── Plugin.php                     # Bootstrap — singleton, dependency check, initializes McpAdapter
@@ -15,6 +15,7 @@ includes/
 │   ├── McpServer.php              # Individual server configuration and component access
 │   ├── McpComponentRegistry.php   # Stores and retrieves McpComponentInterface instances
 │   ├── McpTransportFactory.php    # Instantiates transports with dependency injection
+│   ├── McpProtocolContext.php     # Exact request revision, schema catalog, and capabilities
 │   └── McpVersionNegotiator.php   # MCP protocol version negotiation
 │
 ├── Abilities/                     # Built-in meta-abilities for the default server
@@ -30,25 +31,28 @@ includes/
 ├── Domain/                        # Business logic and MCP component models
 │   ├── Contracts/
 │   │   └── McpComponentInterface.php       # Internal contract for all MCP components
+│   ├── Continuation/
+│   │   ├── McpContinuationContext.php      # Stateless input responses and request state
+│   │   └── McpExecutionResult.php          # Complete or input-required callback outcome
 │   ├── Utils/
 │   │   ├── McpNameSanitizer.php            # Converts ability names to MCP-safe names
 │   │   ├── McpValidator.php                # Validates names, URIs, and schemas
-│   │   ├── McpAnnotationMapper.php         # Maps ability meta.annotations to MCP DTOs
+│   │   ├── McpAnnotationMapper.php         # Maps ability meta.annotations to protocol arrays
 │   │   ├── SchemaTransformer.php           # Transforms JSON Schema formats
-│   │   ├── ContentBlockHelper.php          # Factory for MCP content block DTOs
+│   │   ├── ContentBlockHelper.php          # Factory for MCP content block arrays
 │   │   └── AbilityArgumentNormalizer.php   # Normalizes empty {} input to null
 │   ├── Tools/
-│   │   ├── McpTool.php                     # Wraps Tool DTO with execution logic
+│   │   ├── McpTool.php                     # Stores tool data and execution logic
 │   │   ├── RegisterAbilityAsMcpTool.php    # Converts a WordPress ability to McpTool
 │   │   └── McpToolValidator.php            # Validates tool names and schemas
 │   ├── Resources/
-│   │   ├── McpResource.php                 # Wraps Resource DTO with execution logic
+│   │   ├── McpResource.php                 # Stores resource data and execution logic
 │   │   ├── RegisterAbilityAsMcpResource.php # Converts a WordPress ability to McpResource
 │   │   └── McpResourceValidator.php        # Validates resource URIs and schemas
 │   └── Prompts/
 │       ├── Contracts/
 │       │   └── McpPromptBuilderInterface.php  # Interface for prompt message builders
-│       ├── McpPrompt.php                      # Wraps Prompt DTO with execution logic
+│       ├── McpPrompt.php                      # Stores prompt data and execution logic
 │       ├── McpPromptBuilder.php               # Builds prompt messages from ability output
 │       ├── McpPromptValidator.php             # Validates prompt names and arguments
 │       └── RegisterAbilityAsMcpPrompt.php     # Converts a WordPress ability to McpPrompt
@@ -56,7 +60,7 @@ includes/
 ├── Handlers/                      # JSON-RPC method handlers
 │   ├── HandlerHelperTrait.php     # Shared error response helpers
 │   ├── Initialize/
-│   │   └── InitializeHandler.php  # Handles initialize / initialized
+│   │   └── InitializeHandler.php  # Handles legacy initialize
 │   ├── Tools/
 │   │   └── ToolsHandler.php       # Handles tools/list, tools/call
 │   ├── Resources/
@@ -64,7 +68,7 @@ includes/
 │   ├── Prompts/
 │   │   └── PromptsHandler.php     # Handles prompts/list, prompts/get
 │   └── System/
-│       └── SystemHandler.php      # Handles ping, notifications/cancelled
+│       └── SystemHandler.php      # Handles legacy ping
 │
 ├── Infrastructure/
 │   ├── ErrorHandling/
@@ -86,7 +90,7 @@ includes/
 │   ├── Contracts/
 │   │   ├── McpTransportInterface.php      # Base transport contract
 │   │   └── McpRestTransportInterface.php  # REST transport contract (register_routes, check_permission)
-│   ├── HttpTransport.php                  # Unified HTTP transport (MCP 2025-11-25)
+│   ├── HttpTransport.php                  # Unified dual-revision HTTP transport
 │   └── Infrastructure/
 │       ├── HttpRequestContext.php         # Encapsulates HTTP request data
 │       ├── HttpRequestHandler.php         # Processes raw HTTP requests
@@ -103,30 +107,24 @@ includes/
 
 ## System architecture
 
-The MCP Adapter uses a two-layer architecture that separates protocol concerns from WordPress integration:
+The MCP Adapter uses two layers that separate exact wire contracts from WordPress integration.
 
-### Schema layer (protocol DTOs)
+### Schema layer (descriptor-backed records)
 
-The Schema Layer is provided by the `php-mcp-schema` package (`WP\McpSchema\` namespace). It contains protocol-only data transfer objects that are safe to expose to MCP clients.
+The `php-mcp-schema` package (`WP\McpSchema\` namespace) owns the exact schemas for each supported MCP revision. `McpProtocolContext` selects one catalog for each request. The router hydrates descriptor-backed records from revision-neutral arrays, validates them, and calls `toWireArray()` at the response boundary.
 
-**Key DTOs:**
+The Adapter's component, handler, and routing state does not use generated concrete protocol DTO trees. That keeps revision identity in one place and prevents internal code from accidentally serializing the shape for a different revision.
 
-| Category | Classes |
-|----------|---------|
-| Component definitions | `Tool`, `Resource`, `Prompt`, `PromptArgument`, `ToolAnnotations`, `Annotations` |
-| Result types | `ListToolsResult`, `CallToolResult`, `ListResourcesResult`, `ReadResourceResult`, `ListPromptsResult`, `GetPromptResult` |
-| Content blocks | `TextContent`, `ImageContent`, `AudioContent`, `EmbeddedResource` |
-
-All DTOs extend `AbstractDataTransferObject`, which provides `toArray()` and `fromArray()` methods for serialization. These types carry no execution logic and no adapter-internal metadata.
+`php-mcp-schema` also retains five narrow, descriptor-backed facades under legacy namespaces: `InitializeResult`, `Tool`, `Resource`, `Prompt`, and `PromptArgument`. The Adapter uses them only at established public compatibility boundaries such as prompt builders and list/initialize filters. They hydrate through the descriptor runtime; they are not a second wire codec or the Adapter's internal data model.
 
 ### Adapter layer (WordPress integration)
 
-The Adapter Layer wraps each protocol DTO with execution wiring and WordPress-specific metadata. Domain models `McpTool`, `McpResource`, and `McpPrompt` each implement the `McpComponentInterface` contract:
+`McpTool`, `McpResource`, and `McpPrompt` store clean protocol arrays alongside their execution wiring and WordPress-specific metadata. Each implements the internal `McpComponentInterface` contract:
 
 ```php
 interface McpComponentInterface {
-    public function get_protocol_dto(): AbstractDataTransferObject;
-    public function execute( $arguments );
+    public function get_protocol_data(): array;
+    public function execute( $arguments, ?McpContinuationContext $continuation = null );
     public function check_permission( $arguments );
     public function get_adapter_meta(): array;
     public function get_observability_context(): array;
@@ -135,9 +133,11 @@ interface McpComponentInterface {
 
 This separation ensures that:
 
-- **Protocol DTOs** contain only fields defined by the MCP specification and are serialized directly into responses.
+- **Protocol data** contains only fields defined by MCP and remains independent of an exact revision until routing.
 - **Adapter metadata** (ability references, schema transformation flags, permission callbacks) stays internal and is never exposed to MCP clients.
-- **Observability context** provides structured tags for logging and metrics without polluting DTO `_meta`.
+- **Schema catalogs** validate exact request and response shapes and own JSON map/list identity and wire serialization.
+- **Compatibility facades** preserve established third-party types without reintroducing revision-specific internal DTO graphs.
+- **Observability context** provides structured tags for logging and metrics without polluting protocol `_meta`.
 
 `McpComponentInterface` is an internal contract (`@internal`). It is not intended for third-party implementation.
 
@@ -153,17 +153,20 @@ The remaining layers wire the Schema and Adapter layers together:
 ## Core components
 
 ### McpAdapter (singleton registry)
+
 - **Purpose**: Central registry managing multiple MCP servers
 - **Key Methods**: `create_server()`, `get_server()`, `get_servers()`, `instance()`
 - **Initialization**: Hooks into `rest_api_init` and fires `mcp_adapter_init` action
 
 ### McpServer (server instance)
+
 - **Purpose**: Individual MCP server with specific configuration
 - **Components**: Uses `McpComponentRegistry` to manage `McpComponentInterface` instances
-- **Typed access**: `get_tools()`, `get_resources()`, `get_prompts()` return component collections
+- **Protocol access**: `get_tools()`, `get_resources()`, and `get_prompts()` return protocol arrays
 - **Dependencies**: Error handler, observability handler, transport permission callback
 
 ### McpComponentRegistry
+
 - **Purpose**: Stores and retrieves `McpComponentInterface` instances
 - **Registration**: `register_tools()`, `register_resources()`, `register_prompts()` accept both ability names and `McpComponentInterface` instances
 - **Name sanitization**: Uses `McpNameSanitizer` to normalize tool and prompt names
@@ -171,54 +174,61 @@ The remaining layers wire the Schema and Adapter layers together:
 
 ### McpVersionNegotiator
 
-Negotiates the MCP protocol version between client and server. If the client requests a supported version it is echoed back; otherwise the server falls back to the latest supported version.
+Owns the supported revision list and maps each supported protocol string to its exact schema catalog.
 
 **Supported protocol versions** (newest-first):
-- `2025-11-25` (latest — recommended)
-- `2025-06-18`
-- `2024-11-05`
+
+- `2026-07-28` — stateless discovery and per-request revision selection
+- `2025-11-25` — initialize negotiation and session lifecycle
+
+Legacy `initialize` cannot negotiate into the stateless lifecycle. It echoes `2025-11-25` when requested and otherwise falls back to that supported legacy revision. Modern clients use `server/discover` and select `2026-07-28` in every request.
 
 ### McpTransportFactory
+
 - **Purpose**: Creates transport instances with dependency injection
 - **Context Creation**: Builds `McpTransportContext` with all required handlers
 - **Validation**: Ensures transport classes implement `McpTransportInterface`
 
 ### RequestRouter
-- **Purpose**: Routes MCP method calls to handlers that return schema DTOs
-- **DTO serialization boundary**: Converts `AbstractDataTransferObject` results to arrays via `toArray()` and `JSONRPCErrorResponse` results to error arrays
+
+- **Purpose**: Selects the exact protocol context, validates requests, dispatches revision-neutral handlers, and schema-encodes results
+- **Serialization boundary**: Hydrates descriptor-backed records and calls `toWireArray()` for the selected revision
 - **Observability**: Extracts per-component context from `McpComponentInterface::get_observability_context()` for request tagging
 
 ## Request flow
 
-```
-AI Agent --> Transport --> RequestRouter --> Handler --> McpComponentInterface --> Schema DTO --> Response
+```text
+AI Agent -> Transport -> RequestRouter -> Handler -> McpComponentInterface
+                     -> exact schema record -> JSON-RPC response
 ```
 
 ### Detailed flow
-1. **Transport** receives MCP request and authenticates
-2. **RequestRouter** maps method to appropriate handler
-3. **Handler** finds the `McpComponentInterface` component, validates input, and invokes execution
-4. **Component** delegates to a WordPress ability or direct callable, returning a result
-5. **Handler** wraps the result in a schema DTO (e.g., `CallToolResult`)
-6. **RequestRouter** calls `toArray()` on the DTO at the serialization boundary
-7. **Transport** wraps the array in a JSON-RPC envelope and returns it
+
+1. **Transport** authenticates the request and determines its protocol revision from the negotiated legacy session or modern request metadata.
+2. **RequestRouter** creates `McpProtocolContext` and validates the full request against that revision's schema.
+3. **Handler** finds the `McpComponentInterface`, checks permission, and invokes execution.
+4. **Component** delegates to a WordPress ability or direct callable and returns revision-neutral data or `McpExecutionResult`.
+5. **RequestRouter** adds revision-specific result fields and serializes through the selected descriptor-backed record.
+6. **Transport** wraps the validated result or error in a JSON-RPC 2.0 envelope.
 
 ### Method routing
 
-The `RequestRouter` maps MCP methods to handlers. All handlers return schema DTOs:
+The `RequestRouter` maps supported MCP methods to revision-neutral handlers:
 
-| Method | Handler | Return Type |
-|--------|---------|-------------|
-| `initialize` | `InitializeHandler::handle()` | `InitializeResult` |
-| `tools/list` | `ToolsHandler::list_tools()` | `ListToolsResult` |
-| `tools/call` | `ToolsHandler::call_tool()` | `CallToolResult` or `JSONRPCErrorResponse` |
-| `resources/list` | `ResourcesHandler::list_resources()` | `ListResourcesResult` |
-| `resources/read` | `ResourcesHandler::read_resource()` | `ReadResourceResult` or `JSONRPCErrorResponse` |
-| `prompts/list` | `PromptsHandler::list_prompts()` | `ListPromptsResult` |
-| `prompts/get` | `PromptsHandler::get_prompt()` | `GetPromptResult` or `JSONRPCErrorResponse` |
-| `ping` | `SystemHandler::ping()` | `Result` |
+| Method | Revision | Handler/result source |
+|--------|----------|-----------------------|
+| `initialize` | 2025-11-25 | `InitializeHandler::handle()` |
+| `ping` | 2025-11-25 | `SystemHandler::ping()` |
+| `server/discover` | 2026-07-28 | `RequestRouter` capability discovery |
+| `tools/list` | Both | `ToolsHandler::list_tools()` |
+| `tools/call` | Both | `ToolsHandler::call_tool()` |
+| `resources/list` | Both | `ResourcesHandler::list_resources()` |
+| `resources/templates/list` | Both | `ResourcesHandler::list_resource_templates()` |
+| `resources/read` | Both | `ResourcesHandler::read_resource()` |
+| `prompts/list` | Both | `PromptsHandler::list_prompts()` |
+| `prompts/get` | Both | `PromptsHandler::get_prompt()` |
 
-Protocol-level errors (tool not found, missing parameters) return `JSONRPCErrorResponse`. Execution-level errors (permission denied, runtime failure) return the appropriate result DTO with `isError: true`.
+MCP 2026-07-28 does not define `ping`, so the modern router returns method-not-found for it. Protocol-level errors are plain JSON-RPC error arrays validated by the schema layer. Tool execution errors remain successful protocol results with `isError: true`, so clients can expose them to the model for correction.
 
 ## Component creation
 
@@ -246,23 +256,37 @@ $tool = McpTool::fromArray( [
     'name'        => 'my-tool',
     'title'       => 'My Tool',
     'description' => 'Does something useful',
-    'inputSchema' => [ 'type' => 'object', 'properties' => [ ... ] ],
+    'inputSchema' => array(
+        'type'       => 'object',
+        'properties' => array(),
+    ),
     'handler'     => fn( $args ) => [ 'result' => 'done' ],
     'permission'  => fn() => current_user_can( 'edit_posts' ),
     'annotations' => [ 'readOnlyHint' => true ],
 ] );
 ```
 
-### Protocol DTO access
+### Protocol data access
 
-Each component exposes its clean protocol DTO for serialization:
+Each component exposes clean, revision-neutral protocol data:
 
 ```php
-$dto = $tool->get_protocol_dto();  // Returns WP\McpSchema\Server\Tools\DTO\Tool
-$array = $dto->toArray();          // Protocol-safe array for JSON responses
+$data = $tool->get_protocol_data();
 ```
 
-The DTO contains only MCP specification fields. Adapter metadata (ability reference, schema transformation flags) lives on the `McpTool` instance and is never serialized.
+The array contains only MCP fields. Adapter metadata (ability reference, schema transformation flags, callbacks) lives on the `McpTool` instance and is never serialized. Callers should not hydrate schema records themselves; the router does that after it knows the exact request revision.
+
+### Prompt-builder compatibility
+
+`McpPromptBuilderInterface::build()` retains its established return type:
+
+```php
+interface McpPromptBuilderInterface {
+    public function build(): \WP\McpSchema\Server\Prompts\DTO\Prompt;
+}
+```
+
+The built-in `McpPromptBuilder` and existing third-party implementations therefore remain compatible. The returned `Prompt` is a descriptor-backed legacy namespace facade. `McpPrompt::fromBuilder()` converts it to revision-neutral protocol data immediately; execution and exact wire serialization then follow the same path as other prompts.
 
 ## Utility classes
 
@@ -283,18 +307,18 @@ $name = McpNameSanitizer::sanitize_name( 'my-plugin/action-name' );
 
 ### ContentBlockHelper
 
-Factory for creating typed content block DTOs used in tool call results, prompt messages, and resource contents.
+Factory for creating revision-neutral content block arrays used in tool call results, prompt messages, and resource contents.
 
 | Method | Returns | Purpose |
 |--------|---------|---------|
-| `text( $text )` | `TextContent` | Plain text content |
-| `json_text( $data, $flags )` | `TextContent` | JSON-encoded data as text (flags: `JSON_*` constants) |
-| `image( $data, $mime_type )` | `ImageContent` | Base64-encoded image |
-| `audio( $data, $mime_type )` | `AudioContent` | Base64-encoded audio |
-| `embedded_text_resource( $uri, $text )` | `EmbeddedResource` | Text resource embedded in content |
-| `embedded_blob_resource( $uri, $blob )` | `EmbeddedResource` | Binary resource embedded in content |
-| `error_text( $message )` | `TextContent` | Semantic alias for error messages |
-| `to_array_list( $blocks )` | `array[]` | Converts content block DTOs to arrays |
+| `text( $text )` | `array` | Plain text content |
+| `json_text( $data, $flags )` | `array` | JSON-encoded data as text (flags: `JSON_*` constants) |
+| `image( $data, $mime_type )` | `array` | Base64-encoded image |
+| `audio( $data, $mime_type )` | `array` | Base64-encoded audio |
+| `embedded_text_resource( $uri, $text )` | `array` | Text resource embedded in content |
+| `embedded_blob_resource( $uri, $blob )` | `array` | Binary resource embedded in content |
+| `error_text( $message )` | `array` | Semantic alias for error messages |
+| `to_array_list( $blocks )` | `array[]` | Returns a compatibility list of content block arrays |
 
 ### AbilityArgumentNormalizer
 
@@ -303,6 +327,12 @@ Normalizes arguments between MCP clients and WordPress abilities. MCP clients se
 ```php
 $args = AbilityArgumentNormalizer::normalize( $ability, $args );
 ```
+
+### Stateless continuation
+
+For MCP 2026-07-28, direct tool, resource, and prompt callbacks can opt in to a second `McpContinuationContext` argument. The context carries `inputResponses`, opaque `requestState`, and the client capabilities declared on the current request. One-argument callbacks remain compatible.
+
+A callback returns `McpExecutionResult::input_required()` to pause or `McpExecutionResult::complete()` to provide its final value. The Adapter does not keep server-side continuation state between rounds. See [Protocol versions](../guides/protocol-versions.md#multi-round-continuation) for an example and the state-security requirements.
 
 ### FailureReason
 
@@ -315,7 +345,7 @@ Provides a centralized, stable vocabulary of failure reason constants for observ
 
 ### McpValidator
 
-Extended validation for MCP component data per the MCP 2025-11-25 specification:
+Provides Adapter-side validation for revision-neutral component data before the exact schema boundary:
 
 - `validate_name()` -- Name charset and length validation
 - `validate_resource_uri()` -- URI format per RFC 3986
@@ -341,31 +371,32 @@ interface McpRestTransportInterface extends McpTransportInterface {
 
 ### Built-in transports
 
-- **HttpTransport**: Recommended (MCP Streamable HTTP compliant)
-- **STDIO Transport**: Via WP-CLI commands
+- **HttpTransport**: Supports the MCP 2025-11-25 session lifecycle and MCP 2026-07-28 stateless requests
+- **STDIO Transport**: Supports both revisions through `wp mcp-adapter serve`
 
 ### Dependency injection
 
 Transports and the `RequestRouter` receive all dependencies through `McpTransportContext`, which bundles the server instance, all handlers, the router, error handler, and observability handler.
 
-### DTO-aware RequestRouter
+### Schema-backed RequestRouter
 
-The `RequestRouter` is the serialization boundary between typed DTOs and transport-level arrays:
+The `RequestRouter` is the boundary between revision-neutral Adapter arrays and exact MCP wire shapes:
 
-1. It dispatches to the appropriate handler, which returns an `AbstractDataTransferObject` or `JSONRPCErrorResponse`.
-2. For success DTOs, it calls `toArray()` and returns the resulting array.
-3. For error DTOs, it extracts the error object and returns `['error' => ...]`.
-4. The transport wraps the array in the JSON-RPC 2.0 envelope.
+1. It resolves `McpProtocolContext` from initialize data, modern `_meta`, or an explicit transport-selected version.
+2. It validates the full JSON-RPC request with the exact `php-mcp-schema` catalog before dispatch.
+3. It dispatches to handlers that return arrays or `McpExecutionResult`.
+4. It adds revision-specific fields, hydrates the exact result record, and calls `toWireArray()`.
+5. It validates the complete JSON-RPC success or error envelope before the transport sends it.
 
 ## Error handling
 
 ### Two-part system
 
-1. **Error Response Creation**: `McpErrorFactory` creates `JSONRPCErrorResponse` DTOs for protocol errors
+1. **Error Response Creation**: `McpErrorFactory` creates stable JSON-RPC error arrays for protocol errors
 2. **Error Logging**: `McpErrorHandlerInterface` implementations log errors for monitoring
 
 ```php
-// Protocol error DTO (returned to clients via JSON-RPC)
+// Protocol error envelope (returned to clients via JSON-RPC)
 $error_response = McpErrorFactory::tool_not_found( $request_id, $tool_name );
 
 // Error logging (for monitoring)
@@ -401,39 +432,44 @@ interface McpObservabilityHandlerInterface {
 
 ## Extension points
 
+The descriptor-backed wire boundary does not change the public `McpAdapter::create_server()`, `get_server()`, or `get_servers()` APIs, component `fromArray()` configuration keys, or existing hook names and argument order.
+
+Four established filters retain their legacy object payloads through descriptor-backed facades:
+
+| Filter | First payload |
+|--------|---------------|
+| `mcp_adapter_initialize_response` | `WP\McpSchema\Common\Protocol\DTO\InitializeResult` |
+| `mcp_adapter_tools_list` | Array of `WP\McpSchema\Server\Tools\DTO\Tool` |
+| `mcp_adapter_resources_list` | Array of `WP\McpSchema\Server\Resources\DTO\Resource` |
+| `mcp_adapter_prompts_list` | Array of `WP\McpSchema\Server\Prompts\DTO\Prompt` |
+
+Use each facade's existing getters and `toArray()`/`fromArray()` methods when changing these values. The handlers convert accepted filter output back to revision-neutral arrays before the exact wire boundary. Pre-execution and result filters still run around tool calls, resource reads, and prompt gets in the same order.
+
+When a direct callback opts into modern continuation, the corresponding result filter can receive `McpExecutionResult` before the handler returns it to the router. Filters that do not implement continuation should return that object unchanged.
+
 ### Custom transport
 
 ```php
-class MyTransport implements McpRestTransportInterface {
-    use McpTransportHelperTrait;
+use WP\MCP\Transport\HttpTransport;
 
-    private McpTransportContext $context;
-
-    public function __construct( McpTransportContext $context ) {
-        $this->context = $context;
-    }
-
+class MyTransport extends HttpTransport {
     public function register_routes(): void {
-        // Register custom REST routes
-    }
+        $server = $this->request_handler->get_transport_context()->mcp_server;
 
-    public function check_permission( WP_REST_Request $request ) {
-        return current_user_can( 'manage_options' );
-    }
-
-    public function handle_request( WP_REST_Request $request ): WP_REST_Response {
-        $body   = $request->get_json_params();
-        $result = $this->context->request_router->route_request(
-            $body['method'],
-            $body['params'] ?? [],
-            $body['id'] ?? 0,
-            'my-transport'
+        register_rest_route(
+            $server->get_server_route_namespace(),
+            '/custom/' . ltrim( $server->get_server_route(), '/' ),
+            array(
+                'methods'             => array( 'POST', 'GET', 'DELETE' ),
+                'callback'            => array( $this, 'handle_request' ),
+                'permission_callback' => array( $this, 'check_permission' ),
+            )
         );
-
-        return new WP_REST_Response( $result );
     }
 }
 ```
+
+Extending `HttpTransport` preserves its complete JSON-RPC, notification, batch, object/list, protocol-header, and session handling. Non-HTTP transports can use the injected `RequestRouter` directly after implementing those delivery-level responsibilities.
 
 ### Custom error handler
 
@@ -466,15 +502,19 @@ class MyObservabilityHandler implements McpObservabilityHandlerInterface {
 
 ## Design principles
 
-- **Two-layer DTO separation**: Protocol DTOs from `php-mcp-schema` carry no adapter-internal fields; `get_protocol_dto()->toArray()` always produces spec-compliant output
+- **Exact schema ownership**: `php-mcp-schema` owns revision-specific validation and serialization; Adapter components expose only revision-neutral protocol arrays
+- **Narrow public compatibility**: Legacy namespace facades exist only for established prompt-builder and hook payload types
 - **Dependency injection**: All transports receive dependencies through `McpTransportContext`; no global state beyond the `McpAdapter` singleton
 - **Interface-based design**: Error handlers, observability, and transports are all swappable via interfaces
+- **Request-scoped revision identity**: A request uses exactly one negotiated or declared protocol revision from transport selection through response serialization
+- **Stateless modern continuation**: Callbacks own any `requestState`; the Adapter only returns it to the client and receives it on the next independent request
 - **Event emission over counters**: Observability emits events; external systems handle aggregation — zero overhead when disabled
-- **Lazy loading**: Components created only when needed; validation disabled by default via `mcp_adapter_validation_enabled` filter
+- **Layered validation**: Optional component-registration checks use `mcp_adapter_validation_enabled`; exact request and wire-response schema validation always runs in the router
 
 ## Next steps
 
 - **[Creating Abilities](../guides/creating-abilities.md)** -- Build MCP components from WordPress abilities
+- **[Protocol Versions](../guides/protocol-versions.md)** -- Implement exact legacy and modern request lifecycles
 - **[Custom Transports](../guides/custom-transports.md)** -- Implement specialized transport protocols
 - **[Error Handling](../guides/error-handling.md)** -- Custom error management
 - **[Observability](../guides/observability.md)** -- Metrics and monitoring

--- a/docs/guides/custom-transports.md
+++ b/docs/guides/custom-transports.md
@@ -1,29 +1,18 @@
-# Custom Transport Layers
+# Custom transports
 
-This guide covers how to implement custom transport layers for the MCP Adapter when the built-in `HttpTransport` doesn't meet your specific needs.
+Use a custom transport when the built-in `HttpTransport` and STDIO bridge do not fit the delivery mechanism. The injected `RequestRouter` still owns MCP request validation, method dispatch, and response serialization.
 
-## Built-in Transports
+The built-in transports support both exact revisions described in [Protocol versions](protocol-versions.md):
 
-- ✅ **`HttpTransport`** - Recommended (implements MCP 2025-11-25 specification)
-- ✅ **`STDIO Transport`** - Available via WP-CLI commands
+- MCP 2025-11-25 uses `initialize` and a negotiated session.
+- MCP 2026-07-28 is stateless and selects the revision in every request.
 
-## When to Create Custom Transports
+For authentication or authorization changes on the existing HTTP route, use [transport permissions](transport-permissions.md) instead of a custom transport.
 
-> **💡 Consider [Transport Permissions](transport-permissions.md) first**: For authentication needs, use transport permission callbacks instead of custom transports.
+## Transport interfaces
 
-Create custom transports for:
+All transports implement `McpTransportInterface`:
 
-- **Custom routing patterns** or URL structures
-- **Message queue integration** (Redis, RabbitMQ, AWS SQS)
-- **Request signing** and verification
-- **Custom encryption** or data masking
-- **Specialized protocols** beyond HTTP/STDIO
-
-## Transport Interfaces
-
-Custom transports implement one of two interfaces:
-
-### McpTransportInterface (Base)
 ```php
 interface McpTransportInterface {
     public function __construct( McpTransportContext $context );
@@ -31,7 +20,8 @@ interface McpTransportInterface {
 }
 ```
 
-### McpRestTransportInterface (REST-specific)
+REST transports also implement `McpRestTransportInterface`:
+
 ```php
 interface McpRestTransportInterface extends McpTransportInterface {
     public function check_permission( WP_REST_Request $request );
@@ -39,148 +29,109 @@ interface McpRestTransportInterface extends McpTransportInterface {
 }
 ```
 
-### Helper Trait
-Use `McpTransportHelperTrait` for common functionality:
+`McpTransportHelperTrait` provides the normalized transport name used for observability:
+
 ```php
 use WP\MCP\Transport\Infrastructure\McpTransportHelperTrait;
 
 class MyTransport implements McpRestTransportInterface {
     use McpTransportHelperTrait;
-    
-    // Provides get_transport_name() method
 }
 ```
 
-## Creating Custom Transports
+## Route a request
 
-### Basic Example: API Key Transport
+Call `RequestRouter::route_request()` with the MCP method, params, request ID, and transport name. Existing four- and five-argument calls remain compatible and default to the legacy revision when no other selector exists.
 
-```php
-<?php
-use WP\MCP\Transport\Contracts\McpRestTransportInterface;
-use WP\MCP\Transport\Infrastructure\McpTransportContext;
-use WP\MCP\Transport\Infrastructure\McpTransportHelperTrait;
+When the transport knows the revision, pass it as the optional sixth argument:
 
-class ApiKeyTransport implements McpRestTransportInterface {
-    use McpTransportHelperTrait;
-    
-    private McpTransportContext $context;
-    
-    public function __construct( McpTransportContext $context ) {
-        $this->context = $context;
-        $this->register_routes();
-    }
-    
-    public function register_routes(): void {
-        $server = $this->context->mcp_server;
-        
-        register_rest_route(
-            $server->get_server_route_namespace(),
-            $server->get_server_route(),
-            [
-                'methods' => ['POST', 'GET', 'DELETE'],
-                'callback' => [$this, 'handle_request'],
-                'permission_callback' => [$this, 'check_permission'],
-            ]
-        );
-    }
-    
-    public function check_permission( \WP_REST_Request $request ) {
-        $api_key = sanitize_text_field( $request->get_header( 'X-API-Key' ) );
-
-        if ( empty( $api_key ) ) {
-            return false;
-        }
-
-        // Validate against stored keys
-        $valid_keys = get_option( 'mcp_api_keys', array() );
-        return in_array( $api_key, $valid_keys, true );
-    }
-    
-    public function handle_request( \WP_REST_Request $request ): \WP_REST_Response {
-        $body = $request->get_json_params();
-        
-        if ( empty( $body['method'] ) ) {
-            return new \WP_REST_Response( 
-                ['error' => 'MCP method required'], 
-                400 
-            );
-        }
-        
-        // Route through the request router
-        $result = $this->context->request_router->route_request(
-            $body['method'],
-            $body['params'] ?? [],
-            $body['id'] ?? 0,
-            $this->get_transport_name()
-        );
-        
-        return rest_ensure_response( $result );
-    }
-}
-```
-
-### Using the Custom Transport
-
-```php
-add_action( 'mcp_adapter_init', function( $adapter ) {
-    $adapter->create_server(
-        'api-key-server',
-        'my-plugin',
-        'secure-mcp',
-        'Secure MCP Server',
-        'MCP server with API key authentication',
-        '1.0.0',
-        array( ApiKeyTransport::class ), // Use custom transport
-        \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,
-        null,                            // Observability handler (null = default)
-        array( 'my-plugin/secure-tool' ) // Tools
-    );
-});
-```
-
-## Transport Permissions vs Custom Transports
-
-### Use Transport Permissions For:
-- ✅ **Authentication logic** (role checks, API keys)
-- ✅ **User-based permissions** (capability validation)
-- ✅ **Time-based access** (business hours)
-- ✅ **Most authorization needs**
-
-See [Transport Permissions](transport-permissions.md) for simpler authentication solutions.
-
-### Use Custom Transports For:
-- ✅ **Custom routing patterns**
-- ✅ **Message queue integration**
-- ✅ **Request signing/encryption**
-- ✅ **Specialized protocols**
-
-## Implementation Notes
-
-### Required Methods
-- `__construct()`: Accept `McpTransportContext` and call `register_routes()`
-- `register_routes()`: Register WordPress REST API endpoints
-- `check_permission()`: Validate request access (REST transports only)
-- `handle_request()`: Process MCP requests (REST transports only)
-
-### Helper Trait Benefits
-- `get_transport_name()`: Normalized transport name for metrics
-- Consistent naming conventions
-- Shared utility methods
-
-### Request Routing
-All transports use the injected `request_router` to process MCP methods:
 ```php
 $result = $this->context->request_router->route_request(
     $method,
     $params,
     $request_id,
-    $this->get_transport_name()
+    $this->get_transport_name(),
+    null,              // HttpRequestContext, when available.
+    $protocol_version  // "2025-11-25", "2026-07-28", or null.
 );
 ```
 
-## Next Steps
+The router also reads `params._meta["io.modelcontextprotocol/protocolVersion"]` for modern requests and `params.protocolVersion` for `initialize`. An explicit version does not replace transport-level lifecycle enforcement. A custom transport is responsible for:
 
-- **[Transport Permissions](transport-permissions.md)** - Simpler authentication approach
-- **[Error Handling](error-handling.md)** - Custom error management
-- **[Architecture Overview](../architecture/overview.md)** - System design
+- validating the top-level JSON-RPC envelope before routing;
+- suppressing responses to notifications and client responses;
+- retaining the negotiated `2025-11-25` version and any session identity between legacy requests;
+- requiring and comparing the relevant protocol headers when its delivery mechanism uses them;
+- keeping MCP 2026-07-28 requests independent and passing their exact declared version;
+- authenticating the caller before routing; and
+- wrapping the router's bare result or `error` array in the transport's JSON-RPC envelope.
+
+## REST example
+
+For a custom REST route, extend the built-in `HttpTransport` so JSON-RPC envelopes, notifications, batches, lossless JSON decoding, protocol headers, and legacy sessions keep the same behavior as the default route. Customize authentication with the server's transport permission callback.
+
+```php
+<?php
+use WP\MCP\Transport\HttpTransport;
+
+class CustomRouteTransport extends HttpTransport {
+
+    public function register_routes(): void {
+        $server = $this->request_handler->get_transport_context()->mcp_server;
+
+        register_rest_route(
+            $server->get_server_route_namespace(),
+            '/custom/' . ltrim( $server->get_server_route(), '/' ),
+            array(
+                'methods'             => array( 'POST', 'GET', 'DELETE' ),
+                'callback'            => array( $this, 'handle_request' ),
+                'permission_callback' => array( $this, 'check_permission' ),
+            )
+        );
+    }
+}
+```
+
+The inherited request path keeps nested JSON objects as `stdClass` and JSON lists as PHP arrays until exact schema validation. A transport that implements another delivery mechanism should use `JsonRpcRequestDecoder` and `JsonRpcRequestParams` for the same lossless boundary. Do not replace this boundary with `WP_REST_Request::get_json_params()` when accepting raw JSON.
+
+Register the transport when creating a server:
+
+```php
+add_action( 'mcp_adapter_init', function( $adapter ) {
+    $adapter->create_server(
+        'custom-route-server',
+        'my-plugin',
+        'secure-mcp',
+        'Custom Route MCP Server',
+        'MCP server exposed on a custom REST route',
+        '1.0.0',
+        array( CustomRouteTransport::class ),
+        \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,
+        null,
+        array( 'my-plugin/secure-tool' ),
+        array(),
+        array(),
+        static function(): bool {
+            return current_user_can( 'manage_options' );
+        }
+    );
+} );
+```
+
+## When a custom transport is appropriate
+
+Use transport permissions for role checks, API keys on the built-in route, user capabilities, and other authorization rules.
+
+Use a custom transport for:
+
+- custom routing or URL structures;
+- message queues such as Redis, RabbitMQ, or Amazon SQS;
+- request signing, encryption, or data masking; or
+- delivery mechanisms other than HTTP and STDIO.
+
+## Next steps
+
+- [Protocol versions](protocol-versions.md) — implement the exact lifecycle for each supported revision
+- [Transport permissions](transport-permissions.md) — customize access to built-in transports
+- [Error handling](error-handling.md) — integrate custom error management
+- [Architecture overview](../architecture/overview.md) — understand request routing and schema serialization

--- a/docs/guides/protocol-versions.md
+++ b/docs/guides/protocol-versions.md
@@ -1,0 +1,172 @@
+# Protocol versions
+
+The MCP Adapter supports exactly two Model Context Protocol revisions. They use different lifecycles and cannot be treated as a feature flag on one wire format.
+
+| Behavior | MCP 2025-11-25 | MCP 2026-07-28 |
+|----------|----------------|----------------|
+| Lifecycle | `initialize`, then session-bound requests | Independent stateless requests |
+| Version selection | Negotiated during `initialize` | Declared in every request's `_meta` |
+| Discovery | Initialize result | `server/discover` |
+| HTTP session ID | Required after initialize | Not used |
+| `ping` | Supported | Method not found |
+| Multi-round continuation | Not supported | Supported for call/read/get operations |
+
+The Adapter validates each request and response with the descriptor-backed `php-mcp-schema` catalog for its exact revision. Unsupported modern revisions return JSON-RPC error `-32022`.
+
+## MCP 2025-11-25
+
+Legacy clients start with `initialize`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "example-client",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+The response negotiates `2025-11-25`. If the client requests another revision through this legacy lifecycle, the Adapter falls back to `2025-11-25`; `initialize` never selects the stateless 2026 revision. After a successful response, send the `notifications/initialized` notification before ordinary operations.
+
+For HTTP, the initialize response includes `Mcp-Session-Id`. Every later JSON-RPC request in the session must send both:
+
+- `Mcp-Session-Id: <value returned by initialize>`
+- `MCP-Protocol-Version: 2025-11-25`
+
+The protocol header must match the version retained in the session. A client can terminate the session with an authenticated `DELETE` carrying its `Mcp-Session-Id`.
+
+For STDIO, send `initialize` before other legacy requests in the same `wp mcp-adapter serve` process. The bridge retains the negotiated legacy version for that process.
+
+## MCP 2026-07-28
+
+Modern clients do not initialize or create a session. Start with `server/discover`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "server/discover",
+  "params": {
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "example-client",
+        "version": "1.0.0"
+      },
+      "io.modelcontextprotocol/clientCapabilities": {}
+    }
+  }
+}
+```
+
+The discovery result advertises `2026-07-28` and `2025-11-25`, the server's implemented capabilities, server information, and private zero-duration cache fields.
+
+Every modern request must include these fields in `params._meta`:
+
+- `io.modelcontextprotocol/protocolVersion`, set to `2026-07-28`; and
+- `io.modelcontextprotocol/clientCapabilities`, including any capability used by embedded input requests.
+
+The optional `io.modelcontextprotocol/clientInfo` field identifies the client when supplied, as in the discovery example above. Over HTTP, send `MCP-Protocol-Version: 2026-07-28`; its value must match the body metadata. Do not send `Mcp-Session-Id` for modern requests.
+
+For example, a stateless tools-list request is:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list",
+  "params": {
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientCapabilities": {}
+    }
+  }
+}
+```
+
+Modern results include `resultType` and server information. `server/discover`, `tools/list`, `resources/list`, `resources/templates/list`, `resources/read`, and `prompts/list` also include their exact cache fields. MCP 2026-07-28 has no `ping` method.
+
+## Multi-round continuation
+
+MCP 2026-07-28 permits `tools/call`, `resources/read`, and `prompts/get` to return `resultType: "input_required"`. The client answers the embedded requests, then retries the original operation under a new JSON-RPC ID with `inputResponses` and any returned `requestState`.
+
+Direct component callbacks can opt in by accepting `McpContinuationContext` as a second argument and returning `McpExecutionResult`. Existing one-argument callbacks continue to work. Ability-backed execution and prompt-builder callbacks keep their existing signatures.
+
+This tool asks the client for confirmation on the first round and completes on the next round:
+
+```php
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
+use WP\MCP\Domain\Tools\McpTool;
+
+$tool = McpTool::fromArray(
+    array(
+        'name'        => 'confirm-operation',
+        'inputSchema' => array(
+            'type'       => 'object',
+            'properties' => array(),
+        ),
+        'permission'  => static function(): bool {
+            return current_user_can( 'edit_posts' );
+        },
+        'handler'     => static function( array $arguments, ?McpContinuationContext $continuation ): McpExecutionResult {
+            if ( null === $continuation || ! $continuation->is_resumed() ) {
+                return McpExecutionResult::input_required(
+                    array(
+                        'confirm' => array(
+                            'method' => 'elicitation/create',
+                            'params' => array(
+                                'mode'            => 'form',
+                                'message'         => 'Confirm this operation.',
+                                'requestedSchema' => array(
+                                    'type'       => 'object',
+                                    'properties' => array(
+                                        'confirmed' => array( 'type' => 'boolean' ),
+                                    ),
+                                    'required'   => array( 'confirmed' ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    'confirm-operation-v1'
+                );
+            }
+
+            $responses = $continuation->get_input_responses();
+            $response  = $responses['confirm'] ?? array();
+            $accepted  = 'accept' === ( $response['action'] ?? null )
+                && true === ( $response['content']['confirmed'] ?? false );
+
+            return McpExecutionResult::complete(
+                array( 'confirmed' => $accepted )
+            );
+        },
+    )
+);
+```
+
+The client must advertise `elicitation` in `io.modelcontextprotocol/clientCapabilities` before the callback can return an `elicitation/create` input request. The Adapter rejects an input-required result when the corresponding client capability is absent.
+
+### State and security ownership
+
+The Adapter does not persist continuation state. It passes `requestState` back to the client and returns it to the callback on the next independent request. The callback owner must therefore:
+
+- keep state small and versioned;
+- avoid secrets or personal data in plaintext state;
+- sign or encrypt state when integrity or confidentiality matters;
+- treat `requestState` and `inputResponses` as untrusted client input;
+- revalidate authorization, referenced objects, and business preconditions on every round; and
+- make retries and duplicate submissions safe.
+
+Use `McpExecutionResult::complete( $value )` only for the final callback value. Do not perform a privileged or destructive action solely because the client returned an accepted elicitation response.
+
+## Custom transports
+
+The built-in HTTP and STDIO transports enforce these lifecycles. A [custom transport](custom-transports.md) should pass the exact revision as the optional sixth argument to `RequestRouter::route_request()` when known. Existing calls that omit it remain compatible and use legacy selection unless request metadata or `server/discover` identifies the modern revision.

--- a/includes/Cli/StdioServerBridge.php
+++ b/includes/Cli/StdioServerBridge.php
@@ -15,6 +15,8 @@ namespace WP\MCP\Cli;
 use WP\MCP\Core\McpServer;
 use WP\MCP\Core\McpVersionNegotiator;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
+use WP\MCP\Transport\Infrastructure\JsonRpcRequestDecoder;
+use WP\MCP\Transport\Infrastructure\JsonRpcRequestParams;
 use WP\MCP\Transport\Infrastructure\JsonRpcResponseBuilder;
 use WP\MCP\Transport\Infrastructure\RequestRouter;
 
@@ -181,9 +183,10 @@ class StdioServerBridge {
 	private function handle_request( string $json_input ): string {
 		try {
 			// Parse JSON-RPC request
-			$request = json_decode( $json_input, true );
+			$valid_json = false;
+			$request    = JsonRpcRequestDecoder::decode( $json_input, $valid_json );
 
-			if ( json_last_error() !== JSON_ERROR_NONE ) {
+			if ( ! $valid_json ) {
 				return $this->create_error_response(
 					null,
 					McpErrorFactory::PARSE_ERROR,
@@ -214,7 +217,10 @@ class StdioServerBridge {
 
 			// Extract request components
 			$method = $request['method'] ?? null;
-			$params = $request['params'] ?? array();
+			$params = new JsonRpcRequestParams(
+				array_key_exists( 'params', $request ),
+				$request['params'] ?? null
+			);
 			$id     = $request['id'] ?? null;
 
 			if ( ! is_string( $method ) ) {
@@ -226,27 +232,23 @@ class StdioServerBridge {
 				);
 			}
 
-			// Convert params to array if it's an object
-			if ( is_object( $params ) ) {
-				$params = (array) $params;
-			}
-
-			if ( ! is_array( $params ) ) {
-				$params = array();
-			}
 			if ( null === $id ) {
 				return '';
 			}
 
-			$metadata_version = $params['_meta']['io.modelcontextprotocol/protocolVersion'] ?? null;
+			$params_value     = $params->get_value();
+			$params_array     = $params_value instanceof \stdClass ? get_object_vars( $params_value ) : $params_value;
+			$meta             = is_array( $params_array ) ? ( $params_array['_meta'] ?? null ) : null;
+			$meta_array       = $meta instanceof \stdClass ? get_object_vars( $meta ) : $meta;
+			$metadata_version = is_array( $meta_array ) ? ( $meta_array['io.modelcontextprotocol/protocolVersion'] ?? null ) : null;
 			$protocol_version = is_string( $metadata_version ) ? $metadata_version : null;
 			if ( 'server/discover' === $method && null === $protocol_version ) {
 				$protocol_version = McpVersionNegotiator::MODERN_PROTOCOL_VERSION;
 			}
 			$negotiated_after_success = null;
 			if ( 'initialize' === $method ) {
-				$requested_protocol_version = isset( $params['protocolVersion'] ) && is_string( $params['protocolVersion'] )
-					? $params['protocolVersion']
+				$requested_protocol_version = is_array( $params_array ) && isset( $params_array['protocolVersion'] ) && is_string( $params_array['protocolVersion'] )
+					? $params_array['protocolVersion']
 					: '';
 				$negotiated_after_success   = McpVersionNegotiator::negotiate( $requested_protocol_version );
 			} elseif ( null === $protocol_version ) {

--- a/includes/Cli/StdioServerBridge.php
+++ b/includes/Cli/StdioServerBridge.php
@@ -13,6 +13,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Cli;
 
 use WP\MCP\Core\McpServer;
+use WP\MCP\Core\McpVersionNegotiator;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Transport\Infrastructure\JsonRpcResponseBuilder;
 use WP\MCP\Transport\Infrastructure\RequestRouter;
@@ -46,6 +47,9 @@ class StdioServerBridge {
 	 * @var bool
 	 */
 	private bool $is_running = false;
+
+	/** Negotiated protocol for the legacy STDIO lifecycle. */
+	private ?string $legacy_protocol_version = null;
 
 	/**
 	 * Initialize the STDIO server bridge.
@@ -230,18 +234,43 @@ class StdioServerBridge {
 			if ( ! is_array( $params ) ) {
 				$params = array();
 			}
+			if ( null === $id ) {
+				return '';
+			}
 
-			// Route the request to the appropriate handler
+			$metadata_version = $params['_meta']['io.modelcontextprotocol/protocolVersion'] ?? null;
+			$protocol_version = is_string( $metadata_version ) ? $metadata_version : null;
+			if ( 'server/discover' === $method && null === $protocol_version ) {
+				$protocol_version = McpVersionNegotiator::MODERN_PROTOCOL_VERSION;
+			}
+			$negotiated_after_success = null;
+			if ( 'initialize' === $method ) {
+				$requested_protocol_version = isset( $params['protocolVersion'] ) && is_string( $params['protocolVersion'] )
+					? $params['protocolVersion']
+					: '';
+				$negotiated_after_success   = McpVersionNegotiator::negotiate( $requested_protocol_version );
+			} elseif ( null === $protocol_version ) {
+				if ( null === $this->legacy_protocol_version ) {
+					return $this->create_error_response(
+						$id,
+						McpErrorFactory::INVALID_REQUEST,
+						'Invalid Request: Legacy STDIO clients must initialize before sending requests.'
+					);
+				}
+				$protocol_version = $this->legacy_protocol_version;
+			}
+
+			// Route the request to the appropriate handler.
 			$result = $this->request_router->route_request(
 				$method,
 				$params,
 				$id,
-				'stdio'
+				'stdio',
+				null,
+				$protocol_version
 			);
-
-			// If this is a notification (no id), don't send a response
-			if ( null === $id ) {
-				return '';
+			if ( null !== $negotiated_after_success && ! isset( $result['error'] ) ) {
+				$this->legacy_protocol_version = $negotiated_after_success;
 			}
 
 			// Format the response

--- a/includes/Core/McpComponentRegistry.php
+++ b/includes/Core/McpComponentRegistry.php
@@ -18,9 +18,6 @@ use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface;
 use WP\MCP\Infrastructure\Observability\FailureReason;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 use WP_Error;
 
 /**
@@ -139,9 +136,8 @@ class McpComponentRegistry {
 		if ( $tool_item instanceof McpTool ) {
 			$this->add_mcp_tool( $tool_item );
 
-			/** @var \WP\McpSchema\Server\Tools\DTO\Tool $tool_dto */
-			$tool_dto = $tool_item->get_protocol_dto();
-			$this->track_registration( 'tool', $tool_dto->getName(), 'success' );
+			$tool_data = $tool_item->get_protocol_data();
+			$this->track_registration( 'tool', (string) $tool_data['name'], 'success' );
 
 			return;
 		}
@@ -173,9 +169,8 @@ class McpComponentRegistry {
 	 *
 	 */
 	private function add_mcp_tool( McpTool $mcp_tool ): void {
-		/** @var \WP\McpSchema\Server\Tools\DTO\Tool $tool_dto */
-		$tool_dto  = $mcp_tool->get_protocol_dto();
-		$tool_name = $tool_dto->getName();
+		$tool_data = $mcp_tool->get_protocol_data();
+		$tool_name = (string) $tool_data['name'];
 
 		if ( isset( $this->mcp_tools[ $tool_name ] ) ) {
 			$this->error_handler->log(
@@ -278,9 +273,8 @@ class McpComponentRegistry {
 		if ( $resource_item instanceof McpResource ) {
 			$this->add_mcp_resource( $resource_item );
 
-			/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto */
-			$resource_dto = $resource_item->get_protocol_dto();
-			$this->track_registration( 'resource', $resource_dto->getUri(), 'success' );
+			$resource_data = $resource_item->get_protocol_data();
+			$this->track_registration( 'resource', (string) $resource_data['uri'], 'success' );
 
 			return;
 		}
@@ -313,9 +307,8 @@ class McpComponentRegistry {
 	 *
 	 */
 	private function add_mcp_resource( McpResource $mcp_resource ): bool {
-		/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto */
-		$resource_dto = $mcp_resource->get_protocol_dto();
-		$uri          = $resource_dto->getUri();
+		$resource_data = $mcp_resource->get_protocol_data();
+		$uri           = (string) $resource_data['uri'];
 
 		if ( isset( $this->mcp_resources[ $uri ] ) ) {
 			$this->error_handler->log(
@@ -371,15 +364,14 @@ class McpComponentRegistry {
 		if ( $added ) {
 			$this->track_registration( 'resource', $ability_name, 'success' );
 		} else {
-			/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto */
-			$resource_dto = $mcp_resource->get_protocol_dto();
+			$resource_data = $mcp_resource->get_protocol_data();
 			$this->track_registration(
 				'resource',
 				$ability_name,
 				'failed',
 				array(
 					'failure_reason' => FailureReason::DUPLICATE_URI,
-					'duplicate_uri'  => $resource_dto->getUri(),
+					'duplicate_uri'  => (string) $resource_data['uri'],
 				)
 			);
 		}
@@ -417,9 +409,8 @@ class McpComponentRegistry {
 		if ( $prompt_item instanceof McpPrompt ) {
 			$this->add_mcp_prompt( $prompt_item );
 
-			/** @var \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt_dto */
-			$prompt_dto = $prompt_item->get_protocol_dto();
-			$this->track_registration( 'prompt', $prompt_dto->getName(), 'success' );
+			$prompt_data = $prompt_item->get_protocol_data();
+			$this->track_registration( 'prompt', (string) $prompt_data['name'], 'success' );
 
 			return;
 		}
@@ -467,9 +458,8 @@ class McpComponentRegistry {
 	 *
 	 */
 	private function add_mcp_prompt( McpPrompt $mcp_prompt ): void {
-		/** @var \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt */
-		$prompt      = $mcp_prompt->get_protocol_dto();
-		$prompt_name = $prompt->getName();
+		$prompt_data = $mcp_prompt->get_protocol_data();
+		$prompt_name = (string) $prompt_data['name'];
 
 		if ( isset( $this->mcp_prompts[ $prompt_name ] ) ) {
 			$this->error_handler->log(
@@ -573,11 +563,11 @@ class McpComponentRegistry {
 	/**
 	 * Get all tools registered to the server.
 	 *
-	 * @return array<string, \WP\McpSchema\Server\Tools\DTO\Tool>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public function get_tools(): array {
 		return array_map(
-			static fn( McpTool $mcp_tool ): ToolDto => $mcp_tool->get_protocol_dto(),
+			static fn( McpTool $mcp_tool ): array => $mcp_tool->get_protocol_data(),
 			$this->mcp_tools
 		);
 	}
@@ -585,11 +575,11 @@ class McpComponentRegistry {
 	/**
 	 * Get all resources registered to the server.
 	 *
-	 * @return array<string, \WP\McpSchema\Server\Resources\DTO\Resource>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public function get_resources(): array {
 		return array_map(
-			static fn( McpResource $mcp_resource ): ResourceDto => $mcp_resource->get_protocol_dto(),
+			static fn( McpResource $mcp_resource ): array => $mcp_resource->get_protocol_data(),
 			$this->mcp_resources
 		);
 	}
@@ -597,11 +587,11 @@ class McpComponentRegistry {
 	/**
 	 * Get all prompts registered to the server.
 	 *
-	 * @return array<string, \WP\McpSchema\Server\Prompts\DTO\Prompt>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public function get_prompts(): array {
 		return array_map(
-			static fn( McpPrompt $mcp_prompt ): PromptDto => $mcp_prompt->get_protocol_dto(),
+			static fn( McpPrompt $mcp_prompt ): array => $mcp_prompt->get_protocol_data(),
 			$this->mcp_prompts
 		);
 	}

--- a/includes/Core/McpProtocolContext.php
+++ b/includes/Core/McpProtocolContext.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Exact MCP protocol context for one request.
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Core;
+
+use WP\McpSchema\Contract\RevisionSchema;
+use WP\McpSchema\Schemas;
+
+/**
+ * Retains the exact protocol revision, schema catalog, and modern request metadata.
+ *
+ * @internal
+ * @phpstan-import-type SupportedRevisionSchema from Schemas
+ */
+final class McpProtocolContext {
+
+	/** @var string */
+	private string $protocol_version;
+
+	/** @var SupportedRevisionSchema */
+	private RevisionSchema $schema;
+
+	/** @var array<string, mixed> */
+	private array $client_capabilities;
+
+	/**
+	 * @param string                   $protocol_version MCP protocol revision.
+	 * @param SupportedRevisionSchema $schema Exact schema catalog.
+	 * @param array<string, mixed>     $client_capabilities Per-request modern client capabilities.
+	 */
+	private function __construct( string $protocol_version, RevisionSchema $schema, array $client_capabilities ) {
+		$this->protocol_version    = $protocol_version;
+		$this->schema              = $schema;
+		$this->client_capabilities = $client_capabilities;
+	}
+
+	/**
+	 * Create a context for an exact supported protocol revision.
+	 *
+	 * @param string               $protocol_version MCP protocol revision.
+	 * @param array<string, mixed> $client_capabilities Per-request modern client capabilities.
+	 */
+	public static function for_version( string $protocol_version, array $client_capabilities = array() ): self {
+		$schema_revision = McpVersionNegotiator::schema_revision( $protocol_version );
+
+		return new self( $protocol_version, Schemas::revision( $schema_revision ), $client_capabilities );
+	}
+
+	public function get_protocol_version(): string {
+		return $this->protocol_version;
+	}
+
+	/** @return SupportedRevisionSchema */
+	public function get_schema(): RevisionSchema {
+		return $this->schema;
+	}
+
+	/** @return array<string, mixed> */
+	public function get_client_capabilities(): array {
+		return $this->client_capabilities;
+	}
+
+	public function is_modern(): bool {
+		return McpVersionNegotiator::MODERN_PROTOCOL_VERSION === $this->protocol_version;
+	}
+}

--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -18,7 +18,6 @@ use WP\MCP\Infrastructure\ErrorHandling\NullMcpErrorHandler;
 use WP\MCP\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface;
 use WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 
 /**
  * WordPress MCP Server - Represents a single MCP server with its tools, resources, and prompts.
@@ -338,7 +337,7 @@ class McpServer {
 	/**
 	 * Get all tools registered to this server.
 	 *
-	 * @return array<string, \WP\McpSchema\Server\Tools\DTO\Tool>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public function get_tools(): array {
 		return $this->component_registry->get_tools();
@@ -347,7 +346,7 @@ class McpServer {
 	/**
 	 * Get all resources registered to this server.
 	 *
-	 * @return array<string, \WP\McpSchema\Server\Resources\DTO\Resource>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public function get_resources(): array {
 		return $this->component_registry->get_resources();
@@ -356,7 +355,7 @@ class McpServer {
 	/**
 	 * Get all prompts registered to this server.
 	 *
-	 * @return array<string, \WP\McpSchema\Server\Prompts\DTO\Prompt>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public function get_prompts(): array {
 		return $this->component_registry->get_prompts();
@@ -395,12 +394,12 @@ class McpServer {
 	 *
 	 * @param string $prompt_name Prompt name.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|null
+	 * @return array<string, mixed>|null
 	 */
-	public function get_prompt( string $prompt_name ): ?PromptDto {
+	public function get_prompt( string $prompt_name ): ?array {
 		$mcp_prompt = $this->component_registry->get_mcp_prompt( $prompt_name );
 
-		return $mcp_prompt ? $mcp_prompt->get_protocol_dto() : null;
+		return $mcp_prompt ? $mcp_prompt->get_protocol_data() : null;
 	}
 
 	/**

--- a/includes/Core/McpVersionNegotiator.php
+++ b/includes/Core/McpVersionNegotiator.php
@@ -12,14 +12,17 @@ namespace WP\MCP\Core;
 /**
  * Negotiates the MCP protocol version between client and server.
  *
- * If the client requests a supported version, the server echoes it back.
- * Otherwise the server falls back to the latest supported version.
+ * Legacy initialization negotiates the session-based 2025 revision. Modern
+ * requests select the 2026 revision independently through request metadata.
  *
  * This is a Core layer class — no WordPress function calls.
  *
  * @since 0.5.0
  */
 final class McpVersionNegotiator {
+
+	public const LEGACY_PROTOCOL_VERSION = '2025-11-25';
+	public const MODERN_PROTOCOL_VERSION = '2026-07-28';
 
 	/**
 	 * Protocol versions supported by this server, ordered newest-first.
@@ -28,16 +31,16 @@ final class McpVersionNegotiator {
 	 */
 	// phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- False positive: sniff mistakes array() commas for multi-const commas (only handles short syntax).
 	public const SUPPORTED_PROTOCOL_VERSIONS = array(
-		'2025-11-25',
-		'2025-06-18',
-		'2024-11-05',
+		self::MODERN_PROTOCOL_VERSION,
+		self::LEGACY_PROTOCOL_VERSION,
 	);
 
 	/**
 	 * Negotiate the protocol version to use for a session.
 	 *
-	 * If the client-requested version is in the supported list it is echoed
-	 * back verbatim. Otherwise the latest supported version is returned.
+	 * The legacy lifecycle cannot negotiate into the stateless modern protocol.
+	 * Unsupported initialize versions therefore fall back to the supported
+	 * legacy revision as required by the 2025 lifecycle.
 	 *
 	 * @since 0.5.0
 	 *
@@ -46,11 +49,11 @@ final class McpVersionNegotiator {
 	 * @return string The negotiated protocol version.
 	 */
 	public static function negotiate( string $client_version ): string {
-		if ( in_array( $client_version, self::SUPPORTED_PROTOCOL_VERSIONS, true ) ) {
+		if ( self::LEGACY_PROTOCOL_VERSION === $client_version ) {
 			return $client_version;
 		}
 
-		return self::SUPPORTED_PROTOCOL_VERSIONS[0];
+		return self::LEGACY_PROTOCOL_VERSION;
 	}
 
 	/**
@@ -64,5 +67,18 @@ final class McpVersionNegotiator {
 	 */
 	public static function is_supported( string $version ): bool {
 		return in_array( $version, self::SUPPORTED_PROTOCOL_VERSIONS, true );
+	}
+
+	/**
+	 * Map a supported MCP protocol revision to its exact schema revision.
+	 *
+	 * @throws \InvalidArgumentException For an unsupported revision.
+	 */
+	public static function schema_revision( string $protocol_version ): string {
+		if ( self::is_supported( $protocol_version ) ) {
+			return $protocol_version;
+		}
+
+		throw new \InvalidArgumentException( sprintf( 'Unsupported MCP protocol version: %s', $protocol_version ) );
 	}
 }

--- a/includes/Domain/Continuation/McpContinuationContext.php
+++ b/includes/Domain/Continuation/McpContinuationContext.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Stateless continuation input passed to opt-in component callbacks.
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Domain\Continuation;
+
+/**
+ * Carries client responses and opaque request state for a resumed modern request.
+ */
+final class McpContinuationContext {
+
+	/** @var array<string, mixed> */
+	private array $input_responses;
+
+	/** @var string|null */
+	private ?string $request_state;
+
+	/** @var array<string, mixed> */
+	private array $client_capabilities;
+
+	/**
+	 * @param array<string, mixed> $input_responses Responses keyed by input request ID.
+	 * @param string|null          $request_state Opaque callback-owned state.
+	 * @param array<string, mixed> $client_capabilities Capabilities declared for this request.
+	 */
+	public function __construct( array $input_responses = array(), ?string $request_state = null, array $client_capabilities = array() ) {
+		$this->input_responses     = $input_responses;
+		$this->request_state       = $request_state;
+		$this->client_capabilities = $client_capabilities;
+	}
+
+	/** @return array<string, mixed> */
+	public function get_input_responses(): array {
+		return $this->input_responses;
+	}
+
+	public function get_request_state(): ?string {
+		return $this->request_state;
+	}
+
+	/** @return array<string, mixed> */
+	public function get_client_capabilities(): array {
+		return $this->client_capabilities;
+	}
+
+	public function is_resumed(): bool {
+		return ! empty( $this->input_responses ) || null !== $this->request_state;
+	}
+}

--- a/includes/Domain/Continuation/McpExecutionResult.php
+++ b/includes/Domain/Continuation/McpExecutionResult.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Additive component result contract for complete and input-required outcomes.
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Domain\Continuation;
+
+/**
+ * Allows direct component callbacks to request stateless modern continuation.
+ */
+final class McpExecutionResult {
+
+	/** @var bool */
+	private bool $input_required;
+
+	/** @var mixed */
+	private $value;
+
+	/** @var array<string, mixed> */
+	private array $input_requests;
+
+	/** @var string|null */
+	private ?string $request_state;
+
+	/**
+	 * @param bool                 $input_required Whether more client input is required.
+	 * @param mixed                $value Completed callback value.
+	 * @param array<string, mixed> $input_requests Embedded MCP client requests.
+	 * @param string|null          $request_state Opaque callback-owned state.
+	 */
+	private function __construct( bool $input_required, $value, array $input_requests, ?string $request_state ) {
+		$this->input_required = $input_required;
+		$this->value          = $value;
+		$this->input_requests = $input_requests;
+		$this->request_state  = $request_state;
+	}
+
+	/** @param mixed $value */
+	public static function complete( $value ): self {
+		return new self( false, $value, array(), null );
+	}
+
+	/**
+	 * @param array<string, mixed> $input_requests Embedded requests keyed by request ID.
+	 * @param string|null          $request_state Opaque state returned on retry.
+	 */
+	public static function input_required( array $input_requests = array(), ?string $request_state = null ): self {
+		if ( empty( $input_requests ) && null === $request_state ) {
+			throw new \InvalidArgumentException( 'Input-required results need input requests or request state.' );
+		}
+
+		return new self( true, null, $input_requests, $request_state );
+	}
+
+	public function is_input_required(): bool {
+		return $this->input_required;
+	}
+
+	/** @return mixed */
+	public function get_value() {
+		return $this->value;
+	}
+
+	/** @return array<string, mixed> */
+	public function get_input_requests(): array {
+		return $this->input_requests;
+	}
+
+	public function get_request_state(): ?string {
+		return $this->request_state;
+	}
+}

--- a/includes/Domain/Contracts/McpComponentInterface.php
+++ b/includes/Domain/Contracts/McpComponentInterface.php
@@ -9,16 +9,16 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Contracts;
 
-use WP\McpSchema\Common\AbstractDataTransferObject;
+use WP\MCP\Domain\Continuation\McpContinuationContext;
 
 /**
  * Interface McpComponentInterface.
  *
  * Classes implementing this interface encapsulate:
- * - a clean protocol DTO (Tool/Resource/Prompt) that is safe to expose to MCP clients, and
+ * - clean, revision-neutral protocol data that is safe to expose to MCP clients, and
  * - MCP Adapter internal metadata and execution wiring (ability-backed OR direct-callable).
  *
- * This keeps protocol DTOs free of internal adapter fields, while still
+ * This keeps protocol data free of internal adapter fields, while still
  * providing a uniform execution and permission-check surface for handlers.
  *
  * @internal
@@ -28,16 +28,16 @@ use WP\McpSchema\Common\AbstractDataTransferObject;
 interface McpComponentInterface {
 
 	/**
-	 * Get the clean protocol DTO for MCP responses.
+	 * Get clean, revision-neutral protocol data for MCP responses.
 	 *
-	 * This DTO is used only for protocol serialization and MUST NOT include
+	 * This data is used only for protocol serialization and MUST NOT include
 	 * internal adapter metadata or execution wiring.
 	 *
-	 * @return \WP\McpSchema\Common\AbstractDataTransferObject Protocol-only DTO.
+	 * @return array<string, mixed> Protocol-only data.
 	 * @since 0.5.0
 	 *
 	 */
-	public function get_protocol_dto(): AbstractDataTransferObject;
+	public function get_protocol_data(): array;
 
 	/**
 	 * Execute the component using the configured strategy.
@@ -47,12 +47,13 @@ interface McpComponentInterface {
 	 * - a direct callable handler (for non-ability registrations).
 	 *
 	 * @param mixed $arguments Component arguments (typically an associative array).
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional stateless continuation data.
 	 *
 	 * @return mixed Execution result.
 	 * @since 0.5.0
 	 *
 	 */
-	public function execute( $arguments );
+	public function execute( $arguments, ?McpContinuationContext $continuation = null );
 
 	/**
 	 * Check whether execution is permitted for the current request.
@@ -72,7 +73,7 @@ interface McpComponentInterface {
 	/**
 	 * Get MCP Adapter internal metadata for this component.
 	 *
-	 * This metadata MUST NOT be stored on protocol DTOs and MUST NOT be exposed to MCP clients.
+	 * This metadata MUST NOT be stored in protocol data and MUST NOT be exposed to MCP clients.
 	 *
 	 * @return array<string, mixed> Internal metadata.
 	 * @since 0.5.0
@@ -83,7 +84,7 @@ interface McpComponentInterface {
 	/**
 	 * Get observability context tags for logging/metrics.
 	 *
-	 * This replaces legacy approaches that derived observability tags from DTO `_meta`.
+	 * This replaces legacy approaches that derived observability tags from protocol `_meta`.
 	 *
 	 * @return array<string, mixed> Observability tags (component_type, source, etc.).
 	 * @since 0.5.0

--- a/includes/Domain/Prompts/Contracts/McpPromptBuilderInterface.php
+++ b/includes/Domain/Prompts/Contracts/McpPromptBuilderInterface.php
@@ -9,8 +9,6 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Prompts\Contracts;
 
-use WP\McpSchema\Server\Prompts\DTO\Prompt;
-
 /**
  * Interface for building MCP prompts.
  *
@@ -20,11 +18,11 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt;
 interface McpPromptBuilderInterface {
 
 	/**
-	 * Build and return the Prompt DTO instance.
+	 * Build and return revision-neutral prompt protocol data.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt The built prompt DTO.
+	 * @return array<string, mixed> The built prompt data.
 	 */
-	public function build(): Prompt;
+	public function build(): array;
 
 	/**
 	 * Get the unique name for this prompt.

--- a/includes/Domain/Prompts/Contracts/McpPromptBuilderInterface.php
+++ b/includes/Domain/Prompts/Contracts/McpPromptBuilderInterface.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Prompts\Contracts;
 
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
+
 /**
  * Interface for building MCP prompts.
  *
@@ -18,11 +20,11 @@ namespace WP\MCP\Domain\Prompts\Contracts;
 interface McpPromptBuilderInterface {
 
 	/**
-	 * Build and return revision-neutral prompt protocol data.
+	 * Build and return the descriptor-backed Prompt compatibility facade.
 	 *
-	 * @return array<string, mixed> The built prompt data.
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt The built prompt facade.
 	 */
-	public function build(): array;
+	public function build(): Prompt;
 
 	/**
 	 * Get the unique name for this prompt.

--- a/includes/Domain/Prompts/McpPrompt.php
+++ b/includes/Domain/Prompts/McpPrompt.php
@@ -260,7 +260,7 @@ final class McpPrompt implements McpComponentInterface {
 	 */
 	public static function fromBuilder( McpPromptBuilderInterface $builder ) {
 		try {
-			$prompt = $builder->build();
+			$prompt = $builder->build()->toArray();
 		} catch ( \Throwable $throwable ) {
 			return new WP_Error(
 				'mcp_prompt_builder_failed',

--- a/includes/Domain/Prompts/McpPrompt.php
+++ b/includes/Domain/Prompts/McpPrompt.php
@@ -10,13 +10,13 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Prompts;
 
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Contracts\McpComponentInterface;
 use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
 use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\Observability\FailureReason;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
-use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 use WP_Error;
 
 /**
@@ -48,9 +48,9 @@ use WP_Error;
  * $prompt = McpPrompt::fromBuilder($builder);
  * ```
  *
- * McpPrompt wraps a protocol-only PromptDto for MCP serialization. Internal
+ * McpPrompt stores protocol-only, revision-neutral data for MCP serialization. Internal
  * adapter metadata and execution wiring live on this class and are never
- * exposed to MCP clients. Use get_protocol_dto() for protocol responses.
+ * exposed to MCP clients. Use get_protocol_data() for protocol responses.
  *
  * @since 0.5.0
  */
@@ -62,11 +62,11 @@ final class McpPrompt implements McpComponentInterface {
 	// =========================================================================
 
 	/**
-	 * Clean Prompt DTO (protocol-only).
+	 * Clean prompt data (protocol-only).
 	 *
-	 * @var \WP\McpSchema\Server\Prompts\DTO\Prompt
+	 * @var array<string, mixed>
 	 */
-	private PromptDto $prompt;
+	private array $prompt;
 
 	/**
 	 * Ability used for execution/permission checks (ability-backed prompts).
@@ -117,9 +117,9 @@ final class McpPrompt implements McpComponentInterface {
 	/**
 	 * Private constructor - use factory methods.
 	 *
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The Prompt DTO.
+	 * @param array<string, mixed> $prompt Protocol-only prompt data.
 	 */
-	private function __construct( PromptDto $prompt ) {
+	private function __construct( array $prompt ) {
 		$this->prompt = $prompt;
 	}
 
@@ -152,10 +152,11 @@ final class McpPrompt implements McpComponentInterface {
 			}
 		}
 
-		$prompt_data = array(
-			'name'        => $config['name'],
-			'description' => $config['description'] ?? null,
-		);
+		$prompt_data = array( 'name' => $config['name'] );
+
+		if ( isset( $config['description'] ) ) {
+			$prompt_data['description'] = $config['description'];
+		}
 
 		if ( isset( $config['title'] ) ) {
 			$prompt_data['title'] = $config['title'];
@@ -170,48 +171,44 @@ final class McpPrompt implements McpComponentInterface {
 			$prompt_data['icons'] = $valid_icons;
 		}
 
-		// Create the Prompt DTO - wrap in try-catch since PromptArgument::fromArray() and PromptDto::fromArray() can throw.
-		try {
-			// Process arguments inside try-catch since PromptArgument::fromArray() can throw.
-			if ( isset( $config['arguments'] ) && is_array( $config['arguments'] ) && ! empty( $config['arguments'] ) ) {
-				$prompt_data['arguments'] = array_map(
-					static function ( array $arg ): PromptArgument {
-						return PromptArgument::fromArray(
-							array(
-								'name'        => $arg['name'],
-								'title'       => $arg['title'] ?? null,
-								'description' => $arg['description'] ?? null,
-								'required'    => $arg['required'] ?? null,
-							)
-						);
-					},
-					$config['arguments']
-				);
+		if ( isset( $config['arguments'] ) && is_array( $config['arguments'] ) && ! empty( $config['arguments'] ) ) {
+			foreach ( $config['arguments'] as $argument ) {
+				if ( ! is_array( $argument ) || ! isset( $argument['name'] ) || ! is_string( $argument['name'] ) || '' === trim( $argument['name'] ) ) {
+					return new WP_Error(
+						'mcp_prompt_dto_creation_failed',
+						__( 'Prompt arguments must include a non-empty string "name" field.', 'mcp-adapter' )
+					);
+				}
 			}
 
-			$prompt = PromptDto::fromArray( $prompt_data );
-		} catch ( \Throwable $e ) {
-			return new WP_Error(
-				'mcp_prompt_dto_creation_failed',
-				sprintf(
-				/* translators: %s: error message */
-					__( 'Failed to create Prompt DTO: %s', 'mcp-adapter' ),
-					$e->getMessage()
-				),
-				array( 'exception' => $e )
+			$prompt_data['arguments'] = array_map(
+				static function ( array $arg ): array {
+					$argument = array( 'name' => $arg['name'] );
+
+					foreach ( array( 'title', 'description', 'required' ) as $optional_field ) {
+						if ( ! isset( $arg[ $optional_field ] ) ) {
+							continue;
+						}
+
+						$argument[ $optional_field ] = $arg[ $optional_field ];
+					}
+
+					return $argument;
+				},
+				$config['arguments']
 			);
 		}
 
 		// Optional deep validation if enabled.
 		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
 		if ( $mcp_validation_enabled ) {
-			$validation_result = McpPromptValidator::validate_prompt_dto( $prompt );
+			$validation_result = McpPromptValidator::validate_prompt_data( $prompt_data );
 			if ( is_wp_error( $validation_result ) ) {
 				return $validation_result;
 			}
 		}
 
-		$instance          = new self( $prompt );
+		$instance          = new self( $prompt_data );
 		$instance->handler = $config['handler'];
 
 		if ( isset( $config['permission'] ) && is_callable( $config['permission'] ) ) {
@@ -246,7 +243,7 @@ final class McpPrompt implements McpComponentInterface {
 
 		$instance->observability_context = array(
 			'component_type' => 'prompt',
-			'prompt_name'    => $prompt_data['prompt']->getName(),
+			'prompt_name'    => $prompt_data['prompt']['name'],
 			'ability_name'   => $ability->get_name(),
 			'source'         => 'ability',
 		);
@@ -275,7 +272,7 @@ final class McpPrompt implements McpComponentInterface {
 		// Optional deep validation if enabled.
 		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
 		if ( $mcp_validation_enabled ) {
-			$validation_result = McpPromptValidator::validate_prompt_dto( $prompt );
+			$validation_result = McpPromptValidator::validate_prompt_data( $prompt );
 			if ( is_wp_error( $validation_result ) ) {
 				return $validation_result;
 			}
@@ -291,7 +288,7 @@ final class McpPrompt implements McpComponentInterface {
 
 		$instance->observability_context = array(
 			'component_type' => 'prompt',
-			'prompt_name'    => $prompt->getName(),
+			'prompt_name'    => $prompt['name'],
 			'source'         => 'builder',
 		);
 
@@ -303,11 +300,11 @@ final class McpPrompt implements McpComponentInterface {
 	// =========================================================================
 
 	/**
-	 * Get the clean protocol DTO for MCP responses.
+	 * Get clean protocol data for MCP responses.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt
+	 * @return array<string, mixed>
 	 */
-	public function get_protocol_dto(): PromptDto {
+	public function get_protocol_data(): array {
 		return $this->prompt;
 	}
 
@@ -315,10 +312,11 @@ final class McpPrompt implements McpComponentInterface {
 	 * Execute the prompt.
 	 *
 	 * @param mixed $arguments Prompt arguments.
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional stateless continuation data.
 	 *
 	 * @return mixed
 	 */
-	public function execute( $arguments ) {
+	public function execute( $arguments, ?McpContinuationContext $continuation = null ) {
 		$args = $this->unwrap_input_if_needed( $arguments );
 		$args = is_array( $args ) ? $args : array();
 
@@ -346,7 +344,7 @@ final class McpPrompt implements McpComponentInterface {
 			}
 		} elseif ( null !== $this->handler ) {
 			try {
-				$result = call_user_func( $this->handler, $args );
+				$result = $this->invoke_handler( $args, $continuation );
 			} catch ( \Throwable $throwable ) {
 				return new WP_Error(
 					'mcp_execution_failed',
@@ -359,6 +357,10 @@ final class McpPrompt implements McpComponentInterface {
 		}
 
 		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		if ( $result instanceof McpExecutionResult ) {
 			return $result;
 		}
 
@@ -387,6 +389,29 @@ final class McpPrompt implements McpComponentInterface {
 		$wrapper = is_string( $wrapper ) && '' !== trim( $wrapper ) ? $wrapper : 'input';
 
 		return is_array( $arguments ) ? ( $arguments[ $wrapper ] ?? null ) : null;
+	}
+
+	/**
+	 * Invoke a direct handler, passing continuation data only to handlers that opt in.
+	 *
+	 * @param array<string, mixed> $arguments Prompt arguments.
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional continuation data.
+	 *
+	 * @return mixed
+	 */
+	private function invoke_handler( array $arguments, ?McpContinuationContext $continuation ) {
+		$handler = $this->handler;
+		if ( ! is_callable( $handler ) ) {
+			throw new \LogicException( 'Prompt handler is not callable.' );
+		}
+
+		$reflection = new \ReflectionFunction( \Closure::fromCallable( $handler ) );
+
+		if ( $reflection->isVariadic() || $reflection->getNumberOfParameters() >= 2 ) {
+			return call_user_func( $handler, $arguments, $continuation );
+		}
+
+		return call_user_func( $handler, $arguments );
 	}
 
 	/**

--- a/includes/Domain/Prompts/McpPromptBuilder.php
+++ b/includes/Domain/Prompts/McpPromptBuilder.php
@@ -11,8 +11,6 @@ namespace WP\MCP\Domain\Prompts;
 
 use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
 use WP\MCP\Domain\Utils\McpValidator;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
-use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 
 /**
  * Abstract base class for building MCP prompts.
@@ -123,32 +121,15 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	abstract protected function configure(): void;
 
 	/**
-	 * Build and return the Prompt DTO instance.
+	 * Build and return revision-neutral prompt protocol data.
 	 *
-	 * This method converts the configured state into an MCP Prompt DTO.
-	 * Safe to call multiple times - always returns a fresh DTO based on
+	 * This method converts the configured state into MCP prompt data.
+	 * Safe to call multiple times - always returns a fresh array based on
 	 * the current (immutable after construction) state.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt The built prompt DTO.
+	 * @return array<string, mixed> The built prompt data.
 	 */
-	public function build(): PromptDto {
-		$argument_dtos = null;
-		if ( ! empty( $this->arguments ) ) {
-			$argument_dtos = array_map(
-				static function ( array $arg ): PromptArgument {
-					return PromptArgument::fromArray(
-						array(
-							'name'        => $arg['name'],
-							'title'       => $arg['title'] ?? null,
-							'description' => $arg['description'] ?? null,
-							'required'    => $arg['required'] ?? null,
-						)
-					);
-				},
-				$this->arguments
-			);
-		}
-
+	public function build(): array {
 		// Validate and prepare icons if set.
 		$valid_icons = null;
 		if ( ! empty( $this->icons ) ) {
@@ -158,12 +139,19 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 			}
 		}
 
-		$prompt_data = array(
-			'name'        => $this->name,
-			'title'       => $this->title,
-			'description' => $this->description,
-			'arguments'   => $argument_dtos,
-		);
+		$prompt_data = array( 'name' => $this->name );
+
+		if ( null !== $this->title ) {
+			$prompt_data['title'] = $this->title;
+		}
+
+		if ( null !== $this->description ) {
+			$prompt_data['description'] = $this->description;
+		}
+
+		if ( ! empty( $this->arguments ) ) {
+			$prompt_data['arguments'] = $this->arguments;
+		}
 
 		$prompt_meta = McpValidator::normalize_meta( $this->meta );
 		if ( null !== $prompt_meta ) {
@@ -175,7 +163,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 			$prompt_data['icons'] = $valid_icons;
 		}
 
-		return PromptDto::fromArray( $prompt_data );
+		return $prompt_data;
 	}
 
 	/**

--- a/includes/Domain/Prompts/McpPromptBuilder.php
+++ b/includes/Domain/Prompts/McpPromptBuilder.php
@@ -11,6 +11,8 @@ namespace WP\MCP\Domain\Prompts;
 
 use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
 use WP\MCP\Domain\Utils\McpValidator;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 
 /**
  * Abstract base class for building MCP prompts.
@@ -121,15 +123,19 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 	abstract protected function configure(): void;
 
 	/**
-	 * Build and return revision-neutral prompt protocol data.
+	 * Build and return the descriptor-backed Prompt compatibility facade.
 	 *
 	 * This method converts the configured state into MCP prompt data.
 	 * Safe to call multiple times - always returns a fresh array based on
 	 * the current (immutable after construction) state.
 	 *
-	 * @return array<string, mixed> The built prompt data.
+	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt The built prompt facade.
 	 */
-	public function build(): array {
+	public function build(): Prompt {
+		$arguments = array_map(
+			static fn( array $argument ): PromptArgument => PromptArgument::fromArray( $argument ),
+			$this->arguments
+		);
 		// Validate and prepare icons if set.
 		$valid_icons = null;
 		if ( ! empty( $this->icons ) ) {
@@ -150,7 +156,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 		}
 
 		if ( ! empty( $this->arguments ) ) {
-			$prompt_data['arguments'] = $this->arguments;
+			$prompt_data['arguments'] = $arguments;
 		}
 
 		$prompt_meta = McpValidator::normalize_meta( $this->meta );
@@ -163,7 +169,7 @@ abstract class McpPromptBuilder implements McpPromptBuilderInterface {
 			$prompt_data['icons'] = $valid_icons;
 		}
 
-		return $prompt_data;
+		return Prompt::fromArray( $prompt_data );
 	}
 
 	/**

--- a/includes/Domain/Prompts/McpPromptValidator.php
+++ b/includes/Domain/Prompts/McpPromptValidator.php
@@ -11,7 +11,6 @@ namespace WP\MCP\Domain\Prompts;
 
 use WP\MCP\Domain\Resources\McpResourceValidator;
 use WP\MCP\Domain\Utils\McpValidator;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 use WP_Error;
 
 /**
@@ -49,47 +48,6 @@ class McpPromptValidator {
 	}
 
 	/**
-	 * Validate a Prompt DTO against the MCP schema.
-	 *
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The prompt DTO to validate.
-	 *
-	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
-	 */
-	public static function validate_prompt_dto( PromptDto $prompt ) {
-		$errors = array();
-
-		// Validate name.
-		if ( ! McpValidator::validate_name( $prompt->getName() ) ) {
-			$errors[] = __( 'Prompt name must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'mcp-adapter' );
-		}
-
-		// Validate icons if present.
-		$icons = $prompt->getIcons();
-		if ( ! empty( $icons ) ) {
-			$icons_array  = array_map( static fn( $icon ) => $icon->toArray(), $icons );
-			$icons_result = McpValidator::validate_icons_array( $icons_array );
-			$icons_errors = self::format_icon_validation_errors( $icons_result );
-			$errors       = array_merge( $errors, $icons_errors );
-		}
-
-		// Validate annotations if present (shared annotations).
-		// Currently Prompt DTO doesn't have annotations field in spec, but if it did, we'd validate here.
-		// BaseMetadata has title and name, handled separately.
-
-		if ( ! empty( $errors ) ) {
-			return new WP_Error(
-				'mcp_prompt_validation_failed',
-				sprintf(
-				/* translators: %s: list of validation errors */
-					__( 'Prompt validation failed: %s', 'mcp-adapter' ),
-					implode( '; ', $errors )
-				)
-			);
-		}
-
-		return true;
-	}
-
 	/**
 	 * Validate an McpPrompt instance against the MCP schema.
 	 *
@@ -98,7 +56,7 @@ class McpPromptValidator {
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
 	public static function validate_prompt_instance( McpPrompt $prompt ) {
-		return self::validate_prompt_dto( $prompt->get_protocol_dto() );
+		return self::validate_prompt_data( $prompt->get_protocol_data() );
 	}
 
 
@@ -132,6 +90,15 @@ class McpPromptValidator {
 			$arguments_errors = self::get_arguments_validation_errors( $prompt_data['arguments'] );
 			if ( ! empty( $arguments_errors ) ) {
 				$errors = array_merge( $errors, $arguments_errors );
+			}
+		}
+
+		if ( isset( $prompt_data['icons'] ) ) {
+			if ( ! is_array( $prompt_data['icons'] ) ) {
+				$errors[] = __( 'Prompt icons must be an array if provided', 'mcp-adapter' );
+			} else {
+				$icons_result = McpValidator::validate_icons_array( $prompt_data['icons'], false );
+				$errors       = array_merge( $errors, self::format_icon_validation_errors( $icons_result ) );
 			}
 		}
 

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -13,8 +13,6 @@ namespace WP\MCP\Domain\Prompts;
 use WP\MCP\Domain\Utils\McpNameSanitizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Domain\Utils\SchemaTransformer;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
-use WP\McpSchema\Server\Prompts\DTO\PromptArgument;
 use WP_Error;
 
 /**
@@ -106,7 +104,7 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|\WP_Error Returns Prompt DTO or WP_Error if validation fails.
+	 * @return array<string, mixed>|\WP_Error Returns prompt data or WP_Error if validation fails.
 	 */
 	public static function make( \WP_Ability $ability ) {
 		$prompt = new self( $ability );
@@ -115,9 +113,9 @@ class RegisterAbilityAsMcpPrompt {
 	}
 
 	/**
-	 * Get the MCP prompt instance.
+	 * Get the MCP prompt data.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\Prompt|\WP_Error Prompt DTO or WP_Error if validation fails.
+	 * @return array<string, mixed>|\WP_Error Prompt data or WP_Error if validation fails.
 	 * @since 0.5.0
 	 *
 	 */
@@ -129,15 +127,11 @@ class RegisterAbilityAsMcpPrompt {
 			return $built;
 		}
 
-		try {
-			return PromptDto::fromArray( $built['prompt_data'] );
-		} catch ( \Throwable $e ) {
-			return new WP_Error( 'mcp_prompt_schema_invalid', $e->getMessage() );
-		}
+		return $built['prompt_data'];
 	}
 
 	/**
-	 * Build Prompt DTO data and adapter metadata.
+	 * Build prompt protocol data and adapter metadata.
 	 *
 	 * @return array{prompt_data: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since 0.5.0
@@ -299,7 +293,7 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * @param list<array<string,mixed>> $explicit_arguments User-defined arguments array.
 	 *
-	 * @return list<\WP\McpSchema\Server\Prompts\DTO\PromptArgument>|\WP_Error PromptArgument DTOs or WP_Error.
+	 * @return list<array{name: string, title?: string, description?: string, required?: true}>|\WP_Error Prompt argument data or WP_Error.
 	 * @since 0.5.0
 	 *
 	 */
@@ -351,7 +345,7 @@ class RegisterAbilityAsMcpPrompt {
 				$argument_data['required'] = true;
 			}
 
-			$arguments[] = PromptArgument::fromArray( $argument_data );
+			$arguments[] = $argument_data;
 		}
 
 		return $arguments;
@@ -380,7 +374,7 @@ class RegisterAbilityAsMcpPrompt {
 	 *
 	 * @param array<string,mixed> $input_schema The JSON Schema from ability.
 	 *
-	 * @return list<\WP\McpSchema\Server\Prompts\DTO\PromptArgument> Argument DTO list.
+	 * @return list<array{name: string, title?: string, description?: string, required?: true}> Argument data list.
 	 * @since 0.5.0
 	 *
 	 */
@@ -425,7 +419,7 @@ class RegisterAbilityAsMcpPrompt {
 				$argument_data['required'] = true;
 			}
 
-			$arguments[] = PromptArgument::fromArray( $argument_data );
+			$arguments[] = $argument_data;
 		}
 
 		return $arguments;
@@ -474,15 +468,15 @@ class RegisterAbilityAsMcpPrompt {
 	}
 
 	/**
-	 * Build a clean Prompt DTO and adapter metadata for internal wiring.
+	 * Build clean prompt data and adapter metadata for internal wiring.
 	 *
-	 * This method returns a protocol-only Prompt DTO and provides the adapter metadata
-	 * separately. This keeps the DTO stable across MCP spec changes and avoids coupling internal execution
+	 * This method returns protocol-only prompt data and provides the adapter metadata
+	 * separately. This keeps component storage stable across MCP spec changes and avoids coupling internal execution
 	 * wiring to protocol surfaces.
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return array{prompt: \WP\McpSchema\Server\Prompts\DTO\Prompt, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @return array{prompt: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since 0.5.0
 	 *
 	 */
@@ -494,32 +488,17 @@ class RegisterAbilityAsMcpPrompt {
 			return $data;
 		}
 
-		try {
-			$prompt_dto = PromptDto::fromArray( $data['prompt_data'] );
-		} catch ( \Throwable $e ) {
-			return new WP_Error(
-				'mcp_prompt_dto_creation_failed',
-				sprintf(
-				/* translators: %s: error message */
-					__( 'Failed to create Prompt DTO for ability %1$s: %2$s', 'mcp-adapter' ),
-					$ability->get_name(),
-					$e->getMessage()
-				),
-				array( 'exception' => $e )
-			);
-		}
-
 		// Optional deep validation if enabled.
 		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
 		if ( $mcp_validation_enabled ) {
-			$validation_result = McpPromptValidator::validate_prompt_dto( $prompt_dto );
+			$validation_result = McpPromptValidator::validate_prompt_data( $data['prompt_data'] );
 			if ( is_wp_error( $validation_result ) ) {
 				return $validation_result;
 			}
 		}
 
 		return array(
-			'prompt'       => $prompt_dto,
+			'prompt'       => $data['prompt_data'],
 			'adapter_meta' => $data['adapter_meta'],
 		);
 	}

--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -10,12 +10,11 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Resources;
 
+use WP\MCP\Domain\Continuation\McpContinuationContext;
 use WP\MCP\Domain\Contracts\McpComponentInterface;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\Observability\FailureReason;
-use WP\McpSchema\Common\Protocol\DTO\Annotations;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 use WP_Error;
 
 /**
@@ -39,9 +38,9 @@ use WP_Error;
  * $resource = McpResource::fromAbility($ability);
  * ```
  *
- * McpResource wraps a protocol-only ResourceDto for MCP serialization. Internal
+ * McpResource stores protocol-only, revision-neutral data for MCP serialization. Internal
  * adapter metadata and execution wiring live on this class and are never
- * exposed to MCP clients. Use get_protocol_dto() for protocol responses.
+ * exposed to MCP clients. Use get_protocol_data() for protocol responses.
  *
  * @since 0.5.0
  */
@@ -53,11 +52,11 @@ final class McpResource implements McpComponentInterface {
 	// =========================================================================
 
 	/**
-	 * Clean Resource DTO (protocol-only).
+	 * Clean resource data (protocol-only).
 	 *
-	 * @var \WP\McpSchema\Server\Resources\DTO\Resource
+	 * @var array<string, mixed>
 	 */
-	private ResourceDto $mcp_resource_dto;
+	private array $resource;
 
 	/**
 	 * Ability used for execution/permission checks (ability-backed resources).
@@ -101,10 +100,10 @@ final class McpResource implements McpComponentInterface {
 	/**
 	 * Private constructor - use factory methods.
 	 *
-	 * @param \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto The Resource DTO.
+	 * @param array<string, mixed> $resource_data Protocol-only resource data.
 	 */
-	private function __construct( ResourceDto $resource_dto ) {
-		$this->mcp_resource_dto = $resource_dto;
+	private function __construct( array $resource_data ) {
+		$this->resource = $resource_data;
 	}
 
 	// =========================================================================
@@ -175,36 +174,20 @@ final class McpResource implements McpComponentInterface {
 			$resource_data['_meta'] = $resource_meta;
 		}
 
-		// Create the Resource DTO - wrap in try-catch since Annotations::fromArray() and ResourceDto::fromArray() can throw.
-		try {
-			// Process annotations inside try-catch since Annotations::fromArray() can throw.
-			if ( isset( $config['annotations'] ) && is_array( $config['annotations'] ) && ! empty( $config['annotations'] ) ) {
-				$resource_data['annotations'] = Annotations::fromArray( $config['annotations'] );
-			}
-
-			$resource = ResourceDto::fromArray( $resource_data );
-		} catch ( \Throwable $e ) {
-			return new WP_Error(
-				'mcp_resource_dto_creation_failed',
-				sprintf(
-				/* translators: %s: error message */
-					__( 'Failed to create Resource DTO: %s', 'mcp-adapter' ),
-					$e->getMessage()
-				),
-				array( 'exception' => $e )
-			);
+		if ( isset( $config['annotations'] ) && is_array( $config['annotations'] ) && ! empty( $config['annotations'] ) ) {
+			$resource_data['annotations'] = $config['annotations'];
 		}
 
 		// Optional deep validation if enabled.
 		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
 		if ( $mcp_validation_enabled ) {
-			$validation_result = McpResourceValidator::validate_resource_dto( $resource );
+			$validation_result = McpResourceValidator::validate_resource_metadata( $resource_data );
 			if ( is_wp_error( $validation_result ) ) {
 				return $validation_result;
 			}
 		}
 
-		$instance          = new self( $resource );
+		$instance          = new self( $resource_data );
 		$instance->handler = $config['handler'];
 
 		if ( isset( $config['permission'] ) && is_callable( $config['permission'] ) ) {
@@ -240,7 +223,7 @@ final class McpResource implements McpComponentInterface {
 
 		$instance->observability_context = array(
 			'component_type' => 'resource',
-			'resource_uri'   => $resource_data['resource']->getUri(),
+			'resource_uri'   => $resource_data['resource']['uri'],
 			'ability_name'   => $ability->get_name(),
 			'source'         => 'ability',
 		);
@@ -253,22 +236,23 @@ final class McpResource implements McpComponentInterface {
 	// =========================================================================
 
 	/**
-	 * Get the clean protocol DTO for MCP responses.
+	 * Get clean protocol data for MCP responses.
 	 *
-	 * @return \WP\McpSchema\Server\Resources\DTO\Resource
+	 * @return array<string, mixed>
 	 */
-	public function get_protocol_dto(): ResourceDto {
-		return $this->mcp_resource_dto;
+	public function get_protocol_data(): array {
+		return $this->resource;
 	}
 
 	/**
 	 * Execute the resource read.
 	 *
 	 * @param mixed $arguments Read arguments (may be empty).
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional stateless continuation data.
 	 *
 	 * @return mixed
 	 */
-	public function execute( $arguments ) {
+	public function execute( $arguments, ?McpContinuationContext $continuation = null ) {
 		// Ability-backed resources match existing behavior: no args passed to abilities.
 		if ( null !== $this->ability ) {
 			try {
@@ -284,7 +268,7 @@ final class McpResource implements McpComponentInterface {
 
 		if ( null !== $this->handler ) {
 			try {
-				return call_user_func( $this->handler, $arguments );
+				return $this->invoke_handler( $arguments, $continuation );
 			} catch ( \Throwable $throwable ) {
 				return new WP_Error(
 					'mcp_execution_failed',
@@ -295,6 +279,29 @@ final class McpResource implements McpComponentInterface {
 		}
 
 		return new WP_Error( 'mcp_resource_no_handler', 'No resource execution strategy configured.' );
+	}
+
+	/**
+	 * Invoke a direct handler, passing continuation data only to handlers that opt in.
+	 *
+	 * @param mixed $arguments Resource arguments.
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional continuation data.
+	 *
+	 * @return mixed
+	 */
+	private function invoke_handler( $arguments, ?McpContinuationContext $continuation ) {
+		$handler = $this->handler;
+		if ( ! is_callable( $handler ) ) {
+			throw new \LogicException( 'Resource handler is not callable.' );
+		}
+
+		$reflection = new \ReflectionFunction( \Closure::fromCallable( $handler ) );
+
+		if ( $reflection->isVariadic() || $reflection->getNumberOfParameters() >= 2 ) {
+			return call_user_func( $handler, $arguments, $continuation );
+		}
+
+		return call_user_func( $handler, $arguments );
 	}
 
 	/**

--- a/includes/Domain/Resources/McpResourceValidator.php
+++ b/includes/Domain/Resources/McpResourceValidator.php
@@ -10,7 +10,6 @@ declare( strict_types=1 );
 namespace WP\MCP\Domain\Resources;
 
 use WP\MCP\Domain\Utils\McpValidator;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 use WP_Error;
 
 /**
@@ -48,33 +47,32 @@ class McpResourceValidator {
 	}
 
 	/**
-	 * Validate a Resource DTO against the MCP schema.
+	 * Validate resource metadata returned by resources/list.
 	 *
-	 * @param \WP\McpSchema\Server\Resources\DTO\Resource $resource_dto The resource DTO to validate.
+	 * @param array<string, mixed> $resource_data The resource metadata to validate.
 	 *
 	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
 	 */
-	public static function validate_resource_dto( ResourceDto $resource_dto ) {
+	public static function validate_resource_metadata( array $resource_data ) {
 		$errors = array();
 
 		// Validate URI.
-		if ( ! McpValidator::validate_resource_uri( $resource_dto->getUri() ) ) {
+		if ( ! isset( $resource_data['uri'] ) || ! is_string( $resource_data['uri'] ) || ! McpValidator::validate_resource_uri( $resource_data['uri'] ) ) {
 			$errors[] = __( 'Resource URI must be a valid URI string', 'mcp-adapter' );
 		}
 
 		// Validate icons if present.
-		$icons = $resource_dto->getIcons();
+		$icons = $resource_data['icons'] ?? null;
 		if ( ! empty( $icons ) ) {
-			$icons_array  = array_map( static fn( $icon ) => $icon->toArray(), $icons );
-			$icons_result = McpValidator::validate_icons_array( $icons_array );
+			$icons_result = McpValidator::validate_icons_array( $icons );
 			$icons_errors = self::format_icon_validation_errors( $icons_result );
 			$errors       = array_merge( $errors, $icons_errors );
 		}
 
 		// Validate annotations if present.
-		$annotations = $resource_dto->getAnnotations();
-		if ( $annotations ) {
-			$annotation_errors = McpValidator::get_annotation_validation_errors( $annotations->toArray() );
+		$annotations = $resource_data['annotations'] ?? null;
+		if ( is_array( $annotations ) ) {
+			$annotation_errors = McpValidator::get_annotation_validation_errors( $annotations );
 			$errors            = array_merge( $errors, $annotation_errors );
 		}
 
@@ -100,7 +98,7 @@ class McpResourceValidator {
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
 	public static function validate_resource_instance( McpResource $the_resource ) {
-		return self::validate_resource_dto( $the_resource->get_protocol_dto() );
+		return self::validate_resource_metadata( $the_resource->get_protocol_data() );
 	}
 
 	/**
@@ -111,7 +109,7 @@ class McpResourceValidator {
 	 * - `content` blocks of type `resource` (`EmbeddedResource.resource`)
 	 *
 	 * It does NOT validate the `Resource` metadata object returned by `resources/list`.
-	 * For `Resource` DTO validation (resources/list), use validate_resource_dto() instead.
+	 * For `Resource` metadata validation (resources/list), use validate_resource_metadata() instead.
 	 *
 	 * This validator focuses on the MCP-required fields and ignores unknown fields to remain
 	 * forward-compatible with future schema versions.

--- a/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -13,13 +13,12 @@ namespace WP\MCP\Domain\Resources;
 use WP\MCP\Domain\Utils\McpAnnotationMapper;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 use WP_Error;
 
 /**
  * Converts WordPress abilities to MCP Resource metadata.
  *
- * This class builds Resource DTOs for resources/list responses.
+ * This class builds resource metadata for resources/list responses.
  * It extracts metadata only (uri, name, title, description, mimeType, size, icons, annotations).
  * Resource content (text/blob) is resolved separately at resources/read time.
  *
@@ -74,7 +73,7 @@ class RegisterAbilityAsMcpResource {
 	 * @param \WP_Ability $ability The ability.
 	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler for logging.
 	 *
-	 * @return \WP\McpSchema\Server\Resources\DTO\Resource|\WP_Error Returns Resource DTO or WP_Error if validation fails.
+	 * @return array<string, mixed>|\WP_Error Returns resource data or WP_Error if validation fails.
 	 */
 	public static function make( \WP_Ability $ability, ?McpErrorHandlerInterface $error_handler = null ) {
 		$resource = new self( $ability, $error_handler );
@@ -85,9 +84,7 @@ class RegisterAbilityAsMcpResource {
 	/**
 	 * Get the MCP resource instance.
 	 *
-	 * Resource schema validity is enforced by the php-mcp-schema DTO constructor.
-	 *
-	 * @return \WP\McpSchema\Server\Resources\DTO\Resource|\WP_Error Returns the Resource DTO or WP_Error if validation fails.
+	 * @return array<string, mixed>|\WP_Error Returns resource data or WP_Error if validation fails.
 	 */
 	private function get_resource() {
 		$data = $this->get_data();
@@ -95,14 +92,7 @@ class RegisterAbilityAsMcpResource {
 			return $data;
 		}
 
-		try {
-			return ResourceDto::fromArray( $data );
-		} catch ( \Throwable $e ) {
-			return new WP_Error(
-				'mcp_resource_schema_invalid',
-				$e->getMessage()
-			);
-		}
+		return $data;
 	}
 
 	/**
@@ -123,7 +113,7 @@ class RegisterAbilityAsMcpResource {
 	}
 
 	/**
-	 * Build Resource DTO data and adapter metadata.
+	 * Build resource protocol data and adapter metadata.
 	 *
 	 * @return array{resource_data: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since 0.5.0
@@ -208,7 +198,7 @@ class RegisterAbilityAsMcpResource {
 
 		// Build Resource `_meta`:
 		// - Preserve user-provided `_meta` from ability.meta.mcp._meta.
-		// - Adapter metadata is NEVER included in protocol DTO meta; it is returned separately in adapter_meta.
+		// - Adapter metadata is NEVER included in protocol meta; it is returned separately in adapter_meta.
 		$resource_meta = McpValidator::normalize_meta( $mcp_meta['_meta'] ?? null );
 		if ( null !== $resource_meta ) {
 			$resource_data['_meta'] = $resource_meta;
@@ -425,16 +415,16 @@ class RegisterAbilityAsMcpResource {
 	}
 
 	/**
-	 * Build a clean Resource DTO and adapter metadata for internal wiring.
+	 * Build clean resource data and adapter metadata for internal wiring.
 	 *
-	 * This method returns a protocol-only Resource DTO and provides the adapter metadata
-	 * separately. This keeps the DTO stable across MCP spec changes and avoids coupling internal execution
+	 * This method returns protocol-only resource data and provides the adapter metadata
+	 * separately. This keeps component storage stable across MCP spec changes and avoids coupling internal execution
 	 * wiring to protocol surfaces.
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Optional error handler.
 	 *
-	 * @return array{resource: \WP\McpSchema\Server\Resources\DTO\Resource, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @return array{resource: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since 0.5.0
 	 *
 	 */
@@ -446,32 +436,17 @@ class RegisterAbilityAsMcpResource {
 			return $data;
 		}
 
-		try {
-			$resource_dto = ResourceDto::fromArray( $data['resource_data'] );
-		} catch ( \Throwable $e ) {
-			return new WP_Error(
-				'mcp_resource_dto_creation_failed',
-				sprintf(
-				/* translators: %s: error message */
-					__( 'Failed to create Resource DTO for ability %1$s: %2$s', 'mcp-adapter' ),
-					$ability->get_name(),
-					$e->getMessage()
-				),
-				array( 'exception' => $e )
-			);
-		}
-
 		// Optional deep validation if enabled.
 		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
 		if ( $mcp_validation_enabled ) {
-			$validation_result = McpResourceValidator::validate_resource_dto( $resource_dto );
+			$validation_result = McpResourceValidator::validate_resource_metadata( $data['resource_data'] );
 			if ( is_wp_error( $validation_result ) ) {
 				return $validation_result;
 			}
 		}
 
 		return array(
-			'resource'     => $resource_dto,
+			'resource'     => $data['resource_data'],
 			'adapter_meta' => $data['adapter_meta'],
 		);
 	}

--- a/includes/Domain/Tools/McpTool.php
+++ b/includes/Domain/Tools/McpTool.php
@@ -10,12 +10,12 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Tools;
 
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Contracts\McpComponentInterface;
 use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\Observability\FailureReason;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
-use WP\McpSchema\Server\Tools\DTO\ToolAnnotations;
 use WP_Error;
 
 /**
@@ -41,9 +41,9 @@ use WP_Error;
  * $tool = McpTool::fromAbility($ability);
  * ```
  *
- * McpTool wraps a protocol-only ToolDto for MCP serialization. Internal
+ * McpTool stores protocol-only, revision-neutral data for MCP serialization. Internal
  * adapter metadata and execution wiring live on this class and are never
- * exposed to MCP clients. Use get_protocol_dto() for protocol responses.
+ * exposed to MCP clients. Use get_protocol_data() for protocol responses.
  *
  * @since 0.5.0
  */
@@ -55,11 +55,11 @@ final class McpTool implements McpComponentInterface {
 	// =========================================================================
 
 	/**
-	 * Clean Tool DTO (protocol-only).
+	 * Clean tool data (protocol-only).
 	 *
-	 * @var \WP\McpSchema\Server\Tools\DTO\Tool
+	 * @var array<string, mixed>
 	 */
-	private ToolDto $tool;
+	private array $tool;
 
 	/**
 	 * Ability used for execution/permission checks (ability-backed tools).
@@ -103,9 +103,9 @@ final class McpTool implements McpComponentInterface {
 	/**
 	 * Private constructor - use factory methods.
 	 *
-	 * @param \WP\McpSchema\Server\Tools\DTO\Tool $tool The Tool DTO.
+	 * @param array<string, mixed> $tool The protocol-only tool data.
 	 */
-	private function __construct( ToolDto $tool ) {
+	private function __construct( array $tool ) {
 		$this->tool = $tool;
 	}
 
@@ -168,36 +168,20 @@ final class McpTool implements McpComponentInterface {
 			$tool_data['_meta'] = $tool_meta;
 		}
 
-		// Create the Tool DTO - wrap in try-catch since ToolAnnotations::fromArray() and ToolDto::fromArray() can throw.
-		try {
-			// Process annotations inside try-catch since ToolAnnotations::fromArray() can throw.
-			if ( isset( $config['annotations'] ) && is_array( $config['annotations'] ) && ! empty( $config['annotations'] ) ) {
-				$tool_data['annotations'] = ToolAnnotations::fromArray( $config['annotations'] );
-			}
-
-			$tool = ToolDto::fromArray( $tool_data );
-		} catch ( \Throwable $e ) {
-			return new WP_Error(
-				'mcp_tool_dto_creation_failed',
-				sprintf(
-				/* translators: %s: error message */
-					__( 'Failed to create Tool DTO: %s', 'mcp-adapter' ),
-					$e->getMessage()
-				),
-				array( 'exception' => $e )
-			);
+		if ( isset( $config['annotations'] ) && is_array( $config['annotations'] ) && ! empty( $config['annotations'] ) ) {
+			$tool_data['annotations'] = $config['annotations'];
 		}
 
 		// Optional deep validation if enabled.
 		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
 		if ( $mcp_validation_enabled ) {
-			$validation_result = McpToolValidator::validate_tool_dto( $tool );
+			$validation_result = McpToolValidator::validate_tool_data( $tool_data );
 			if ( is_wp_error( $validation_result ) ) {
 				return $validation_result;
 			}
 		}
 
-		$instance          = new self( $tool );
+		$instance          = new self( $tool_data );
 		$instance->handler = $config['handler'];
 
 		if ( isset( $config['permission'] ) && is_callable( $config['permission'] ) ) {
@@ -232,7 +216,7 @@ final class McpTool implements McpComponentInterface {
 
 		$instance->observability_context = array(
 			'component_type' => 'tool',
-			'tool_name'      => $tool_data['tool']->getName(),
+			'tool_name'      => $tool_data['tool']['name'],
 			'ability_name'   => $ability->get_name(),
 			'source'         => 'ability',
 		);
@@ -245,11 +229,11 @@ final class McpTool implements McpComponentInterface {
 	// =========================================================================
 
 	/**
-	 * Get the clean protocol DTO for MCP responses.
+	 * Get clean protocol data for MCP responses.
 	 *
-	 * @return \WP\McpSchema\Server\Tools\DTO\Tool
+	 * @return array<string, mixed>
 	 */
-	public function get_protocol_dto(): ToolDto {
+	public function get_protocol_data(): array {
 		return $this->tool;
 	}
 
@@ -257,10 +241,11 @@ final class McpTool implements McpComponentInterface {
 	 * Execute the tool.
 	 *
 	 * @param mixed $arguments Tool arguments.
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional stateless continuation data.
 	 *
 	 * @return mixed
 	 */
-	public function execute( $arguments ) {
+	public function execute( $arguments, ?McpContinuationContext $continuation = null ) {
 		$args = $this->unwrap_input_if_needed( $arguments );
 
 		if ( null !== $this->ability ) {
@@ -277,7 +262,7 @@ final class McpTool implements McpComponentInterface {
 			}
 		} elseif ( null !== $this->handler ) {
 			try {
-				$result = call_user_func( $this->handler, $args );
+				$result = $this->invoke_handler( $args, $continuation );
 			} catch ( \Throwable $throwable ) {
 				return new WP_Error(
 					'mcp_execution_failed',
@@ -290,6 +275,10 @@ final class McpTool implements McpComponentInterface {
 		}
 
 		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		if ( $result instanceof McpExecutionResult ) {
 			return $result;
 		}
 
@@ -343,6 +332,29 @@ final class McpTool implements McpComponentInterface {
 	}
 
 	/**
+	 * Invoke a direct handler, passing continuation data only to handlers that opt in.
+	 *
+	 * @param mixed $arguments Tool arguments.
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional continuation data.
+	 *
+	 * @return mixed
+	 */
+	private function invoke_handler( $arguments, ?McpContinuationContext $continuation ) {
+		$handler = $this->handler;
+		if ( ! is_callable( $handler ) ) {
+			throw new \LogicException( 'Tool handler is not callable.' );
+		}
+
+		$reflection = new \ReflectionFunction( \Closure::fromCallable( $handler ) );
+
+		if ( $reflection->isVariadic() || $reflection->getNumberOfParameters() >= 2 ) {
+			return call_user_func( $handler, $arguments, $continuation );
+		}
+
+		return call_user_func( $handler, $arguments );
+	}
+
+	/**
 	 * Check whether the current request has permission to execute this tool.
 	 *
 	 * @param mixed $arguments Tool arguments.
@@ -388,7 +400,7 @@ final class McpTool implements McpComponentInterface {
 			'Access denied.',
 			array(
 				'failure_reason' => FailureReason::NO_PERMISSION_STRATEGY,
-				'tool_name'      => $this->tool->getName(),
+				'tool_name'      => $this->tool['name'],
 			)
 		);
 	}

--- a/includes/Domain/Tools/McpToolValidator.php
+++ b/includes/Domain/Tools/McpToolValidator.php
@@ -10,7 +10,6 @@ declare( strict_types=1 );
 namespace WP\MCP\Domain\Tools;
 
 use WP\MCP\Domain\Utils\McpValidator;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 use WP_Error;
 
 /**
@@ -69,81 +68,7 @@ class McpToolValidator {
 	 * @return bool|\WP_Error True if valid, WP_Error if validation fails.
 	 */
 	public static function validate_tool_instance( McpTool $tool, string $context = '' ) {
-		return self::validate_tool_data( $tool->get_protocol_dto()->toArray(), $context );
-	}
-
-	/**
-	 * Validate a Tool DTO against the MCP schema.
-	 *
-	 * @param \WP\McpSchema\Server\Tools\DTO\Tool $tool The tool DTO to validate.
-	 *
-	 * @return bool|\WP_Error True if valid, WP_Error otherwise.
-	 */
-	public static function validate_tool_dto( ToolDto $tool ) {
-		$errors = array();
-
-		// Validate name (required, 1-128 chars, alphanumeric + _.-).
-		if ( ! McpValidator::validate_name( $tool->getName() ) ) {
-			$errors[] = __( 'Tool name must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'mcp-adapter' );
-		}
-
-		// Validate icons if present.
-		$icons = $tool->getIcons();
-		if ( ! empty( $icons ) ) {
-			// Convert DTO icons to arrays for validation.
-			$icons_array  = array_map( static fn( $icon ) => $icon->toArray(), $icons );
-			$icons_result = McpValidator::validate_icons_array( $icons_array );
-			$icons_errors = self::format_icon_validation_errors( $icons_result );
-			$errors       = array_merge( $errors, $icons_errors );
-		}
-
-		// Validate annotations if present (tool-specific only).
-		$annotations = $tool->getAnnotations();
-		if ( $annotations ) {
-			$annotations_array = $annotations->toArray();
-			$annotation_errors = self::get_tool_annotation_validation_errors( $annotations_array );
-			$errors            = array_merge( $errors, $annotation_errors );
-		}
-
-		// Validate execution if present.
-		$execution = $tool->getExecution();
-		if ( $execution ) {
-			$execution_array  = $execution->toArray();
-			$execution_errors = self::get_execution_validation_errors( $execution_array );
-			$errors           = array_merge( $errors, $execution_errors );
-		}
-
-		// Validate schemas (inputSchema and outputSchema).
-		$tool_array = $tool->toArray();
-
-		// Validate inputSchema (required field).
-		$input_schema_errors = self::get_schema_validation_errors(
-			$tool_array['inputSchema'] ?? null,
-			'inputSchema'
-		);
-		$errors              = array_merge( $errors, $input_schema_errors );
-
-		// Validate outputSchema if present (optional field).
-		if ( isset( $tool_array['outputSchema'] ) ) {
-			$output_schema_errors = self::get_schema_validation_errors(
-				$tool_array['outputSchema'],
-				'outputSchema'
-			);
-			$errors               = array_merge( $errors, $output_schema_errors );
-		}
-
-		if ( ! empty( $errors ) ) {
-			return new WP_Error(
-				'mcp_tool_validation_failed',
-				sprintf(
-				/* translators: %s: list of validation errors */
-					__( 'Tool validation failed: %s', 'mcp-adapter' ),
-					implode( '; ', $errors )
-				)
-			);
-		}
-
-		return true;
+		return self::validate_tool_data( $tool->get_protocol_data(), $context );
 	}
 
 	/**
@@ -265,7 +190,7 @@ class McpToolValidator {
 			);
 		}
 
-		// Normalize stdClass properties (e.g. an empty `{}` emitted by the schema DTO for
+		// Normalize stdClass properties (e.g. an empty `{}` emitted at a schema boundary for
 		// parameter-less tools) to an array so the structural checks below treat it as a valid object.
 		if ( isset( $schema['properties'] ) && $schema['properties'] instanceof \stdClass ) {
 			$schema['properties'] = (array) $schema['properties'];

--- a/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -14,7 +14,6 @@ use WP\MCP\Domain\Utils\McpAnnotationMapper;
 use WP\MCP\Domain\Utils\McpNameSanitizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Domain\Utils\SchemaTransformer;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 use WP_Error;
 
 /**
@@ -45,15 +44,15 @@ class RegisterAbilityAsMcpTool {
 	}
 
 	/**
-	 * Build a clean Tool DTO and adapter metadata for internal wiring.
+	 * Build clean tool data and adapter metadata for internal wiring.
 	 *
-	 * This method returns a protocol-only Tool DTO and provides the adapter metadata
-	 * separately. This keeps the DTO stable across MCP spec changes and avoids coupling internal execution
+	 * This method returns protocol-only data and provides the adapter metadata
+	 * separately. This keeps stored component data stable across MCP spec changes and avoids coupling internal execution
 	 * wiring to protocol surfaces.
 	 *
 	 * @param \WP_Ability $ability The ability.
 	 *
-	 * @return array{tool: \WP\McpSchema\Server\Tools\DTO\Tool, adapter_meta: array<string, mixed>}|\WP_Error
+	 * @return array{tool: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since 0.5.0
 	 *
 	 */
@@ -65,38 +64,23 @@ class RegisterAbilityAsMcpTool {
 			return $data;
 		}
 
-		try {
-			$tool_dto = ToolDto::fromArray( $data['tool_data'] );
-		} catch ( \Throwable $e ) {
-			return new WP_Error(
-				'mcp_tool_dto_creation_failed',
-				sprintf(
-				/* translators: %s: error message */
-					__( 'Failed to create Tool DTO for ability %1$s: %2$s', 'mcp-adapter' ),
-					$ability->get_name(),
-					$e->getMessage()
-				),
-				array( 'exception' => $e )
-			);
-		}
-
 		// Optional deep validation if enabled.
 		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
 		if ( $mcp_validation_enabled ) {
-			$validation_result = McpToolValidator::validate_tool_dto( $tool_dto );
+			$validation_result = McpToolValidator::validate_tool_data( $data['tool_data'] );
 			if ( is_wp_error( $validation_result ) ) {
 				return $validation_result;
 			}
 		}
 
 		return array(
-			'tool'         => $tool_dto,
+			'tool'         => $data['tool_data'],
 			'adapter_meta' => $data['adapter_meta'],
 		);
 	}
 
 	/**
-	 * Build Tool DTO data and adapter metadata.
+	 * Build tool protocol data and adapter metadata.
 	 *
 	 * @return array{tool_data: array<string, mixed>, adapter_meta: array<string, mixed>}|\WP_Error
 	 * @since 0.5.0
@@ -182,7 +166,7 @@ class RegisterAbilityAsMcpTool {
 
 		// Build Tool `_meta`:
 		// - Preserve user-provided `_meta` from ability.meta.mcp._meta.
-		// - Adapter metadata is NEVER included in protocol DTO meta; it is returned separately in adapter_meta.
+		// - Adapter metadata is NEVER included in protocol meta; it is returned separately in adapter_meta.
 		$tool_meta = McpValidator::normalize_meta( $mcp_meta['_meta'] ?? null );
 		if ( null !== $tool_meta ) {
 			$tool_data['_meta'] = $tool_meta;

--- a/includes/Domain/Utils/ContentBlockHelper.php
+++ b/includes/Domain/Utils/ContentBlockHelper.php
@@ -1,10 +1,6 @@
 <?php
 /**
- * ContentBlockHelper - Factory for creating MCP content block DTOs.
- *
- * This helper provides convenience methods for constructing typed content block DTOs
- * from the php-mcp-schema library. It simplifies the creation of TextContent,
- * ImageContent, AudioContent, and EmbeddedResource instances.
+ * ContentBlockHelper - Factory for creating revision-neutral MCP content block data.
  *
  * @package WP\MCP\Domain\Utils
  */
@@ -13,21 +9,11 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Domain\Utils;
 
-use WP\McpSchema\Common\Content\DTO\AudioContent;
-use WP\McpSchema\Common\Content\DTO\ImageContent;
-use WP\McpSchema\Common\Content\DTO\TextContent;
-use WP\McpSchema\Common\Protocol\DTO\Annotations;
-use WP\McpSchema\Common\Protocol\DTO\BlobResourceContents;
-use WP\McpSchema\Common\Protocol\DTO\EmbeddedResource;
-use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
-use WP\McpSchema\Common\Protocol\Union\ContentBlockInterface;
-
 /**
- * Helper class for creating MCP content block DTOs.
+ * Helper class for creating MCP content block arrays.
  *
- * Provides static factory methods to create typed content blocks that implement
- * ContentBlockInterface. These DTOs are used in tool call results, prompt messages,
- * and resource contents throughout the MCP protocol.
+ * The schema package validates and hydrates these values at the selected revision's
+ * wire boundary. Component and handler code remain independent of generated records.
  *
  * Every `_meta` argument passes through {@see McpValidator::normalize_meta()}, so a
  * PHP list is omitted instead of being serialized where MCP declares a JSON object.
@@ -37,195 +23,189 @@ use WP\McpSchema\Common\Protocol\Union\ContentBlockInterface;
 final class ContentBlockHelper {
 
 	/**
-	 * Creates an ImageContent DTO.
+	 * Create image content.
 	 *
 	 * @param string $data Base64-encoded image data.
 	 * @param string $mime_type The MIME type of the image (e.g., 'image/png').
-	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
-	 * @param array|null $_meta Optional metadata for the content block.
+	 * @param array<string, mixed>|null $annotations Optional annotations for the client.
+	 * @param array<string, mixed>|null $_meta Optional metadata for the content block.
 	 *
-	 * @return \WP\McpSchema\Common\Content\DTO\ImageContent The created ImageContent DTO.
+	 * @return array<string, mixed> Image content data.
 	 */
-	public static function image( string $data, string $mime_type, ?Annotations $annotations = null, ?array $_meta = null ): ImageContent {
-		return ImageContent::fromArray(
+	public static function image( string $data, string $mime_type, ?array $annotations = null, ?array $_meta = null ): array {
+		return self::with_optional_fields(
 			array(
-				'type'        => ImageContent::TYPE,
-				'data'        => $data,
-				'mimeType'    => $mime_type,
-				'annotations' => $annotations,
-				'_meta'       => McpValidator::normalize_meta( $_meta ),
-			)
+				'type'     => 'image',
+				'data'     => $data,
+				'mimeType' => $mime_type,
+			),
+			$annotations,
+			$_meta
 		);
 	}
 
 	/**
-	 * Creates an AudioContent DTO.
+	 * Create audio content.
 	 *
 	 * @param string $data Base64-encoded audio data.
 	 * @param string $mime_type The MIME type of the audio (e.g., 'audio/mp3').
-	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
-	 * @param array|null $_meta Optional metadata for the content block.
+	 * @param array<string, mixed>|null $annotations Optional annotations for the client.
+	 * @param array<string, mixed>|null $_meta Optional metadata for the content block.
 	 *
-	 * @return \WP\McpSchema\Common\Content\DTO\AudioContent The created AudioContent DTO.
+	 * @return array<string, mixed> Audio content data.
 	 */
-	public static function audio( string $data, string $mime_type, ?Annotations $annotations = null, ?array $_meta = null ): AudioContent {
-		return AudioContent::fromArray(
+	public static function audio( string $data, string $mime_type, ?array $annotations = null, ?array $_meta = null ): array {
+		return self::with_optional_fields(
 			array(
-				'type'        => AudioContent::TYPE,
-				'data'        => $data,
-				'mimeType'    => $mime_type,
-				'annotations' => $annotations,
-				'_meta'       => McpValidator::normalize_meta( $_meta ),
-			)
+				'type'     => 'audio',
+				'data'     => $data,
+				'mimeType' => $mime_type,
+			),
+			$annotations,
+			$_meta
 		);
 	}
 
 	/**
-	 * Creates an EmbeddedResource DTO with TextResourceContents.
+	 * Create embedded text resource content.
 	 *
-	 * Use this for embedding text-based resources (files, documents, etc.) in content.
-	 *
-	 * The DTO tree has two levels that each carry their own `_meta`: the content
-	 * block wrapper and the resource contents nested inside it. `$_meta` sets the
-	 * wrapper's; `$resource_meta` sets the contents'. They are distinct fields in
-	 * the spec and are not interchangeable.
+	 * The wrapper and nested resource each have their own `_meta` field.
 	 *
 	 * @since 0.6.0 Added the optional $resource_meta parameter.
 	 *
 	 * @param string $uri The URI of the resource.
 	 * @param string $text The text content of the resource.
 	 * @param string|null $mime_type Optional MIME type of the resource.
-	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
-	 * @param array|null $_meta Optional metadata for the content block.
-	 * @param array|null $resource_meta Optional metadata for the nested resource contents.
+	 * @param array<string, mixed>|null $annotations Optional annotations for the client.
+	 * @param array<string, mixed>|null $_meta Optional metadata for the content block.
+	 * @param array<string, mixed>|null $resource_meta Optional metadata for the nested resource contents.
 	 *
-	 * @return \WP\McpSchema\Common\Protocol\DTO\EmbeddedResource The created EmbeddedResource DTO.
+	 * @return array<string, mixed> Embedded resource content data.
 	 */
 	public static function embedded_text_resource(
 		string $uri,
 		string $text,
 		?string $mime_type = null,
-		?Annotations $annotations = null,
+		?array $annotations = null,
 		?array $_meta = null,
 		?array $resource_meta = null
-	): EmbeddedResource {
-		$resource = TextResourceContents::fromArray(
-			array(
-				'uri'      => $uri,
-				'text'     => $text,
-				'mimeType' => $mime_type,
-				'_meta'    => McpValidator::normalize_meta( $resource_meta ),
-			)
+	): array {
+		$resource = array(
+			'uri'  => $uri,
+			'text' => $text,
 		);
 
-		return EmbeddedResource::fromArray(
+		if ( null !== $mime_type ) {
+			$resource['mimeType'] = $mime_type;
+		}
+
+		$normalized_resource_meta = McpValidator::normalize_meta( $resource_meta );
+		if ( null !== $normalized_resource_meta ) {
+			$resource['_meta'] = $normalized_resource_meta;
+		}
+
+		return self::with_optional_fields(
 			array(
-				'type'        => EmbeddedResource::TYPE,
-				'resource'    => $resource,
-				'annotations' => $annotations,
-				'_meta'       => McpValidator::normalize_meta( $_meta ),
-			)
+				'type'     => 'resource',
+				'resource' => $resource,
+			),
+			$annotations,
+			$_meta
 		);
 	}
 
 	/**
-	 * Creates an EmbeddedResource DTO with BlobResourceContents.
+	 * Create embedded binary resource content.
 	 *
-	 * Use this for embedding binary resources (images, PDFs, etc.) in content.
-	 *
-	 * The DTO tree has two levels that each carry their own `_meta`: the content
-	 * block wrapper and the resource contents nested inside it. `$_meta` sets the
-	 * wrapper's; `$resource_meta` sets the contents'. They are distinct fields in
-	 * the spec and are not interchangeable.
+	 * The wrapper and nested resource each have their own `_meta` field.
 	 *
 	 * @since 0.6.0 Added the optional $resource_meta parameter.
 	 *
 	 * @param string $uri The URI of the resource.
 	 * @param string $blob Base64-encoded binary data.
 	 * @param string|null $mime_type Optional MIME type of the resource.
-	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
-	 * @param array|null $_meta Optional metadata for the content block.
-	 * @param array|null $resource_meta Optional metadata for the nested resource contents.
+	 * @param array<string, mixed>|null $annotations Optional annotations for the client.
+	 * @param array<string, mixed>|null $_meta Optional metadata for the content block.
+	 * @param array<string, mixed>|null $resource_meta Optional metadata for the nested resource contents.
 	 *
-	 * @return \WP\McpSchema\Common\Protocol\DTO\EmbeddedResource The created EmbeddedResource DTO.
+	 * @return array<string, mixed> Embedded resource content data.
 	 */
 	public static function embedded_blob_resource(
 		string $uri,
 		string $blob,
 		?string $mime_type = null,
-		?Annotations $annotations = null,
+		?array $annotations = null,
 		?array $_meta = null,
 		?array $resource_meta = null
-	): EmbeddedResource {
-		$resource = BlobResourceContents::fromArray(
-			array(
-				'uri'      => $uri,
-				'blob'     => $blob,
-				'mimeType' => $mime_type,
-				'_meta'    => McpValidator::normalize_meta( $resource_meta ),
-			)
+	): array {
+		$resource = array(
+			'uri'  => $uri,
+			'blob' => $blob,
 		);
 
-		return EmbeddedResource::fromArray(
+		if ( null !== $mime_type ) {
+			$resource['mimeType'] = $mime_type;
+		}
+
+		$normalized_resource_meta = McpValidator::normalize_meta( $resource_meta );
+		if ( null !== $normalized_resource_meta ) {
+			$resource['_meta'] = $normalized_resource_meta;
+		}
+
+		return self::with_optional_fields(
 			array(
-				'type'        => EmbeddedResource::TYPE,
-				'resource'    => $resource,
-				'annotations' => $annotations,
-				'_meta'       => McpValidator::normalize_meta( $_meta ),
-			)
+				'type'     => 'resource',
+				'resource' => $resource,
+			),
+			$annotations,
+			$_meta
 		);
 	}
 
 	/**
-	 * Creates a TextContent DTO for error messages.
-	 *
-	 * Convenience method for creating text content specifically for error responses.
-	 * This is semantically equivalent to text() but makes the intent clearer in code.
+	 * Create text content for an error response.
 	 *
 	 * @param string $message The error message.
-	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
-	 * @param array|null $_meta Optional metadata for the content block.
+	 * @param array<string, mixed>|null $annotations Optional annotations for the client.
+	 * @param array<string, mixed>|null $_meta Optional metadata for the content block.
 	 *
-	 * @return \WP\McpSchema\Common\Content\DTO\TextContent The created TextContent DTO.
+	 * @return array<string, mixed> Text content data.
 	 */
-	public static function error_text( string $message, ?Annotations $annotations = null, ?array $_meta = null ): TextContent {
+	public static function error_text( string $message, ?array $annotations = null, ?array $_meta = null ): array {
 		return self::text( $message, $annotations, $_meta );
 	}
 
 	/**
-	 * Creates a TextContent DTO.
+	 * Create text content.
 	 *
 	 * @param string $text The text content.
-	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
-	 * @param array|null $_meta Optional metadata for the content block.
+	 * @param array<string, mixed>|null $annotations Optional annotations for the client.
+	 * @param array<string, mixed>|null $_meta Optional metadata for the content block.
 	 *
-	 * @return \WP\McpSchema\Common\Content\DTO\TextContent The created TextContent DTO.
+	 * @return array<string, mixed> Text content data.
 	 */
-	public static function text( string $text, ?Annotations $annotations = null, ?array $_meta = null ): TextContent {
-		return TextContent::fromArray(
+	public static function text( string $text, ?array $annotations = null, ?array $_meta = null ): array {
+		return self::with_optional_fields(
 			array(
-				'type'        => TextContent::TYPE,
-				'text'        => $text,
-				'annotations' => $annotations,
-				'_meta'       => McpValidator::normalize_meta( $_meta ),
-			)
+				'type' => 'text',
+				'text' => $text,
+			),
+			$annotations,
+			$_meta
 		);
 	}
 
 	/**
-	 * Creates a TextContent DTO with JSON-encoded data.
-	 *
-	 * Convenience method for creating text content from structured data.
-	 * The data is encoded as JSON and wrapped in a TextContent DTO.
+	 * Create text content with JSON-encoded data.
 	 *
 	 * @param mixed $data The data to JSON-encode.
 	 * @param int $flags JSON encoding flags (default: 0).
-	 * @param \WP\McpSchema\Common\Protocol\DTO\Annotations|null $annotations Optional annotations for the client.
-	 * @param array|null $_meta Optional metadata for the content block.
+	 * @param array<string, mixed>|null $annotations Optional annotations for the client.
+	 * @param array<string, mixed>|null $_meta Optional metadata for the content block.
 	 *
-	 * @return \WP\McpSchema\Common\Content\DTO\TextContent The created TextContent DTO.
+	 * @return array<string, mixed> Text content data.
 	 */
-	public static function json_text( $data, int $flags = 0, ?Annotations $annotations = null, ?array $_meta = null ): TextContent {
+	public static function json_text( $data, int $flags = 0, ?array $annotations = null, ?array $_meta = null ): array {
 		$json = wp_json_encode( $data, $flags );
 		if ( false === $json ) {
 			$json = '{}';
@@ -235,20 +215,35 @@ final class ContentBlockHelper {
 	}
 
 	/**
-	 * Converts an array of ContentBlockInterface DTOs to their array representations.
+	 * Return an array of content blocks at compatibility call sites.
 	 *
-	 * Use this at the serialization boundary when preparing content blocks for JSON output.
+	 * @param list<array<string, mixed>> $blocks Content block data.
 	 *
-	 * @param \WP\McpSchema\Common\Protocol\Union\ContentBlockInterface[] $blocks Array of content block DTOs.
-	 *
-	 * @return array[] Array of content block arrays.
+	 * @return list<array<string, mixed>> Content block data.
 	 */
 	public static function to_array_list( array $blocks ): array {
-		return array_map(
-			static function ( ContentBlockInterface $block ): array {
-				return $block->toArray();
-			},
-			$blocks
-		);
+		return array_values( $blocks );
+	}
+
+	/**
+	 * Add optional shared content-block fields without storing nulls.
+	 *
+	 * @param array<string, mixed> $content Required content data.
+	 * @param array<string, mixed>|null $annotations Optional annotations.
+	 * @param array<string, mixed>|null $_meta Optional metadata.
+	 *
+	 * @return array<string, mixed> Content data.
+	 */
+	private static function with_optional_fields( array $content, ?array $annotations, ?array $_meta ): array {
+		if ( null !== $annotations ) {
+			$content['annotations'] = $annotations;
+		}
+
+		$normalized_meta = McpValidator::normalize_meta( $_meta );
+		if ( null !== $normalized_meta ) {
+			$content['_meta'] = $normalized_meta;
+		}
+
+		return $content;
 	}
 }

--- a/includes/Handlers/Initialize/InitializeHandler.php
+++ b/includes/Handlers/Initialize/InitializeHandler.php
@@ -11,9 +11,6 @@ namespace WP\MCP\Handlers\Initialize;
 
 use WP\MCP\Core\McpServer;
 use WP\MCP\Core\McpVersionNegotiator;
-use WP\McpSchema\Common\Lifecycle\DTO\Implementation;
-use WP\McpSchema\Common\Protocol\DTO\InitializeResult;
-use WP\McpSchema\Server\Lifecycle\DTO\ServerCapabilities;
 
 /**
  * Handles the initialize MCP method.
@@ -39,61 +36,53 @@ class InitializeHandler {
 	 * Handles the initialize request.
 	 *
 	 * Negotiates the protocol version with the client using McpVersionNegotiator.
-	 * If the client requests a supported version, that version is used. Otherwise
-	 * the server falls back to the latest supported version.
+	 * Unsupported initialize versions fall back to the supported legacy revision;
+	 * modern requests use per-request negotiation rather than initialize.
 	 *
 	 * @since 0.5.0
 	 *
 	 * @param string $client_protocol_version The protocol version requested by the client.
 	 *
-	 * @return \WP\McpSchema\Common\Protocol\DTO\InitializeResult Response with server capabilities and information.
+	 * @return array Response with server capabilities and information.
 	 */
-	public function handle( string $client_protocol_version ): InitializeResult {
+	public function handle( string $client_protocol_version ): array {
 		$negotiated_version = McpVersionNegotiator::negotiate( $client_protocol_version );
 
-		$server_info = Implementation::fromArray(
-			array(
-				'name'    => $this->mcp->get_server_name(),
-				'version' => $this->mcp->get_server_version(),
-			)
+		$server_info = array(
+			'name'    => $this->mcp->get_server_name(),
+			'version' => $this->mcp->get_server_version(),
 		);
 
 		// Capabilities should only be advertised if they are implemented end-to-end.
 		// IMPORTANT: We set explicit boolean values (not empty arrays) to ensure proper JSON serialization.
 		// Empty arrays `[]` serialize as JSON arrays `[]`, but MCP spec requires JSON objects `{}`.
 		// Setting explicit values like `listChanged: false` produces associative arrays that serialize correctly.
-		$capabilities = ServerCapabilities::fromArray(
-			array(
-				'prompts'   => array( 'listChanged' => false ),
-				'resources' => array(
-					'subscribe'   => false,
-					'listChanged' => false,
-				),
-				'tools'     => array( 'listChanged' => false ),
-			)
+		$capabilities = array(
+			'prompts'   => array( 'listChanged' => false ),
+			'resources' => array(
+				'subscribe'   => false,
+				'listChanged' => false,
+			),
+			'tools'     => array( 'listChanged' => false ),
 		);
 
-		$result = InitializeResult::fromArray(
-			array(
-				'protocolVersion' => $negotiated_version,
-				'capabilities'    => $capabilities,
-				'serverInfo'      => $server_info,
-				'instructions'    => $this->mcp->get_server_description(),
-			)
+		$result = array(
+			'protocolVersion' => $negotiated_version,
+			'capabilities'    => $capabilities,
+			'serverInfo'      => $server_info,
+			'instructions'    => $this->mcp->get_server_description(),
 		);
 
 		/**
 		 * Filters the initialize response before returning to the client.
 		 *
 		 * Use this filter to modify server capabilities, instructions, or
-		 * other initialization data dynamically. To modify the result, call
-		 * `$result->toArray()`, change the data, and return
-		 * `InitializeResult::fromArray( $modified_data )`.
+		 * other initialization data dynamically.
 		 *
 		 * @since 0.5.0
 		 *
-		 * @param \WP\McpSchema\Common\Protocol\DTO\InitializeResult $result The initialize result DTO.
-		 * @param \WP\MCP\Core\McpServer                             $server The MCP server instance.
+		 * @param array                  $result The initialize result data.
+		 * @param \WP\MCP\Core\McpServer $server The MCP server instance.
 		 */
 		return apply_filters( 'mcp_adapter_initialize_response', $result, $this->mcp );
 	}

--- a/includes/Handlers/Initialize/InitializeHandler.php
+++ b/includes/Handlers/Initialize/InitializeHandler.php
@@ -11,6 +11,7 @@ namespace WP\MCP\Handlers\Initialize;
 
 use WP\MCP\Core\McpServer;
 use WP\MCP\Core\McpVersionNegotiator;
+use WP\McpSchema\Common\Protocol\DTO\InitializeResult;
 
 /**
  * Handles the initialize MCP method.
@@ -66,24 +67,32 @@ class InitializeHandler {
 			'tools'     => array( 'listChanged' => false ),
 		);
 
-		$result = array(
-			'protocolVersion' => $negotiated_version,
-			'capabilities'    => $capabilities,
-			'serverInfo'      => $server_info,
-			'instructions'    => $this->mcp->get_server_description(),
+		$result = InitializeResult::fromArray(
+			array(
+				'protocolVersion' => $negotiated_version,
+				'capabilities'    => $capabilities,
+				'serverInfo'      => $server_info,
+				'instructions'    => $this->mcp->get_server_description(),
+			)
 		);
 
 		/**
 		 * Filters the initialize response before returning to the client.
 		 *
 		 * Use this filter to modify server capabilities, instructions, or
-		 * other initialization data dynamically.
+		 * other initialization data dynamically. Call `$result->toArray()`,
+		 * change the data, and return `InitializeResult::fromArray( $data )`.
 		 *
 		 * @since 0.5.0
 		 *
-		 * @param array                  $result The initialize result data.
-		 * @param \WP\MCP\Core\McpServer $server The MCP server instance.
+		 * @param \WP\McpSchema\Common\Protocol\DTO\InitializeResult $result The initialize result facade.
+		 * @param \WP\MCP\Core\McpServer                              $server The MCP server instance.
 		 */
-		return apply_filters( 'mcp_adapter_initialize_response', $result, $this->mcp );
+		$filtered = apply_filters( 'mcp_adapter_initialize_response', $result, $this->mcp );
+		if ( $filtered instanceof InitializeResult ) {
+			return $filtered->toArray();
+		}
+
+		return is_array( $filtered ) ? $filtered : $result->toArray();
 	}
 }

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -15,6 +15,7 @@ use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Handlers\HandlerHelperTrait;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
 
 /**
  * Handles prompts-related MCP methods.
@@ -67,7 +68,10 @@ class PromptsHandler {
 	 * @return array Response with prompts list.
 	 */
 	public function list_prompts(): array {
-		$prompts = array_values( $this->mcp->get_prompts() );
+		$prompts = array_map(
+			static fn( array $prompt ): Prompt => Prompt::fromArray( $prompt ),
+			array_values( $this->mcp->get_prompts() )
+		);
 
 		/**
 		 * Filters the list of prompts before returning to the client.
@@ -77,8 +81,8 @@ class PromptsHandler {
 		 *
 		 * @since 0.5.0
 		 *
-		 * @param array                  $prompts Array of prompt protocol data.
-		 * @param \WP\MCP\Core\McpServer $server  The MCP server instance.
+		 * @param array<\WP\McpSchema\Server\Prompts\DTO\Prompt> $prompts Array of Prompt facades.
+		 * @param \WP\MCP\Core\McpServer                             $server The MCP server instance.
 		 */
 		$prompts = $this->validate_filtered_list(
 			apply_filters( 'mcp_adapter_prompts_list', $prompts, $this->mcp ),
@@ -88,7 +92,10 @@ class PromptsHandler {
 		);
 
 		return array(
-			'prompts' => $prompts,
+			'prompts' => array_map(
+				static fn( $prompt ): array => $prompt instanceof Prompt ? $prompt->toArray() : (array) $prompt,
+				$prompts
+			),
 		);
 	}
 
@@ -190,7 +197,10 @@ class PromptsHandler {
 			}
 
 			if ( $result instanceof McpExecutionResult ) {
-				return $result;
+				if ( $result->is_input_required() ) {
+					return $result;
+				}
+				$result = $result->get_value();
 			}
 
 			return $this->normalize_result( $result, $prompt, $prompt_name );

--- a/includes/Handlers/Prompts/PromptsHandler.php
+++ b/includes/Handlers/Prompts/PromptsHandler.php
@@ -10,13 +10,11 @@ declare( strict_types=1 );
 namespace WP\MCP\Handlers\Prompts;
 
 use WP\MCP\Core\McpServer;
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Handlers\HandlerHelperTrait;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
-use WP\McpSchema\Server\Prompts\DTO\GetPromptResult;
-use WP\McpSchema\Server\Prompts\DTO\ListPromptsResult;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
-use WP\McpSchema\Server\Prompts\DTO\PromptMessage;
 
 /**
  * Handles prompts-related MCP methods.
@@ -27,14 +25,14 @@ class PromptsHandler {
 	use HandlerHelperTrait;
 
 	/**
-	 * Valid content types from ContentBlockFactory.
+	 * Valid protocol content types.
 	 *
 	 * @var list<string>
 	 */
 	private static array $valid_content_types = array( 'text', 'image', 'audio', 'resource_link', 'resource' );
 
 	/**
-	 * Valid role values for PromptMessage.
+	 * Valid prompt-message role values.
 	 *
 	 * @var list<string>
 	 */
@@ -66,9 +64,9 @@ class PromptsHandler {
 	/**
 	 * Handles the prompts/list request.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\ListPromptsResult Response with prompts list DTO.
+	 * @return array Response with prompts list.
 	 */
-	public function list_prompts(): ListPromptsResult {
+	public function list_prompts(): array {
 		$prompts = array_values( $this->mcp->get_prompts() );
 
 		/**
@@ -79,8 +77,8 @@ class PromptsHandler {
 		 *
 		 * @since 0.5.0
 		 *
-		 * @param array<\WP\McpSchema\Server\Prompts\DTO\Prompt> $prompts Array of Prompt DTOs.
-		 * @param \WP\MCP\Core\McpServer                         $server  The MCP server instance.
+		 * @param array                  $prompts Array of prompt protocol data.
+		 * @param \WP\MCP\Core\McpServer $server  The MCP server instance.
 		 */
 		$prompts = $this->validate_filtered_list(
 			apply_filters( 'mcp_adapter_prompts_list', $prompts, $this->mcp ),
@@ -89,10 +87,8 @@ class PromptsHandler {
 			$this->mcp->get_error_handler()
 		);
 
-		return ListPromptsResult::fromArray(
-			array(
-				'prompts' => $prompts,
-			)
+		return array(
+			'prompts' => $prompts,
 		);
 	}
 
@@ -101,10 +97,11 @@ class PromptsHandler {
 	 *
 	 * @param array           $params Request parameters.
 	 * @param string|int|null $request_id Optional. The request ID for JSON-RPC. Default 0.
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional stateless continuation input.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\GetPromptResult|\WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse Response with prompt execution results or error.
+	 * @return array|\WP\MCP\Domain\Continuation\McpExecutionResult Response data, continuation result, or a JSON-RPC error envelope.
 	 */
-	public function get_prompt( array $params, $request_id = 0 ) {
+	public function get_prompt( array $params, $request_id = 0, ?McpContinuationContext $continuation = null ) {
 		// Extract parameters using helper method.
 		$request_params = $this->extract_params( $params );
 
@@ -125,8 +122,7 @@ class PromptsHandler {
 			return McpErrorFactory::prompt_not_found( $request_id, $prompt_name );
 		}
 
-		/** @var \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt */
-		$prompt = $mcp_prompt->get_protocol_dto();
+		$prompt = $mcp_prompt->get_protocol_data();
 
 		// Get the arguments for the prompt.
 		$arguments = $request_params['arguments'] ?? array();
@@ -162,7 +158,7 @@ class PromptsHandler {
 				return McpErrorFactory::internal_error( $request_id, $arguments->get_error_message() );
 			}
 
-			$result = $mcp_prompt->execute( $arguments );
+			$result = $mcp_prompt->execute( $arguments, $continuation );
 
 			/**
 			 * Filters the prompt execution result before normalization.
@@ -193,7 +189,11 @@ class PromptsHandler {
 				return McpErrorFactory::internal_error( $request_id, $result->get_error_message() );
 			}
 
-			return $this->normalize_result_to_dto( $result, $prompt, $prompt_name );
+			if ( $result instanceof McpExecutionResult ) {
+				return $result;
+			}
+
+			return $this->normalize_result( $result, $prompt, $prompt_name );
 		} catch ( \Throwable $e ) {
 			$this->mcp->get_error_handler()->log(
 				'Prompt execution failed',
@@ -213,7 +213,7 @@ class PromptsHandler {
 	// =========================================================================
 
 	/**
-	 * Normalize and convert prompt execution result to GetPromptResult DTO.
+	 * Normalize a prompt execution result to stable protocol data.
 	 *
 	 * Supports tiered return formats:
 	 * - Tier 1: Full MCP format with 'messages' array
@@ -224,17 +224,17 @@ class PromptsHandler {
 	 *
 	 * @since 0.5.0
 	 *
-	 * @param array                                 $result      Raw result from prompt execution.
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt      The prompt DTO for description fallback.
-	 * @param string                                $prompt_name Prompt name for logging.
+	 * @param array  $result      Raw result from prompt execution.
+	 * @param array  $prompt      Prompt protocol data for description fallback.
+	 * @param string $prompt_name Prompt name for logging.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\GetPromptResult
+	 * @return array
 	 */
-	private function normalize_result_to_dto(
+	private function normalize_result(
 		array $result,
-		PromptDto $prompt,
+		array $prompt,
 		string $prompt_name
-	): GetPromptResult {
+	): array {
 		// Tier 1: Full MCP format with 'messages' array.
 		if ( isset( $result['messages'] ) && is_array( $result['messages'] ) ) {
 			return $this->normalize_tier1_messages( $result, $prompt, $prompt_name );
@@ -264,18 +264,18 @@ class PromptsHandler {
 	 *
 	 * @since 0.5.0
 	 *
-	 * @param array                                 $result      Raw result with 'messages' key.
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt      The prompt DTO.
-	 * @param string                                $prompt_name Prompt name for logging.
+	 * @param array  $result      Raw result with 'messages' key.
+	 * @param array  $prompt      Prompt protocol data.
+	 * @param string $prompt_name Prompt name for logging.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\GetPromptResult
+	 * @return array
 	 */
 	private function normalize_tier1_messages(
 		array $result,
-		PromptDto $prompt,
+		array $prompt,
 		string $prompt_name
-	): GetPromptResult {
-		$message_dtos = array();
+	): array {
+		$messages = array();
 
 		foreach ( $result['messages'] as $index => $message ) {
 			if ( ! is_array( $message ) ) {
@@ -291,27 +291,23 @@ class PromptsHandler {
 				continue;
 			}
 
-			$message_dtos[] = $this->validate_and_create_message( $message, $prompt_name );
+			$messages[] = $this->validate_and_create_message( $message, $prompt_name );
 		}
 
 		// Ensure we have at least one message.
-		if ( empty( $message_dtos ) ) {
-			$message_dtos[] = PromptMessage::fromArray(
-				array(
-					'role'    => self::$default_role,
-					'content' => array(
-						'type' => 'text',
-						'text' => '(No messages returned)',
-					),
-				)
+		if ( empty( $messages ) ) {
+			$messages[] = array(
+				'role'    => self::$default_role,
+				'content' => array(
+					'type' => 'text',
+					'text' => '(No messages returned)',
+				),
 			);
 		}
 
-		return GetPromptResult::fromArray(
-			array(
-				'messages'    => $message_dtos,
-				'description' => $result['description'] ?? $prompt->getDescription(),
-			)
+		return $this->create_prompt_result(
+			$messages,
+			$result['description'] ?? $prompt['description'] ?? null
 		);
 	}
 
@@ -322,12 +318,12 @@ class PromptsHandler {
 	 *
 	 * @since 0.5.0
 	 *
-	 * @param array                                 $result Raw result with 'text' key.
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The prompt DTO.
+	 * @param array $result Raw result with 'text' key.
+	 * @param array $prompt Prompt protocol data.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\GetPromptResult
+	 * @return array
 	 */
-	private function normalize_tier2_text( array $result, PromptDto $prompt ): GetPromptResult {
+	private function normalize_tier2_text( array $result, array $prompt ): array {
 		$content = array(
 			'type' => 'text',
 			'text' => (string) $result['text'],
@@ -338,18 +334,14 @@ class PromptsHandler {
 			$content['annotations'] = $result['annotations'];
 		}
 
-		$message_dto = PromptMessage::fromArray(
-			array(
-				'role'    => self::$default_role,
-				'content' => $content,
-			)
+		$message = array(
+			'role'    => self::$default_role,
+			'content' => $content,
 		);
 
-		return GetPromptResult::fromArray(
-			array(
-				'messages'    => array( $message_dto ),
-				'description' => $result['description'] ?? $prompt->getDescription(),
-			)
+		return $this->create_prompt_result(
+			array( $message ),
+			$result['description'] ?? $prompt['description'] ?? null
 		);
 	}
 
@@ -358,24 +350,22 @@ class PromptsHandler {
 	 *
 	 * @since 0.5.0
 	 *
-	 * @param array                                 $result      Raw result with 'role' and 'content' keys.
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt      The prompt DTO.
-	 * @param string                                $prompt_name Prompt name for logging.
+	 * @param array  $result      Raw result with 'role' and 'content' keys.
+	 * @param array  $prompt      Prompt protocol data.
+	 * @param string $prompt_name Prompt name for logging.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\GetPromptResult
+	 * @return array
 	 */
 	private function normalize_tier3_single_message(
 		array $result,
-		PromptDto $prompt,
+		array $prompt,
 		string $prompt_name
-	): GetPromptResult {
-		$message_dto = $this->validate_and_create_message( $result, $prompt_name );
+	): array {
+		$message = $this->validate_and_create_message( $result, $prompt_name );
 
-		return GetPromptResult::fromArray(
-			array(
-				'messages'    => array( $message_dto ),
-				'description' => $result['description'] ?? $prompt->getDescription(),
-			)
+		return $this->create_prompt_result(
+			array( $message ),
+			$result['description'] ?? $prompt['description'] ?? null
 		);
 	}
 
@@ -386,49 +376,43 @@ class PromptsHandler {
 	 *
 	 * @since 0.5.0
 	 *
-	 * @param array                                 $result Raw result with 'texts' key.
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt The prompt DTO.
+	 * @param array $result Raw result with 'texts' key.
+	 * @param array $prompt Prompt protocol data.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\GetPromptResult
+	 * @return array
 	 */
-	private function normalize_tier4_texts( array $result, PromptDto $prompt ): GetPromptResult {
-		$role         = $this->validate_role( $result['role'] ?? self::$default_role, '' );
-		$message_dtos = array();
+	private function normalize_tier4_texts( array $result, array $prompt ): array {
+		$role     = $this->validate_role( $result['role'] ?? self::$default_role, '' );
+		$messages = array();
 
 		foreach ( $result['texts'] as $text ) {
 			if ( ! is_string( $text ) ) {
 				continue;
 			}
 
-			$message_dtos[] = PromptMessage::fromArray(
-				array(
-					'role'    => $role,
-					'content' => array(
-						'type' => 'text',
-						'text' => $text,
-					),
-				)
+			$messages[] = array(
+				'role'    => $role,
+				'content' => array(
+					'type' => 'text',
+					'text' => $text,
+				),
 			);
 		}
 
 		// Ensure we have at least one message.
-		if ( empty( $message_dtos ) ) {
-			$message_dtos[] = PromptMessage::fromArray(
-				array(
-					'role'    => $role,
-					'content' => array(
-						'type' => 'text',
-						'text' => '(No texts provided)',
-					),
-				)
+		if ( empty( $messages ) ) {
+			$messages[] = array(
+				'role'    => $role,
+				'content' => array(
+					'type' => 'text',
+					'text' => '(No texts provided)',
+				),
 			);
 		}
 
-		return GetPromptResult::fromArray(
-			array(
-				'messages'    => $message_dtos,
-				'description' => $result['description'] ?? $prompt->getDescription(),
-			)
+		return $this->create_prompt_result(
+			$messages,
+			$result['description'] ?? $prompt['description'] ?? null
 		);
 	}
 
@@ -439,17 +423,17 @@ class PromptsHandler {
 	 *
 	 * @since 0.5.0
 	 *
-	 * @param array                                 $result      Raw result (arbitrary structure).
-	 * @param \WP\McpSchema\Server\Prompts\DTO\Prompt $prompt      The prompt DTO.
-	 * @param string                                $prompt_name Prompt name for logging.
+	 * @param array  $result      Raw result (arbitrary structure).
+	 * @param array  $prompt      Prompt protocol data.
+	 * @param string $prompt_name Prompt name for logging.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\GetPromptResult
+	 * @return array
 	 */
 	private function normalize_tier5_fallback(
 		array $result,
-		PromptDto $prompt,
+		array $prompt,
 		string $prompt_name
-	): GetPromptResult {
+	): array {
 		// Log observability event for fallback normalization.
 		$this->mcp->get_observability_handler()->record_event(
 			'prompt_result_fallback_normalization',
@@ -464,21 +448,17 @@ class PromptsHandler {
 			$json_content = '{}';
 		}
 
-		$message_dto = PromptMessage::fromArray(
-			array(
-				'role'    => self::$default_role,
-				'content' => array(
-					'type' => 'text',
-					'text' => $json_content,
-				),
-			)
+		$message = array(
+			'role'    => self::$default_role,
+			'content' => array(
+				'type' => 'text',
+				'text' => $json_content,
+			),
 		);
 
-		return GetPromptResult::fromArray(
-			array(
-				'messages'    => array( $message_dto ),
-				'description' => $prompt->getDescription(),
-			)
+		return $this->create_prompt_result(
+			array( $message ),
+			$prompt['description'] ?? null
 		);
 	}
 
@@ -487,7 +467,7 @@ class PromptsHandler {
 	// =========================================================================
 
 	/**
-	 * Validate message structure and create PromptMessage DTO.
+	 * Validate and normalize a prompt message.
 	 *
 	 * Validates role and content type, applying defaults where needed.
 	 *
@@ -496,9 +476,9 @@ class PromptsHandler {
 	 * @param array  $message     Raw message array.
 	 * @param string $prompt_name Prompt name for logging.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\PromptMessage
+	 * @return array
 	 */
-	private function validate_and_create_message( array $message, string $prompt_name ): PromptMessage {
+	private function validate_and_create_message( array $message, string $prompt_name ): array {
 		// Validate and normalize role.
 		$role = $this->validate_role( $message['role'] ?? self::$default_role, $prompt_name );
 
@@ -515,31 +495,43 @@ class PromptsHandler {
 		$content = $this->validate_content_type( $content, $prompt_name );
 		$content = $this->normalize_content_block( $content );
 
-		return PromptMessage::fromArray(
-			array(
-				'role'    => $role,
-				'content' => $content,
-			)
+		return array(
+			'role'    => $role,
+			'content' => $content,
 		);
 	}
 
 	/**
-	 * Bring a caller-supplied content block into the shape the schema DTOs accept.
+	 * Assemble a prompt result while preserving an omitted optional description.
 	 *
-	 * Prompt messages carry the same content blocks tool results do, and reach the wire
-	 * through the same DTOs, so they carry the same hazard: a `_meta` that would serialize
+	 * @param array $messages    Prompt messages.
+	 * @param mixed $description Optional description.
+	 *
+	 * @return array
+	 */
+	private function create_prompt_result( array $messages, $description ): array {
+		$result = array( 'messages' => $messages );
+		if ( is_string( $description ) ) {
+			$result['description'] = $description;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Bring a caller-supplied content block into the stable protocol shape.
+	 *
+	 * Prompt messages carry the same content blocks tool results do, so they carry the
+	 * same hazard: a `_meta` that would serialize
 	 * as a JSON array where MCP declares an object.
 	 *
-	 * Here the cost is higher than on the tool path. A value the DTO refuses throws, and
-	 * the catch in get_prompt() turns that into an error response - so a `_meta` that is
-	 * not an array at all loses the whole prompt rather than the field. It is dropped so
-	 * that the message survives.
+	 * A `_meta` that is not an array is dropped so that the message survives.
 	 *
 	 * @since 0.6.0
 	 *
 	 * @param array $content Content block as the prompt returned it.
 	 *
-	 * @return array Content block safe to hand to PromptMessage::fromArray().
+	 * @return array Normalized content block.
 	 */
 	private function normalize_content_block( array $content ): array {
 		$block_meta = McpValidator::normalize_meta( $content['_meta'] ?? null );
@@ -549,8 +541,7 @@ class PromptsHandler {
 			$content['_meta'] = $block_meta;
 		}
 
-		// EmbeddedResource takes its resource contents as given, so a nested block never
-		// reaches a DTO that could reject them. This is the only level that inspects them.
+		// This is the only level that inspects nested resource metadata.
 		if ( 'resource' === ( $content['type'] ?? '' ) && isset( $content['resource'] ) && is_array( $content['resource'] ) ) {
 			$resource = $content['resource'];
 
@@ -567,7 +558,7 @@ class PromptsHandler {
 	}
 
 	/**
-	 * Validate content type against ContentBlockFactory registry.
+	 * Validate the content type against the supported protocol types.
 	 *
 	 * @since 0.5.0
 	 *

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -10,14 +10,11 @@ declare( strict_types=1 );
 namespace WP\MCP\Handlers\Resources;
 
 use WP\MCP\Core\McpServer;
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Handlers\HandlerHelperTrait;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
-use WP\McpSchema\Common\Protocol\DTO\BlobResourceContents;
-use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
-use WP\McpSchema\Server\Resources\DTO\ListResourceTemplatesResult;
-use WP\McpSchema\Server\Resources\DTO\ListResourcesResult;
-use WP\McpSchema\Server\Resources\DTO\ReadResourceResult;
 
 /**
  * Handles resources-related MCP methods.
@@ -45,12 +42,12 @@ class ResourcesHandler {
 	/**
 	 * Handles the resources/list request.
 	 *
-	 * Returns a ListResourcesResult DTO containing all registered resources.
-	 * Returns protocol DTOs as-is; any `_meta` fields are passed through unchanged.
+	 * Returns registered resource protocol data as-is; any `_meta` fields are
+	 * passed through unchanged.
 	 *
-	 * @return \WP\McpSchema\Server\Resources\DTO\ListResourcesResult Response with resources list.
+	 * @return array Response with resources list.
 	 */
-	public function list_resources(): ListResourcesResult {
+	public function list_resources(): array {
 		$resources = array_values( $this->mcp->get_resources() );
 
 		/**
@@ -61,8 +58,8 @@ class ResourcesHandler {
 		 *
 		 * @since 0.5.0
 		 *
-		 * @param array<\WP\McpSchema\Server\Resources\DTO\Resource> $resources Array of Resource DTOs.
-		 * @param \WP\MCP\Core\McpServer                             $server    The MCP server instance.
+		 * @param array                  $resources Array of resource protocol data.
+		 * @param \WP\MCP\Core\McpServer $server    The MCP server instance.
 		 */
 		$resources = $this->validate_filtered_list(
 			apply_filters( 'mcp_adapter_resources_list', $resources, $this->mcp ),
@@ -71,10 +68,8 @@ class ResourcesHandler {
 			$this->mcp->get_error_handler()
 		);
 
-		return ListResourcesResult::fromArray(
-			array(
-				'resources' => $resources,
-			)
+		return array(
+			'resources' => $resources,
 		);
 	}
 
@@ -86,20 +81,18 @@ class ResourcesHandler {
 	 * the base `resources` capability (no sub-flag gates it), which the server always
 	 * advertises, so spec-compliant clients call it during resource discovery.
 	 *
-	 * @return \WP\McpSchema\Server\Resources\DTO\ListResourceTemplatesResult Empty resource-templates list.
+	 * @return array Empty resource-templates list.
 	 */
-	public function list_resource_templates(): ListResourceTemplatesResult {
-		return ListResourceTemplatesResult::fromArray(
-			array(
-				'resourceTemplates' => array(),
-			)
+	public function list_resource_templates(): array {
+		return array(
+			'resourceTemplates' => array(),
 		);
 	}
 
 	/**
 	 * Handles the resources/read request.
 	 *
-	 * Returns either a ReadResourceResult DTO (for success) or a JSONRPCErrorResponse DTO
+	 * Returns either stable resource result data (for success) or a JSON-RPC error envelope
 	 * (for protocol errors like missing parameter or resource not found).
 	 *
 	 * Unlike tools, resources don't have a concept of "execution errors" that should be
@@ -107,10 +100,11 @@ class ResourcesHandler {
 	 *
 	 * @param array $params Request parameters.
 	 * @param string|int|null $request_id Optional. The request ID for JSON-RPC. Default 0.
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional stateless continuation input.
 	 *
-	 * @return \WP\McpSchema\Server\Resources\DTO\ReadResourceResult|\WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array|\WP\MCP\Domain\Continuation\McpExecutionResult
 	 */
-	public function read_resource( array $params, $request_id = 0 ) {
+	public function read_resource( array $params, $request_id = 0, ?McpContinuationContext $continuation = null ) {
 		// Extract parameters using helper method.
 		$request_params = $this->extract_params( $params );
 
@@ -126,14 +120,13 @@ class ResourcesHandler {
 			return McpErrorFactory::resource_not_found( $request_id, $uri );
 		}
 
-		/** @var \WP\McpSchema\Server\Resources\DTO\Resource $resource */
-		$resource = $mcp_resource->get_protocol_dto();
+		$resource = $mcp_resource->get_protocol_data();
 
 		try {
 			$has_permission = $mcp_resource->check_permission( $request_params );
 			if ( true !== $has_permission ) {
 				// Extract detailed error message if WP_Error was returned.
-				$error_message = 'Access denied for resource: ' . $resource->getName();
+				$error_message = 'Access denied for resource: ' . ( $resource['name'] ?? $uri );
 
 				if ( is_wp_error( $has_permission ) ) {
 					$error_message = $has_permission->get_error_message();
@@ -162,7 +155,7 @@ class ResourcesHandler {
 				return McpErrorFactory::internal_error( $request_id, $request_params->get_error_message() );
 			}
 
-			$contents = $mcp_resource->execute( $request_params );
+			$contents = $mcp_resource->execute( $request_params, $continuation );
 
 			/**
 			 * Filters the resource contents after execution.
@@ -194,20 +187,22 @@ class ResourcesHandler {
 				return McpErrorFactory::internal_error( $request_id, $contents->get_error_message() );
 			}
 
-			// Successful execution - convert contents to DTOs.
+			if ( $contents instanceof McpExecutionResult ) {
+				return $contents;
+			}
+
+			// Successful execution - convert contents to validated protocol arrays.
 			// Contents should be an array of resource content items.
-			// If it's already an array of properly formatted items, convert each to a DTO.
+			// If it's already an array of properly formatted items, normalize each item.
 			// Otherwise, wrap the result as text content.
 			//
 			// Seed the fallback content URI with the advertised URI, not the client's
 			// request URI, so contents[].uri matches resources/list even when the client
 			// lowercased the scheme (RFC 3986 3.1). For an exact-case read the two are equal.
-			$content_dtos = $this->convert_contents_to_dtos( $contents, $resource->getUri() );
+			$content_items = $this->convert_contents( $contents, $resource['uri'] );
 
-			return ReadResourceResult::fromArray(
-				array(
-					'contents' => $content_dtos,
-				)
+			return array(
+				'contents' => $content_items,
 			);
 		} catch ( \Throwable $exception ) {
 			$this->mcp->get_error_handler()->log(
@@ -223,17 +218,17 @@ class ResourcesHandler {
 	}
 
 	/**
-	 * Convert ability execution results to resource content DTOs.
+	 * Convert ability execution results to resource content arrays.
 	 *
-	 * The MCP spec expects contents to be an array of TextResourceContents or BlobResourceContents.
+	 * The MCP spec expects contents to be text-resource or blob-resource arrays.
 	 * This method handles various return formats from abilities and normalizes them.
 	 *
 	 * @param mixed $contents The contents returned by the ability.
 	 * @param string $uri The resource URI.
 	 *
-	 * @return array<\WP\McpSchema\Common\Protocol\DTO\TextResourceContents|\WP\McpSchema\Common\Protocol\DTO\BlobResourceContents>
+	 * @return array
 	 */
-	private function convert_contents_to_dtos( $contents, string $uri ): array {
+	private function convert_contents( $contents, string $uri ): array {
 		// If contents is already an array of properly structured items, convert each.
 		if ( is_array( $contents ) && ! empty( $contents ) ) {
 			// Check if this is an array of content items (has 'uri', 'text', or 'blob' in first item).
@@ -241,7 +236,7 @@ class ResourcesHandler {
 			if ( is_array( $first_item ) && ( isset( $first_item['uri'] ) || isset( $first_item['text'] ) || isset( $first_item['blob'] ) ) ) {
 				return array_map(
 					function ( $item ) use ( $uri ) {
-						return $this->create_content_dto( $item, $uri );
+						return $this->create_content( $item, $uri );
 					},
 					$contents
 				);
@@ -259,17 +254,15 @@ class ResourcesHandler {
 		}
 
 		return array(
-			TextResourceContents::fromArray(
-				array(
-					'uri'  => $uri,
-					'text' => $text,
-				)
+			array(
+				'uri'  => $uri,
+				'text' => $text,
 			),
 		);
 	}
 
 	/**
-	 * Create a content DTO from an array item.
+	 * Create a validated content array from an item.
 	 *
 	 * `_meta` is carried through from the item so metadata a handler attaches to its
 	 * resource contents reaches the client. MCP Apps UI resources rely on this: they
@@ -284,35 +277,56 @@ class ResourcesHandler {
 	 * @param array{uri?: mixed, mimeType?: mixed, text?: mixed, blob?: mixed, _meta?: mixed} $item The content item array.
 	 * @param string $default_uri The URI to use when the item names none.
 	 *
-	 * @return \WP\McpSchema\Common\Protocol\DTO\TextResourceContents|\WP\McpSchema\Common\Protocol\DTO\BlobResourceContents
+	 * @return array
 	 */
-	private function create_content_dto( array $item, string $default_uri ) {
+	private function create_content( array $item, string $default_uri ): array {
 		$item_uri  = $item['uri'] ?? $default_uri;
 		$mime_type = $item['mimeType'] ?? null;
 		$meta      = McpValidator::normalize_meta( $item['_meta'] ?? null );
 
-		// If there's blob data, create BlobResourceContents.
+		// If there's blob data, create blob-resource content.
 		if ( isset( $item['blob'] ) ) {
-			return BlobResourceContents::fromArray(
+			return $this->with_optional_content_fields(
 				array(
-					'uri'      => $item_uri,
-					'blob'     => (string) $item['blob'],
-					'mimeType' => is_string( $mime_type ) ? $mime_type : null,
-					'_meta'    => $meta,
-				)
+					'uri'  => $item_uri,
+					'blob' => (string) $item['blob'],
+				),
+				$mime_type,
+				$meta
 			);
 		}
 
-		// Default to TextResourceContents.
+		// Default to text-resource content.
 		$text = $item['text'] ?? '';
 
-		return TextResourceContents::fromArray(
+		return $this->with_optional_content_fields(
 			array(
-				'uri'      => $item_uri,
-				'text'     => (string) $text,
-				'mimeType' => is_string( $mime_type ) ? $mime_type : null,
-				'_meta'    => $meta,
-			)
+				'uri'  => $item_uri,
+				'text' => (string) $text,
+			),
+			$mime_type,
+			$meta
 		);
+	}
+
+	/**
+	 * Add valid optional fields to resource content.
+	 *
+	 * @param array      $content   Required content fields.
+	 * @param mixed      $mime_type Optional MIME type.
+	 * @param array|null $meta      Optional normalized metadata.
+	 *
+	 * @return array
+	 */
+	private function with_optional_content_fields( array $content, $mime_type, ?array $meta ): array {
+		if ( is_string( $mime_type ) ) {
+			$content['mimeType'] = $mime_type;
+		}
+
+		if ( null !== $meta ) {
+			$content['_meta'] = $meta;
+		}
+
+		return $content;
 	}
 }

--- a/includes/Handlers/Resources/ResourcesHandler.php
+++ b/includes/Handlers/Resources/ResourcesHandler.php
@@ -15,6 +15,7 @@ use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Handlers\HandlerHelperTrait;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
+use WP\McpSchema\Server\Resources\DTO\Resource;
 
 /**
  * Handles resources-related MCP methods.
@@ -48,7 +49,10 @@ class ResourcesHandler {
 	 * @return array Response with resources list.
 	 */
 	public function list_resources(): array {
-		$resources = array_values( $this->mcp->get_resources() );
+		$resources = array_map(
+			static fn( array $resource_data ): Resource => Resource::fromArray( $resource_data ),
+			array_values( $this->mcp->get_resources() )
+		);
 
 		/**
 		 * Filters the list of resources before returning to the client.
@@ -58,8 +62,8 @@ class ResourcesHandler {
 		 *
 		 * @since 0.5.0
 		 *
-		 * @param array                  $resources Array of resource protocol data.
-		 * @param \WP\MCP\Core\McpServer $server    The MCP server instance.
+		 * @param array<\WP\McpSchema\Server\Resources\DTO\Resource> $resources Array of Resource facades.
+		 * @param \WP\MCP\Core\McpServer                                 $server The MCP server instance.
 		 */
 		$resources = $this->validate_filtered_list(
 			apply_filters( 'mcp_adapter_resources_list', $resources, $this->mcp ),
@@ -69,7 +73,10 @@ class ResourcesHandler {
 		);
 
 		return array(
-			'resources' => $resources,
+			'resources' => array_map(
+				static fn( $resource_item ): array => $resource_item instanceof Resource ? $resource_item->toArray() : (array) $resource_item,
+				$resources
+			),
 		);
 	}
 
@@ -188,7 +195,10 @@ class ResourcesHandler {
 			}
 
 			if ( $contents instanceof McpExecutionResult ) {
-				return $contents;
+				if ( $contents->is_input_required() ) {
+					return $contents;
+				}
+				$contents = $contents->get_value();
 			}
 
 			// Successful execution - convert contents to validated protocol arrays.

--- a/includes/Handlers/System/SystemHandler.php
+++ b/includes/Handlers/System/SystemHandler.php
@@ -9,9 +9,6 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Handlers\System;
 
-use WP\McpSchema\Common\AbstractDataTransferObject;
-use WP\McpSchema\Common\Protocol\DTO\Result;
-
 /**
  * Handles system-related MCP methods.
  */
@@ -19,9 +16,9 @@ class SystemHandler {
 	/**
 	 * Handles the ping request.
 	 *
-	 * @return \WP\McpSchema\Common\AbstractDataTransferObject Empty result DTO per MCP specification.
+	 * @return array Empty result per MCP specification.
 	 */
-	public function ping(): AbstractDataTransferObject {
-		return Result::fromArray( array() );
+	public function ping(): array {
+		return array();
 	}
 }

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -17,6 +17,7 @@ use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Handlers\HandlerHelperTrait;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Infrastructure\Observability\FailureReason;
+use WP\McpSchema\Server\Tools\DTO\Tool;
 
 /**
  * Handles tools-related MCP methods.
@@ -72,7 +73,10 @@ class ToolsHandler {
 	 * @return array Response with tools list.
 	 */
 	public function list_tools(): array {
-		$tools = array_values( $this->mcp->get_tools() );
+		$tools = array_map(
+			static fn( array $tool ): Tool => Tool::fromArray( $tool ),
+			array_values( $this->mcp->get_tools() )
+		);
 
 		/**
 		 * Filters the list of tools before returning to the client.
@@ -82,8 +86,8 @@ class ToolsHandler {
 		 *
 		 * @since 0.5.0
 		 *
-		 * @param array                  $tools  Array of tool protocol data.
-		 * @param \WP\MCP\Core\McpServer $server The MCP server instance.
+		 * @param array<\WP\McpSchema\Server\Tools\DTO\Tool> $tools Array of Tool facades.
+		 * @param \WP\MCP\Core\McpServer                         $server The MCP server instance.
 		 */
 		$tools = $this->validate_filtered_list(
 			apply_filters( 'mcp_adapter_tools_list', $tools, $this->mcp ),
@@ -93,7 +97,10 @@ class ToolsHandler {
 		);
 
 		return array(
-			'tools' => $tools,
+			'tools' => array_map(
+				static fn( $tool ): array => $tool instanceof Tool ? $tool->toArray() : (array) $tool,
+				$tools
+			),
 		);
 	}
 
@@ -219,7 +226,10 @@ class ToolsHandler {
 			}
 
 			if ( $result instanceof McpExecutionResult ) {
-				return $result;
+				if ( $result->is_input_required() ) {
+					return $result;
+				}
+				$result = $result->get_value();
 			}
 
 			// Backward compatibility: treat `{ success: false, error: string }` as tool execution error.

--- a/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/Handlers/Tools/ToolsHandler.php
@@ -10,13 +10,13 @@ declare( strict_types=1 );
 namespace WP\MCP\Handlers\Tools;
 
 use WP\MCP\Core\McpServer;
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Utils\ContentBlockHelper;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Handlers\HandlerHelperTrait;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Infrastructure\Observability\FailureReason;
-use WP\McpSchema\Server\Tools\DTO\CallToolResult;
-use WP\McpSchema\Server\Tools\DTO\ListToolsResult;
 
 /**
  * Handles tools-related MCP methods.
@@ -51,13 +51,13 @@ class ToolsHandler {
 	 * Handles the tools/list/all request.
 	 *
 	 * This is a custom extension to the MCP spec that includes availability status.
-	 * Returns a ListToolsResult DTO containing all registered tools.
+	 * Returns all registered tool definitions.
 	 *
 	 * Note: The 'available' flag is a non-standard extension and is not currently implemented.
 	 *
-	 * @return \WP\McpSchema\Server\Tools\DTO\ListToolsResult Response with all tools.
+	 * @return array Response with all tools.
 	 */
-	public function list_all_tools(): ListToolsResult {
+	public function list_all_tools(): array {
 		// Return the standard tools list.
 		return $this->list_tools();
 	}
@@ -65,13 +65,13 @@ class ToolsHandler {
 	/**
 	 * Handles the tools/list request.
 	 *
-	 * Returns a ListToolsResult DTO containing all registered tools.
-	 * Tool DTOs are protocol-only; internal adapter metadata is stored in McpTool instances and is never exposed
+	 * Tool protocol data contains only wire-safe fields; internal adapter metadata is
+	 * stored in McpTool instances and is never exposed
 	 * to MCP clients.
 	 *
-	 * @return \WP\McpSchema\Server\Tools\DTO\ListToolsResult Response with tools list.
+	 * @return array Response with tools list.
 	 */
-	public function list_tools(): ListToolsResult {
+	public function list_tools(): array {
 		$tools = array_values( $this->mcp->get_tools() );
 
 		/**
@@ -82,8 +82,8 @@ class ToolsHandler {
 		 *
 		 * @since 0.5.0
 		 *
-		 * @param array<\WP\McpSchema\Server\Tools\DTO\Tool> $tools  Array of Tool DTOs.
-		 * @param \WP\MCP\Core\McpServer                     $server The MCP server instance.
+		 * @param array                  $tools  Array of tool protocol data.
+		 * @param \WP\MCP\Core\McpServer $server The MCP server instance.
 		 */
 		$tools = $this->validate_filtered_list(
 			apply_filters( 'mcp_adapter_tools_list', $tools, $this->mcp ),
@@ -92,32 +92,31 @@ class ToolsHandler {
 			$this->mcp->get_error_handler()
 		);
 
-		return ListToolsResult::fromArray(
-			array(
-				'tools' => $tools,
-			)
+		return array(
+			'tools' => $tools,
 		);
 	}
 
 	/**
 	 * Handles the tools/call request.
 	 *
-	 * Returns either a CallToolResult DTO (for success or tool execution errors)
-	 * or a JSONRPCErrorResponse DTO (for protocol errors like tool not found).
+	 * Returns either stable tool result data (for success or tool execution errors)
+	 * or a JSON-RPC error envelope (for protocol errors like tool not found).
 	 *
 	 * The MCP spec distinguishes between:
 	 * 1. **Protocol errors** (tool not found, server error) → JSONRPCErrorResponse
-	 * 2. **Tool execution errors** (permission denied, runtime error) → CallToolResult with isError=true
+	 * 2. **Tool execution errors** (permission denied, runtime error) → result with isError=true
 	 *
 	 * This distinction is critical for LLM self-correction - execution errors are
 	 * visible to the LLM, while protocol errors indicate infrastructure issues.
 	 *
 	 * @param array $params Request params.
 	 * @param string|int|null $request_id Optional. The request ID for JSON-RPC. Default 0.
+	 * @param \WP\MCP\Domain\Continuation\McpContinuationContext|null $continuation Optional stateless continuation input.
 	 *
-	 * @return \WP\McpSchema\Server\Tools\DTO\CallToolResult|\WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array|\WP\MCP\Domain\Continuation\McpExecutionResult
 	 */
-	public function call_tool( array $params, $request_id = 0 ) {
+	public function call_tool( array $params, $request_id = 0, ?McpContinuationContext $continuation = null ) {
 		// Extract parameters using helper method.
 		$request_params = $this->extract_params( $params );
 
@@ -187,7 +186,7 @@ class ToolsHandler {
 				return $this->create_error_result( $args->get_error_message() );
 			}
 
-			$result = $mcp_tool->execute( $args );
+			$result = $mcp_tool->execute( $args, $continuation );
 
 			/**
 			 * Filters the tool execution result before response assembly.
@@ -219,6 +218,10 @@ class ToolsHandler {
 				return $this->create_error_result( $result->get_error_message() );
 			}
 
+			if ( $result instanceof McpExecutionResult ) {
+				return $result;
+			}
+
 			// Backward compatibility: treat `{ success: false, error: string }` as tool execution error.
 			if (
 				is_array( $result )
@@ -231,7 +234,7 @@ class ToolsHandler {
 				return $this->create_error_result( $result['error'] );
 			}
 
-			// Successful tool execution - build CallToolResult DTO.
+			// Successful tool execution - build stable result data.
 
 			// Handle embedded resource results (MCP ContentBlock type: "resource").
 			// This allows tools to return text/blob resources using the MCP schema's EmbeddedResource content block.
@@ -239,13 +242,13 @@ class ToolsHandler {
 			// Two shapes are accepted, and they place `_meta` differently:
 			//
 			// - Nested `{ type, resource: { uri, text, _meta }, _meta }` maps one-to-one onto
-			//   the DTO tree, so the outer `_meta` belongs to the content block and the inner
+			//   the wire tree, so the outer `_meta` belongs to the content block and the inner
 			//   one to the resource contents.
 			// - Flat `{ type, uri, mimeType, text, _meta }` is a resource-contents literal
 			//   carrying a `type` tag: every key beside `type` is a `ResourceContents` field,
 			//   and `_meta` is declared there alongside them. Its `_meta` therefore describes
 			//   the resource, which is what the same literal already means to
-			//   `ResourcesHandler::create_content_dto()`. A caller who needs block-level
+			//   `ResourcesHandler::create_content()`. A caller who needs block-level
 			//   `_meta` writes the nested form, which exists to express that distinction.
 			if ( isset( $result['type'] ) && 'resource' === $result['type'] ) {
 				$is_nested     = isset( $result['resource'] ) && is_array( $result['resource'] );
@@ -269,38 +272,34 @@ class ToolsHandler {
 					$resource_meta = McpValidator::normalize_meta( $resource_item['_meta'] ?? null );
 
 					if ( $has_text ) {
-						return CallToolResult::fromArray(
-							array(
-								'content' => array(
-									ContentBlockHelper::embedded_text_resource(
-										$uri,
-										$resource_item['text'],
-										is_string( $mime_type ) ? $mime_type : null,
-										null,
-										$block_meta,
-										$resource_meta
-									),
+						return array(
+							'content' => array(
+								ContentBlockHelper::embedded_text_resource(
+									$uri,
+									$resource_item['text'],
+									is_string( $mime_type ) ? $mime_type : null,
+									null,
+									$block_meta,
+									$resource_meta
 								),
-								'isError' => false,
-							)
+							),
+							'isError' => false,
 						);
 					}
 
 					if ( $has_blob ) {
-						return CallToolResult::fromArray(
-							array(
-								'content' => array(
-									ContentBlockHelper::embedded_blob_resource(
-										$uri,
-										$resource_item['blob'],
-										is_string( $mime_type ) ? $mime_type : null,
-										null,
-										$block_meta,
-										$resource_meta
-									),
+						return array(
+							'content' => array(
+								ContentBlockHelper::embedded_blob_resource(
+									$uri,
+									$resource_item['blob'],
+									is_string( $mime_type ) ? $mime_type : null,
+									null,
+									$block_meta,
+									$resource_meta
 								),
-								'isError' => false,
-							)
+							),
+							'isError' => false,
 						);
 					}
 				}
@@ -315,19 +314,16 @@ class ToolsHandler {
 				$image_data = base64_encode( $result['results'] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 				$mime_type  = $result['mimeType'] ?? self::DEFAULT_IMAGE_MIME_TYPE;
 
-				return CallToolResult::fromArray(
-					array(
-						'content'           => array(
-							ContentBlockHelper::image(
-								$image_data,
-								$mime_type,
-								null,
-								McpValidator::normalize_meta( $result['_meta'] ?? null )
-							),
+				return array(
+					'content' => array(
+						ContentBlockHelper::image(
+							$image_data,
+							$mime_type,
+							null,
+							McpValidator::normalize_meta( $result['_meta'] ?? null )
 						),
-						'structuredContent' => null,
-						'isError'           => false,
-					)
+					),
+					'isError' => false,
 				);
 			}
 
@@ -342,12 +338,10 @@ class ToolsHandler {
 				$json_text = '{}';
 			}
 
-			return CallToolResult::fromArray(
-				array(
-					'content'           => array( ContentBlockHelper::text( $json_text ) ),
-					'structuredContent' => $result,
-					'isError'           => false,
-				)
+			return array(
+				'content'           => array( ContentBlockHelper::text( $json_text ) ),
+				'structuredContent' => $result,
+				'isError'           => false,
 			);
 		} catch ( \Throwable $exception ) {
 			$this->mcp->get_error_handler()->log(
@@ -363,21 +357,18 @@ class ToolsHandler {
 	}
 
 	/**
-	 * Create an error CallToolResult from a message string.
+	 * Create an error tool result from a message string.
 	 *
 	 * @since 0.5.0
 	 *
 	 * @param string $message The error message.
 	 *
-	 * @return \WP\McpSchema\Server\Tools\DTO\CallToolResult
+	 * @return array
 	 */
-	private function create_error_result( string $message ): CallToolResult {
-		return CallToolResult::fromArray(
-			array(
-				'content'           => array( ContentBlockHelper::text( $message ) ),
-				'structuredContent' => null,
-				'isError'           => true,
-			)
+	private function create_error_result( string $message ): array {
+		return array(
+			'content' => array( ContentBlockHelper::text( $message ) ),
+			'isError' => true,
 		);
 	}
 }

--- a/includes/Infrastructure/ErrorHandling/McpErrorFactory.php
+++ b/includes/Infrastructure/ErrorHandling/McpErrorFactory.php
@@ -9,27 +9,27 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Infrastructure\ErrorHandling;
 
-use WP\McpSchema\Common\JsonRpc\DTO\Error;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
-use WP\McpSchema\Common\McpConstants;
-
 /**
  * Factory for creating standardized MCP error responses.
  *
  * This class provides static methods for creating various types of JSON-RPC
- * error responses according to the MCP specification. All methods return
- * typed DTOs from php-mcp-schema for type safety and protocol compliance.
+ * error responses according to the MCP specification.
  */
 class McpErrorFactory {
+
+	private const JSONRPC_VERSION = '2.0';
 
 	/**
 	 * Standard JSON-RPC error codes as defined in the specification.
 	 */
-	public const PARSE_ERROR      = McpConstants::PARSE_ERROR;
-	public const INVALID_REQUEST  = McpConstants::INVALID_REQUEST;
-	public const METHOD_NOT_FOUND = McpConstants::METHOD_NOT_FOUND;
-	public const INVALID_PARAMS   = McpConstants::INVALID_PARAMS;
-	public const INTERNAL_ERROR   = McpConstants::INTERNAL_ERROR;
+	public const PARSE_ERROR                        = -32700;
+	public const INVALID_REQUEST                    = -32600;
+	public const METHOD_NOT_FOUND                   = -32601;
+	public const INVALID_PARAMS                     = -32602;
+	public const INTERNAL_ERROR                     = -32603;
+	public const HEADER_MISMATCH                    = -32020;
+	public const MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
+	public const UNSUPPORTED_PROTOCOL_VERSION       = -32022;
 
 	/**
 	 * Implementation-defined server error codes (in -32000 to -32099 range as per JSON-RPC spec).
@@ -50,9 +50,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function parse_error( $id, string $details = '' ): JSONRPCErrorResponse {
+	public static function parse_error( $id, string $details = '' ): array {
 		$message = __( 'Parse error', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -62,42 +62,43 @@ class McpErrorFactory {
 	}
 
 	/**
-	 * Create a standardized JSON-RPC error response DTO.
+	 * Create a standardized JSON-RPC error response.
 	 *
 	 * @param string|int|null $id The request ID (JSON-RPC allows string, int, or null).
 	 * @param int $code The error code.
 	 * @param string $message The error message.
 	 * @param mixed|null $data Optional additional error data.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function create_error_response( $id, int $code, string $message, $data = null ): JSONRPCErrorResponse {
-		return JSONRPCErrorResponse::fromArray(
-			array(
-				'jsonrpc' => McpConstants::JSONRPC_VERSION,
-				'error'   => self::create_error( $code, $message, $data ),
-				'id'      => $id,
-			)
+	public static function create_error_response( $id, int $code, string $message, $data = null ): array {
+		return array(
+			'jsonrpc' => self::JSONRPC_VERSION,
+			'error'   => self::create_error( $code, $message, $data ),
+			'id'      => $id,
 		);
 	}
 
 	/**
-	 * Create an Error DTO.
+	 * Create a JSON-RPC error object.
 	 *
 	 * @param int $code The error code.
 	 * @param string $message The error message.
 	 * @param mixed|null $data Optional additional error data.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\Error
+	 * @return array{code: int, message: string, data?: mixed}
 	 */
-	public static function create_error( int $code, string $message, $data = null ): Error {
-		return Error::fromArray(
-			array(
-				'code'    => $code,
-				'message' => $message,
-				'data'    => $data,
-			)
+	public static function create_error( int $code, string $message, $data = null ): array {
+		$error = array(
+			'code'    => $code,
+			'message' => $message,
 		);
+
+		if ( null !== $data ) {
+			$error['data'] = $data;
+		}
+
+		return $error;
 	}
 
 	/**
@@ -106,9 +107,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $method The method that was not found.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function method_not_found( $id, string $method ): JSONRPCErrorResponse {
+	public static function method_not_found( $id, string $method ): array {
 		return self::create_error_response(
 			$id,
 			self::METHOD_NOT_FOUND,
@@ -126,9 +127,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function invalid_params( $id, string $details = '' ): JSONRPCErrorResponse {
+	public static function invalid_params( $id, string $details = '' ): array {
 		$message = __( 'Invalid params', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -143,9 +144,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function internal_error( $id, string $details = '' ): JSONRPCErrorResponse {
+	public static function internal_error( $id, string $details = '' ): array {
 		$message = __( 'Internal error', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -159,9 +160,9 @@ class McpErrorFactory {
 	 *
 	 * @param string|int|null $id The request ID.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function mcp_disabled( $id ): JSONRPCErrorResponse {
+	public static function mcp_disabled( $id ): array {
 		return self::create_error_response(
 			$id,
 			self::SERVER_ERROR,
@@ -175,9 +176,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $details Validation error details.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function validation_error( $id, string $details ): JSONRPCErrorResponse {
+	public static function validation_error( $id, string $details ): array {
 		return self::create_error_response(
 			$id,
 			self::INVALID_PARAMS,
@@ -195,9 +196,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $parameter The missing parameter name.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function missing_parameter( $id, string $parameter ): JSONRPCErrorResponse {
+	public static function missing_parameter( $id, string $parameter ): array {
 		return self::create_error_response(
 			$id,
 			self::INVALID_PARAMS,
@@ -215,9 +216,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $resource_uri The resource identifier.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function resource_not_found( $id, string $resource_uri ): JSONRPCErrorResponse {
+	public static function resource_not_found( $id, string $resource_uri ): array {
 		return self::create_error_response(
 			$id,
 			self::RESOURCE_NOT_FOUND,
@@ -235,9 +236,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $tool The tool name.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function tool_not_found( $id, string $tool ): JSONRPCErrorResponse {
+	public static function tool_not_found( $id, string $tool ): array {
 		return self::create_error_response(
 			$id,
 			self::TOOL_NOT_FOUND,
@@ -255,9 +256,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $ability The ability name.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function ability_not_found( $id, string $ability ): JSONRPCErrorResponse {
+	public static function ability_not_found( $id, string $ability ): array {
 		return self::create_error_response(
 			$id,
 			self::TOOL_NOT_FOUND,
@@ -275,9 +276,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $prompt The prompt name.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function prompt_not_found( $id, string $prompt ): JSONRPCErrorResponse {
+	public static function prompt_not_found( $id, string $prompt ): array {
 		return self::create_error_response(
 			$id,
 			self::PROMPT_NOT_FOUND,
@@ -298,9 +299,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function session_not_found( $id, string $details = '' ): JSONRPCErrorResponse {
+	public static function session_not_found( $id, string $details = '' ): array {
 		$message = __( 'Session not found', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -315,9 +316,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function permission_denied( $id, string $details = '' ): JSONRPCErrorResponse {
+	public static function permission_denied( $id, string $details = '' ): array {
 		$message = __( 'Permission denied', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -332,9 +333,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function unauthorized( $id, string $details = '' ): JSONRPCErrorResponse {
+	public static function unauthorized( $id, string $details = '' ): array {
 		$message = __( 'Unauthorized', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;
@@ -344,23 +345,87 @@ class McpErrorFactory {
 	}
 
 	/**
+	 * Create a modern header mismatch error response.
+	 *
+	 * @param string|int|null $id The request ID.
+	 * @param string          $header The HTTP header name.
+	 * @param string|null     $expected The expected header value.
+	 * @param string|null     $actual The actual header value.
+	 *
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
+	 */
+	public static function header_mismatch( $id, string $header, ?string $expected, ?string $actual ): array {
+		$expected_display = null === $expected ? '(missing)' : $expected;
+		$actual_display   = null === $actual ? '(missing)' : $actual;
+
+		return self::create_error_response(
+			$id,
+			self::HEADER_MISMATCH,
+			sprintf(
+				/* translators: 1: HTTP header name, 2: header value, 3: request body value. */
+				__( "Header mismatch: %1\$s header value '%2\$s' does not match body value '%3\$s'", 'mcp-adapter' ),
+				$header,
+				$expected_display,
+				$actual_display
+			),
+			array(
+				'header'   => $header,
+				'expected' => $expected_display,
+				'actual'   => $actual_display,
+			)
+		);
+	}
+
+	/**
+	 * Create a modern missing required client capability error response.
+	 *
+	 * @param string|int|null    $id The request ID.
+	 * @param array<string, mixed> $required Required client capabilities.
+	 *
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
+	 */
+	public static function missing_required_client_capability( $id, array $required ): array {
+		return self::create_error_response(
+			$id,
+			self::MISSING_REQUIRED_CLIENT_CAPABILITY,
+			__( 'Server requires an undeclared client capability for this request', 'mcp-adapter' ),
+			array( 'requiredCapabilities' => $required )
+		);
+	}
+
+	/**
+	 * Create a modern unsupported protocol version error response.
+	 *
+	 * @param string|int|null $id The request ID.
+	 * @param string          $requested Requested protocol version.
+	 * @param list<string>    $supported Supported protocol versions.
+	 *
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
+	 */
+	public static function unsupported_protocol_version( $id, string $requested, array $supported ): array {
+		return self::create_error_response(
+			$id,
+			self::UNSUPPORTED_PROTOCOL_VERSION,
+			__( 'Unsupported protocol version', 'mcp-adapter' ),
+			array(
+				'supported' => $supported,
+				'requested' => $requested,
+			)
+		);
+	}
+
+	/**
 	 * Determine if an MCP error should return HTTP 200 or an HTTP error status.
 	 *
 	 * This method helps distinguish between transport-level errors (which should
 	 * return HTTP error codes) and application-level errors (which should return
 	 * HTTP 200 with a JSON-RPC error response).
 	 *
-	 * @param \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse|array $error_response The MCP error response (DTO or array).
+	 * @param array $error_response The MCP error response.
 	 *
 	 * @return int The appropriate HTTP status code.
 	 */
 	public static function get_http_status_for_error( $error_response ): int {
-		// Handle DTO
-		if ( $error_response instanceof JSONRPCErrorResponse ) {
-			return self::mcp_error_to_http_status( $error_response->getError()->getCode() );
-		}
-
-		// Handle legacy array format
 		if ( ! isset( $error_response['error']['code'] ) ) {
 			return 500; // Invalid error response structure
 		}
@@ -389,6 +454,9 @@ class McpErrorFactory {
 				return 400;
 
 			case self::INVALID_REQUEST:  // Invalid JSON-RPC structure - syntactic error
+			case self::HEADER_MISMATCH:
+			case self::MISSING_REQUIRED_CLIENT_CAPABILITY:
+			case self::UNSUPPORTED_PROTOCOL_VERSION:
 				return 400;
 
 			// Authentication and authorization errors
@@ -426,7 +494,7 @@ class McpErrorFactory {
 	 *
 	 * @param mixed $message The message to validate.
 	 *
-	 * @return true|\WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse Returns true if valid, or JSONRPCErrorResponse DTO if invalid.
+	 * @return true|array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null} Returns true if valid, or an error response if invalid.
 	 */
 	public static function validate_jsonrpc_message( $message ) {
 		if ( ! is_array( $message ) ) {
@@ -434,13 +502,13 @@ class McpErrorFactory {
 		}
 
 		// Must have jsonrpc field with value "2.0".
-		if ( ! isset( $message['jsonrpc'] ) || McpConstants::JSONRPC_VERSION !== $message['jsonrpc'] ) {
+		if ( ! isset( $message['jsonrpc'] ) || self::JSONRPC_VERSION !== $message['jsonrpc'] ) {
 			return self::invalid_request(
 				null,
 				sprintf(
 				/* translators: %s: JSON-RPC version */
 					__( 'jsonrpc version must be "%s"', 'mcp-adapter' ),
-					McpConstants::JSONRPC_VERSION
+					self::JSONRPC_VERSION
 				)
 			);
 		}
@@ -467,9 +535,9 @@ class McpErrorFactory {
 	 * @param string|int|null $id The request ID.
 	 * @param string $details Optional additional details.
 	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array{jsonrpc: '2.0', error: array{code: int, message: string, data?: mixed}, id: string|int|null}
 	 */
-	public static function invalid_request( $id, string $details = '' ): JSONRPCErrorResponse {
+	public static function invalid_request( $id, string $details = '' ): array {
 		$message = __( 'Invalid Request', 'mcp-adapter' );
 		if ( $details ) {
 			$message .= ': ' . $details;

--- a/includes/Transport/Infrastructure/HttpRequestContext.php
+++ b/includes/Transport/Infrastructure/HttpRequestContext.php
@@ -39,9 +39,12 @@ class HttpRequestContext {
 	/**
 	 * The JSON-decoded body of the request.
 	 *
-	 * @var array|null
+	 * @var mixed
 	 */
-	public ?array $body;
+	public $body;
+
+	/** Whether the POST body was valid JSON. */
+	public bool $body_is_valid_json = true;
 
 	/**
 	 * The MCP-Protocol-Version header from the request.
@@ -70,6 +73,11 @@ class HttpRequestContext {
 		$this->session_id       = $request->get_header( 'Mcp-Session-Id' );
 		$this->protocol_version = $request->get_header( 'Mcp-Protocol-Version' );
 		$this->accept_header    = $request->get_header( 'accept' );
-		$this->body             = 'POST' === $this->method ? $request->get_json_params() : null;
+		$this->body             = null;
+		if ( 'POST' !== $this->method ) {
+			return;
+		}
+
+		$this->body = JsonRpcRequestDecoder::decode( (string) $request->get_body(), $this->body_is_valid_json );
 	}
 }

--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -77,7 +77,7 @@ class HttpRequestHandler {
 
 		// Method not allowed
 		return new \WP_REST_Response(
-			McpErrorFactory::invalid_request( null, 'Method not allowed' )->toArray(),
+			McpErrorFactory::invalid_request( null, 'Method not allowed' ),
 			405
 		);
 	}
@@ -95,7 +95,7 @@ class HttpRequestHandler {
 			// Validate request body
 			if ( null === $context->body ) {
 				return new \WP_REST_Response(
-					McpErrorFactory::parse_error( null, 'Invalid JSON in request body' )->toArray(),
+					McpErrorFactory::parse_error( null, 'Invalid JSON in request body' ),
 					400
 				);
 			}
@@ -112,7 +112,7 @@ class HttpRequestHandler {
 			);
 
 			return new \WP_REST_Response(
-				McpErrorFactory::internal_error( null, 'Handler error occurred' )->toArray(),
+				McpErrorFactory::internal_error( null, 'Handler error occurred' ),
 				500
 			);
 		}
@@ -165,7 +165,7 @@ class HttpRequestHandler {
 		// Validate JSON-RPC message format
 		$validation = McpErrorFactory::validate_jsonrpc_message( $message );
 		if ( true !== $validation ) {
-			return $validation->toArray();
+			return $validation;
 		}
 
 		// Handle notifications (no response required)
@@ -196,17 +196,39 @@ class HttpRequestHandler {
 		$method     = $message['method'];
 		$params     = $message['params'] ?? array();
 
-		// Validate session for all requests except initialize (router will handle initialize session creation)
+		$protocol_version = null;
 		if ( 'initialize' !== $method ) {
-			$session_validation = HttpSessionValidator::validate_session_with_error_handler( $context, $this->transport_context->error_handler );
-			if ( true !== $session_validation ) {
-				return JsonRpcResponseBuilder::create_error_response( $request_id, $session_validation['error'] ?? $session_validation );
-			}
+			$body_protocol_version = $this->get_body_protocol_version( $params );
+			$is_modern_request     = 'server/discover' === $method
+				|| McpVersionNegotiator::MODERN_PROTOCOL_VERSION === $body_protocol_version
+				|| ( null !== $body_protocol_version && ! McpVersionNegotiator::is_supported( $body_protocol_version ) )
+				|| (
+					null === $context->session_id
+					&& null !== $context->protocol_version
+					&& McpVersionNegotiator::LEGACY_PROTOCOL_VERSION !== $context->protocol_version
+				);
 
-			// Validate MCP-Protocol-Version header for non-initialize requests.
-			$protocol_version_error = $this->validate_protocol_version_header( $context );
-			if ( null !== $protocol_version_error ) {
-				return JsonRpcResponseBuilder::create_error_response( $request_id, $protocol_version_error );
+			if ( $is_modern_request ) {
+				$header_error = $this->validate_modern_protocol_headers( $context, $body_protocol_version, $request_id );
+				if ( null !== $header_error ) {
+					return $header_error;
+				}
+				$protocol_version = $body_protocol_version ?? $context->protocol_version ?? McpVersionNegotiator::MODERN_PROTOCOL_VERSION;
+			} else {
+				$session_validation = HttpSessionValidator::validate_session_with_error_handler( $context, $this->transport_context->error_handler );
+				if ( true !== $session_validation ) {
+					return JsonRpcResponseBuilder::create_error_response( $request_id, $session_validation['error'] ?? $session_validation );
+				}
+
+				$session_version = HttpSessionValidator::get_protocol_version( $context, $this->transport_context->error_handler );
+				if ( ! is_string( $session_version ) ) {
+					return JsonRpcResponseBuilder::create_error_response( $request_id, $session_version['error'] ?? $session_version );
+				}
+				$protocol_version_error = $this->validate_legacy_protocol_header( $context, $session_version, $request_id );
+				if ( null !== $protocol_version_error ) {
+					return $protocol_version_error;
+				}
+				$protocol_version = $session_version;
 			}
 		}
 
@@ -216,7 +238,8 @@ class HttpRequestHandler {
 			$params,
 			$request_id,
 			$this->get_transport_name(),
-			$context
+			$context,
+			$protocol_version
 		);
 
 		// Handle session header if provided by router
@@ -243,35 +266,58 @@ class HttpRequestHandler {
 	}
 
 	/**
-	 * Validate the MCP-Protocol-Version header on non-initialize requests.
+	 * Read the modern body-level protocol selector.
 	 *
-	 * A missing header is accepted (returns null). A header containing a supported
-	 * version is also accepted. An unsupported version returns a JSON-RPC
-	 * invalid-request error payload.
-	 *
-	 * @since 0.5.0
-	 *
-	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext $context The HTTP request context.
-	 *
-	 * @return array|null Null when the header is absent or valid, error payload otherwise.
+	 * @param array<string,mixed> $params Request params.
 	 */
-	private function validate_protocol_version_header( HttpRequestContext $context ): ?array {
+	private function get_body_protocol_version( array $params ): ?string {
+		$value = $params['_meta']['io.modelcontextprotocol/protocolVersion'] ?? null;
+
+		return is_string( $value ) ? $value : null;
+	}
+
+	/**
+	 * Enforce the 2026 body/header agreement.
+	 *
+	 * @param string|null    $body_version Protocol version declared in params metadata.
+	 * @param string|int|null $request_id Request ID.
+	 * @return array<string,mixed>|null
+	 */
+	private function validate_modern_protocol_headers( HttpRequestContext $context, ?string $body_version, $request_id ): ?array {
 		if ( null === $context->protocol_version ) {
+			return McpErrorFactory::header_mismatch( $request_id, 'MCP-Protocol-Version', $body_version, null );
+		}
+
+		if ( null !== $body_version && $context->protocol_version !== $body_version ) {
+			return McpErrorFactory::header_mismatch(
+				$request_id,
+				'MCP-Protocol-Version',
+				$body_version,
+				$context->protocol_version
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Enforce the negotiated legacy session/header agreement.
+	 *
+	 * @param string          $session_version Negotiated session version.
+	 * @param string|int|null $request_id Request ID.
+	 * @return array<string,mixed>|null
+	 */
+	private function validate_legacy_protocol_header( HttpRequestContext $context, string $session_version, $request_id ): ?array {
+		if ( $context->protocol_version === $session_version ) {
 			return null;
 		}
 
-		if ( McpVersionNegotiator::is_supported( $context->protocol_version ) ) {
-			return null;
-		}
-
-		return McpErrorFactory::create_error(
-			McpErrorFactory::INVALID_REQUEST,
-			sprintf(
-				'Bad Request: Unsupported protocol version: %s (supported versions: %s)',
-				$context->protocol_version,
-				implode( ', ', McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS )
-			)
-		)->toArray();
+		return McpErrorFactory::invalid_request(
+			$request_id,
+			null === $context->protocol_version
+				? 'Missing MCP-Protocol-Version header.'
+				: 'MCP-Protocol-Version header does not match the negotiated session version.'
+		);
 	}
 
 	/**

--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Transport\Infrastructure;
 
+use WP\MCP\Core\McpProtocolContext;
 use WP\MCP\Core\McpVersionNegotiator;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 
@@ -93,7 +94,7 @@ class HttpRequestHandler {
 	private function handle_mcp_request( HttpRequestContext $context ): \WP_REST_Response {
 		try {
 			// Validate request body
-			if ( null === $context->body ) {
+			if ( ! $context->body_is_valid_json ) {
 				return new \WP_REST_Response(
 					McpErrorFactory::parse_error( null, 'Invalid JSON in request body' ),
 					400
@@ -132,7 +133,7 @@ class HttpRequestHandler {
 		$response_body = JsonRpcResponseBuilder::process_messages(
 			$messages,
 			$is_batch_request,
-			function ( array $message ) use ( $context ) {
+			function ( $message ) use ( $context ) {
 				return $this->process_single_message( $message, $context );
 			}
 		);
@@ -146,6 +147,13 @@ class HttpRequestHandler {
 		// Determine HTTP status code based on error type
 		if ( ! $is_batch_request && isset( $response_body['error'] ) ) {
 			$http_status = McpErrorFactory::get_http_status_for_error( $response_body );
+			if (
+				McpErrorFactory::INVALID_PARAMS === ( $response_body['error']['code'] ?? null )
+				&& null === $context->session_id
+				&& McpVersionNegotiator::LEGACY_PROTOCOL_VERSION !== $context->protocol_version
+			) {
+				$http_status = 400;
+			}
 
 			return new \WP_REST_Response( $response_body, $http_status );
 		}
@@ -156,12 +164,12 @@ class HttpRequestHandler {
 	/**
 	 * Process a single MCP message.
 	 *
-	 * @param array $message The MCP JSON-RPC message.
+	 * @param mixed $message The decoded MCP JSON-RPC message.
 	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext $context The HTTP request context.
 	 *
 	 * @return array|null JSON-RPC response or null for notifications.
 	 */
-	private function process_single_message( array $message, HttpRequestContext $context ): ?array {
+	private function process_single_message( $message, HttpRequestContext $context ): ?array {
 		// Validate JSON-RPC message format
 		$validation = McpErrorFactory::validate_jsonrpc_message( $message );
 		if ( true !== $validation ) {
@@ -169,12 +177,16 @@ class HttpRequestHandler {
 		}
 
 		// Handle notifications (no response required)
-		if ( isset( $message['method'] ) && ! isset( $message['id'] ) ) {
+		if ( ! is_array( $message ) ) {
+			return McpErrorFactory::invalid_request( null );
+		}
+
+		if ( isset( $message['method'] ) && ! array_key_exists( 'id', $message ) ) {
 			return null; // Notifications don't get a response
 		}
 
 		// Process requests with IDs
-		if ( isset( $message['method'] ) && isset( $message['id'] ) ) {
+		if ( isset( $message['method'] ) && array_key_exists( 'id', $message ) ) {
 			return $this->process_jsonrpc_request( $message, $context );
 		}
 
@@ -194,11 +206,14 @@ class HttpRequestHandler {
 	private function process_jsonrpc_request( array $message, HttpRequestContext $context ): array {
 		$request_id = $message['id']; // Preserve original scalar ID (string, number, or null)
 		$method     = $message['method'];
-		$params     = $message['params'] ?? array();
+		$params     = new JsonRpcRequestParams(
+			array_key_exists( 'params', $message ),
+			$message['params'] ?? null
+		);
 
 		$protocol_version = null;
 		if ( 'initialize' !== $method ) {
-			$body_protocol_version = $this->get_body_protocol_version( $params );
+			$body_protocol_version = $this->get_body_protocol_version( $params->get_value() );
 			$is_modern_request     = 'server/discover' === $method
 				|| McpVersionNegotiator::MODERN_PROTOCOL_VERSION === $body_protocol_version
 				|| ( null !== $body_protocol_version && ! McpVersionNegotiator::is_supported( $body_protocol_version ) )
@@ -270,8 +285,18 @@ class HttpRequestHandler {
 	 *
 	 * @param array<string,mixed> $params Request params.
 	 */
-	private function get_body_protocol_version( array $params ): ?string {
-		$value = $params['_meta']['io.modelcontextprotocol/protocolVersion'] ?? null;
+	private function get_body_protocol_version( $params ): ?string {
+		if ( $params instanceof \stdClass ) {
+			$params = get_object_vars( $params );
+		}
+		if ( ! is_array( $params ) ) {
+			return null;
+		}
+		$meta = $params['_meta'] ?? null;
+		if ( $meta instanceof \stdClass ) {
+			$meta = get_object_vars( $meta );
+		}
+		$value = is_array( $meta ) ? ( $meta['io.modelcontextprotocol/protocolVersion'] ?? null ) : null;
 
 		return is_string( $value ) ? $value : null;
 	}
@@ -285,19 +310,32 @@ class HttpRequestHandler {
 	 */
 	private function validate_modern_protocol_headers( HttpRequestContext $context, ?string $body_version, $request_id ): ?array {
 		if ( null === $context->protocol_version ) {
-			return McpErrorFactory::header_mismatch( $request_id, 'MCP-Protocol-Version', $body_version, null );
+			return $this->modern_header_mismatch( $request_id, $body_version, null );
 		}
 
 		if ( null !== $body_version && $context->protocol_version !== $body_version ) {
-			return McpErrorFactory::header_mismatch(
-				$request_id,
-				'MCP-Protocol-Version',
-				$body_version,
-				$context->protocol_version
-			);
+			return $this->modern_header_mismatch( $request_id, $body_version, $context->protocol_version );
 		}
 
 		return null;
+	}
+
+	/**
+	 * Create and validate the transport-owned modern header error envelope.
+	 *
+	 * @param string|int|null $request_id Request ID.
+	 * @param string|null     $expected Body-declared version.
+	 * @param string|null     $actual Header version.
+	 * @return array<string,mixed>
+	 */
+	private function modern_header_mismatch( $request_id, ?string $expected, ?string $actual ): array {
+		$response = McpErrorFactory::header_mismatch( $request_id, 'MCP-Protocol-Version', $expected, $actual );
+		$record   = McpProtocolContext::for_version( McpVersionNegotiator::MODERN_PROTOCOL_VERSION )
+			->get_schema()
+			->type( 'HeaderMismatchError' )
+			->fromValue( $response );
+
+		return $record->toArray();
 	}
 
 	/**

--- a/includes/Transport/Infrastructure/HttpSessionValidator.php
+++ b/includes/Transport/Infrastructure/HttpSessionValidator.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Transport\Infrastructure;
 
+use WP\MCP\Core\McpVersionNegotiator;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 
@@ -49,18 +50,18 @@ class HttpSessionValidator {
 		// Check session header presence
 		$session_id = $context->session_id;
 		if ( ! $session_id ) {
-			return McpErrorFactory::invalid_request( null, 'Missing Mcp-Session-Id header' )->toArray();
+			return McpErrorFactory::invalid_request( null, 'Missing Mcp-Session-Id header' );
 		}
 
 		// Check user authentication
 		$user_id = get_current_user_id();
 		if ( ! $user_id ) {
-			return McpErrorFactory::unauthorized( null, 'User not authenticated' )->toArray();
+			return McpErrorFactory::unauthorized( null, 'User not authenticated' );
 		}
 
 		// Validate session using SessionManager
 		if ( ! SessionManager::validate_session( $user_id, $session_id, $error_handler ) ) {
-			return McpErrorFactory::session_not_found( null, 'Invalid or expired session' )->toArray();
+			return McpErrorFactory::session_not_found( null, 'Invalid or expired session' );
 		}
 
 		return true;
@@ -77,10 +78,40 @@ class HttpSessionValidator {
 		$session_id = $context->session_id;
 
 		if ( ! $session_id ) {
-			return McpErrorFactory::invalid_request( null, 'Missing Mcp-Session-Id header' )->toArray();
+			return McpErrorFactory::invalid_request( null, 'Missing Mcp-Session-Id header' );
 		}
 
 		return $session_id;
+	}
+
+	/**
+	 * Get the supported protocol version retained by a valid legacy session.
+	 *
+	 * @internal
+	 *
+	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext                  $context The HTTP request context.
+	 * @param \WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface|null $error_handler Error handler for reporting storage failures.
+	 *
+	 * @return string|array Supported protocol version on success, error array on failure.
+	 */
+	public static function get_protocol_version( HttpRequestContext $context, ?McpErrorHandlerInterface $error_handler = null ) {
+		$validation = self::validate_session_with_error_handler( $context, $error_handler );
+		if ( true !== $validation ) {
+			return $validation;
+		}
+
+		$user_id = get_current_user_id();
+		$session = SessionManager::get_session( $user_id, (string) $context->session_id );
+		if ( ! is_array( $session ) ) {
+			return McpErrorFactory::session_not_found( null, 'Invalid or expired session' );
+		}
+
+		$protocol_version = $session['client_params']['protocolVersion'] ?? null;
+		if ( ! is_string( $protocol_version ) || ! McpVersionNegotiator::is_supported( $protocol_version ) ) {
+			return McpErrorFactory::invalid_request( null, 'Session does not contain a supported protocol version' );
+		}
+
+		return $protocol_version;
 	}
 
 	/**
@@ -111,13 +142,13 @@ class HttpSessionValidator {
 	public static function create_session_with_error_handler( array $params, ?McpErrorHandlerInterface $error_handler ) {
 		$user_id = get_current_user_id();
 		if ( ! $user_id ) {
-			return McpErrorFactory::unauthorized( null, 'User authentication required for session creation' )->toArray();
+			return McpErrorFactory::unauthorized( null, 'User authentication required for session creation' );
 		}
 
 		$session_id = SessionManager::create_session( $user_id, $params, $error_handler );
 
 		if ( ! $session_id ) {
-			return McpErrorFactory::internal_error( null, 'Failed to create session' )->toArray();
+			return McpErrorFactory::internal_error( null, 'Failed to create session' );
 		}
 
 		return $session_id;
@@ -152,13 +183,13 @@ class HttpSessionValidator {
 		// Validate session header
 		$session_id = $context->session_id;
 		if ( ! $session_id ) {
-			return McpErrorFactory::invalid_request( null, 'Missing Mcp-Session-Id header' )->toArray();
+			return McpErrorFactory::invalid_request( null, 'Missing Mcp-Session-Id header' );
 		}
 
 		// Validate user authentication
 		$user_id = get_current_user_id();
 		if ( ! $user_id ) {
-			return McpErrorFactory::unauthorized( null, 'User not authenticated' )->toArray();
+			return McpErrorFactory::unauthorized( null, 'User not authenticated' );
 		}
 
 		// Terminate the session

--- a/includes/Transport/Infrastructure/JsonRpcRequestDecoder.php
+++ b/includes/Transport/Infrastructure/JsonRpcRequestDecoder.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Lossless JSON-RPC request decoding.
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Transport\Infrastructure;
+
+/**
+ * Decodes transport input without collapsing JSON objects into PHP arrays.
+ *
+ * Only the JSON-RPC message object itself is converted to an associative array
+ * for routing. Nested JSON objects remain stdClass instances, so the schema can
+ * distinguish them from JSON lists before callback-facing normalization.
+ *
+ * @since n.e.x.t
+ */
+final class JsonRpcRequestDecoder {
+
+	/**
+	 * Decode one JSON document.
+	 *
+	 * @param string $json Raw JSON document.
+	 * @param bool   $valid Set to whether the document is valid JSON.
+	 * @return mixed Decoded single message, batch, scalar, or null.
+	 */
+	public static function decode( string $json, &$valid ) {
+		$decoded = json_decode( $json, false );
+		$valid   = JSON_ERROR_NONE === json_last_error();
+
+		if ( ! $valid ) {
+			return null;
+		}
+
+		if ( $decoded instanceof \stdClass ) {
+			return get_object_vars( $decoded );
+		}
+
+		if ( is_array( $decoded ) ) {
+			return array_map(
+				static function ( $message ) {
+					return $message instanceof \stdClass ? get_object_vars( $message ) : $message;
+				},
+				$decoded
+			);
+		}
+
+		return $decoded;
+	}
+}

--- a/includes/Transport/Infrastructure/JsonRpcRequestParams.php
+++ b/includes/Transport/Infrastructure/JsonRpcRequestParams.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Lossless transport request params carrier.
+ *
+ * @package McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Transport\Infrastructure;
+
+/**
+ * Keeps params presence and raw JSON object/list identity until validation.
+ *
+ * @since n.e.x.t
+ */
+final class JsonRpcRequestParams {
+
+	/** @var mixed */
+	private $value;
+
+	private bool $present;
+
+	/** @param mixed $value Raw decoded params value. */
+	public function __construct( bool $present, $value = null ) {
+		$this->present = $present;
+		$this->value   = $value;
+	}
+
+	public function is_present(): bool {
+		return $this->present;
+	}
+
+	/** @return mixed */
+	public function get_value() {
+		return $this->value;
+	}
+}

--- a/includes/Transport/Infrastructure/JsonRpcResponseBuilder.php
+++ b/includes/Transport/Infrastructure/JsonRpcResponseBuilder.php
@@ -61,7 +61,7 @@ class JsonRpcResponseBuilder {
 	 * @param array $messages Array of JSON-RPC messages to process.
 	 * @param bool $is_batch_request Whether the original request was a batch.
 	 * @param callable $processor Callback function to process each individual message.
-	 *                                Should accept (array $message) and return array $response.
+	 *                                Should accept the decoded message and return an array response.
 	 *
 	 * @return array|null The formatted response (array for batch, single response for non-batch).
 	 */
@@ -105,6 +105,6 @@ class JsonRpcResponseBuilder {
 	 * @return bool True if this is a batch request.
 	 */
 	public static function is_batch_request( $body ): bool {
-		return is_array( $body ) && isset( $body[0] );
+		return is_array( $body ) && array() !== $body && array_keys( $body ) === range( 0, count( $body ) - 1 );
 	}
 }

--- a/includes/Transport/Infrastructure/JsonRpcResponseBuilder.php
+++ b/includes/Transport/Infrastructure/JsonRpcResponseBuilder.php
@@ -9,8 +9,6 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Transport\Infrastructure;
 
-use WP\McpSchema\Common\McpConstants;
-
 /**
  * Builds standardized JSON-RPC 2.0 responses for MCP transport.
  *
@@ -18,6 +16,8 @@ use WP\McpSchema\Common\McpConstants;
  * consistent response formatting across all MCP transport implementations.
  */
 class JsonRpcResponseBuilder {
+
+	private const JSONRPC_VERSION = '2.0';
 
 	/**
 	 * Create a JSON-RPC 2.0 success response.
@@ -29,7 +29,7 @@ class JsonRpcResponseBuilder {
 	 */
 	public static function create_success_response( $request_id, $result ): array {
 		return array(
-			'jsonrpc' => McpConstants::JSONRPC_VERSION,
+			'jsonrpc' => self::JSONRPC_VERSION,
 			'id'      => $request_id,
 			// Make sure the result is an object (not an array)
 			'result'  => (object) $result,
@@ -46,7 +46,7 @@ class JsonRpcResponseBuilder {
 	 */
 	public static function create_error_response( $request_id, array $error ): array {
 		return array(
-			'jsonrpc' => McpConstants::JSONRPC_VERSION,
+			'jsonrpc' => self::JSONRPC_VERSION,
 			'id'      => $request_id,
 			'error'   => $error,
 		);

--- a/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/Transport/Infrastructure/RequestRouter.php
@@ -9,12 +9,12 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Transport\Infrastructure;
 
+use WP\MCP\Core\McpProtocolContext;
+use WP\MCP\Core\McpVersionNegotiator;
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Infrastructure\Observability\ErrorLogMcpObservabilityHandler;
-use WP\McpSchema\Common\AbstractDataTransferObject;
-use WP\McpSchema\Common\Content\DTO\TextContent;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
-use WP\McpSchema\Server\Tools\DTO\CallToolResult;
 
 /**
  * Service for routing MCP requests to appropriate handlers.
@@ -53,7 +53,14 @@ class RequestRouter {
 	 *
 	 * @return array
 	 */
-	public function route_request( string $method, array $params, $request_id = 0, string $transport_name = 'unknown', ?HttpRequestContext $http_context = null ): array {
+	public function route_request(
+		string $method,
+		array $params,
+		$request_id = 0,
+		string $transport_name = 'unknown',
+		?HttpRequestContext $http_context = null,
+		?string $protocol_version = null
+	): array {
 		// Track request start time.
 		$start_time = microtime( true );
 
@@ -70,88 +77,121 @@ class RequestRouter {
 			'session_id' => $http_context ? $http_context->session_id : null,
 		);
 
-		$handlers = array(
-			'initialize'               => function () use ( $params, $request_id, $http_context, &$new_session_id ) {
-				return $this->handle_initialize_with_session( $params, $request_id, $http_context, $new_session_id );
-			},
-			'ping'                     => fn() => $this->context->system_handler->ping(),
-			'tools/list'               => fn() => $this->context->tools_handler->list_tools(),
-			'tools/list/all'           => fn() => $this->context->tools_handler->list_all_tools(),
-			'tools/call'               => fn() => $this->context->tools_handler->call_tool( $params, $request_id ),
-			'resources/list'           => fn() => $this->context->resources_handler->list_resources(),
-			'resources/templates/list' => fn() => $this->context->resources_handler->list_resource_templates(),
-			'resources/read'           => fn() => $this->context->resources_handler->read_resource( $params, $request_id ),
-			'prompts/list'             => fn() => $this->context->prompts_handler->list_prompts(),
-			'prompts/get'              => fn() => $this->context->prompts_handler->get_prompt( $params, $request_id ),
-		);
-
 		try {
-			$handler_result = isset( $handlers[ $method ] ) ? $handlers[ $method ]() : $this->create_method_not_found_error( $method, $request_id );
+			$protocol = $this->resolve_protocol_context( $method, $params, $protocol_version, $request_id );
+			if ( is_array( $protocol ) ) {
+				return $this->record_error_result( $protocol, $common_tags, $component_tags, $start_time );
+			}
+
+			if ( ! $this->method_is_supported( $method, $protocol ) ) {
+				$error = $this->error_object( McpErrorFactory::method_not_found( $request_id, $method ) );
+				return $this->record_error_result(
+					$this->normalize_protocol_error( $protocol, $method, $request_id, $error ),
+					$common_tags,
+					$component_tags,
+					$start_time
+				);
+			}
+
+			$request_error = $this->validate_request( $protocol, $method, $params, $request_id );
+			if ( null !== $request_error ) {
+				return $this->record_error_result(
+					$this->normalize_protocol_error( $protocol, $method, $request_id, $request_error ),
+					$common_tags,
+					$component_tags,
+					$start_time
+				);
+			}
+
+			$continuation = new McpContinuationContext(
+				isset( $params['inputResponses'] ) && is_array( $params['inputResponses'] ) ? $params['inputResponses'] : array(),
+				isset( $params['requestState'] ) && is_string( $params['requestState'] ) ? $params['requestState'] : null,
+				$protocol->get_client_capabilities()
+			);
+
+			$handler_result = $this->dispatch(
+				$protocol,
+				$method,
+				$params,
+				$request_id,
+				$continuation,
+				$http_context,
+				$new_session_id
+			);
 
 			// Calculate request duration.
 			$duration = ( microtime( true ) - $start_time ) * 1000; // Convert to milliseconds.
 
-			// Handle DTO results from migrated handlers.
-			// DTOs are converted to arrays at the serialization boundary (here).
-			if ( $handler_result instanceof JSONRPCErrorResponse ) {
-				// Normalize to transport-level shape: only the JSON-RPC error object.
-				// The JSON-RPC envelope is created by the transport boundary.
-				$result                 = array( 'error' => $handler_result->getError()->toArray() );
+			if ( is_array( $handler_result ) && isset( $handler_result['error'] ) && is_array( $handler_result['error'] ) ) {
+				$error                  = $this->normalize_protocol_error( $protocol, $method, $request_id, $handler_result['error'] );
+				$result                 = array( 'error' => $error );
 				$tags                   = array_merge( $common_tags, $component_tags, array( 'status' => 'error' ) );
-				$tags['error_code']     = $handler_result->getError()->getCode();
-				$tags['failure_reason'] = $handler_result->getError()->getMessage();
+				$tags['error_code']     = $error['code'] ?? McpErrorFactory::INTERNAL_ERROR;
+				$tags['failure_reason'] = $error['message'] ?? 'Unknown error';
 				$this->context->observability_handler->record_event( 'mcp.request', $tags, $duration );
 
 				return $result;
 			}
-
-			if ( $handler_result instanceof AbstractDataTransferObject ) {
-				// Success DTO (ListToolsResult, CallToolResult, etc.) - convert to array.
-				// Note: If a future schema version ever returns nested DTO objects inside `toArray()`,
-				// we may need to add a deep normalizer at this boundary (before JSON serialization)
-				// to prevent placeholder `{}` objects in client output.
-				$raw_result = $handler_result->toArray();
-				$result     = $raw_result;
-
-				if ( null !== $new_session_id ) {
-					$component_tags['new_session_id'] = $new_session_id;
-					$result['_session_id']            = $new_session_id;
+			if ( $handler_result instanceof McpExecutionResult && $handler_result->is_input_required() ) {
+				$missing_capability = $this->find_missing_input_request_capability(
+					$handler_result->get_input_requests(),
+					$protocol->get_client_capabilities()
+				);
+				if ( null !== $missing_capability ) {
+					$error_response = McpErrorFactory::missing_required_client_capability(
+						$request_id,
+						array( $missing_capability => new \stdClass() )
+					);
+					return $this->record_error_result(
+						$this->normalize_protocol_error(
+							$protocol,
+							$method,
+							$request_id,
+							$this->error_object( $error_response )
+						),
+						$common_tags,
+						$component_tags,
+						$start_time
+					);
 				}
-
-				$status = 'success';
-				if ( $handler_result instanceof CallToolResult && true === $handler_result->getIsError() ) {
-					$status = 'error';
-
-					if ( ! isset( $component_tags['failure_reason'] ) ) {
-						$content = $handler_result->getContent();
-						if ( isset( $content[0] ) && $content[0] instanceof TextContent ) {
-							$component_tags['failure_reason'] = $content[0]->getText();
-						}
-					}
-				}
-
-				$tags = array_merge( $common_tags, $component_tags, array( 'status' => $status ) );
-				$this->context->observability_handler->record_event( 'mcp.request', $tags, $duration );
-
-				return $result;
 			}
 
-			// Handlers should only return schema DTOs.
-			$actual_type = is_object( $handler_result ) ? get_class( $handler_result ) : gettype( $handler_result );
-			$this->context->error_handler->log(
-				sprintf( 'Handler for method "%s" returned unexpected type: %s', $method, $actual_type ),
-				array(
-					'method'      => $method,
-					'actual_type' => $actual_type,
-				)
-			);
-			$unexpected_error   = McpErrorFactory::internal_error( $request_id, 'Handler returned invalid response type.' );
-			$result             = array( 'error' => $unexpected_error->getError()->toArray() );
-			$tags               = array_merge( $common_tags, $component_tags, array( 'status' => 'error' ) );
-			$tags['error_code'] = $unexpected_error->getError()->getCode();
+			$result = $this->encode_result( $protocol, $method, $handler_result );
+			$this->validate_result_response( $protocol, $method, $request_id, $result );
+			if ( null !== $new_session_id ) {
+				$component_tags['new_session_id'] = $new_session_id;
+				$result['_session_id']            = $new_session_id;
+			}
+
+			$status = isset( $result['isError'] ) && true === $result['isError'] ? 'error' : 'success';
+			if ( 'error' === $status && ! isset( $component_tags['failure_reason'] ) ) {
+				$content = $result['content'][0] ?? null;
+				if ( is_array( $content ) && isset( $content['text'] ) && is_string( $content['text'] ) ) {
+					$component_tags['failure_reason'] = $content['text'];
+				}
+			}
+			$tags = array_merge( $common_tags, $component_tags, array( 'status' => $status ) );
 			$this->context->observability_handler->record_event( 'mcp.request', $tags, $duration );
 
 			return $result;
+		} catch ( \WP\McpSchema\Runtime\ValidationException $exception ) {
+			$this->context->error_handler->log(
+				$exception->getMessage(),
+				array(
+					'method'           => $method,
+					'protocol_version' => $protocol_version,
+				)
+			);
+			$error = $this->error_object( McpErrorFactory::internal_error( $request_id, 'Response failed MCP schema validation.' ) );
+			if ( isset( $protocol ) && $protocol instanceof McpProtocolContext ) {
+				$error = $this->normalize_protocol_error( $protocol, $method, $request_id, $error );
+			}
+			return $this->record_error_result(
+				$error,
+				$common_tags,
+				$component_tags,
+				$start_time
+			);
 		} catch ( \Throwable $exception ) {
 			// Calculate request duration.
 			$duration = ( microtime( true ) - $start_time ) * 1000; // Convert to milliseconds.
@@ -169,10 +209,465 @@ class RequestRouter {
 			$this->context->observability_handler->record_event( 'mcp.request', $tags, $duration );
 
 			// Create error response from exception.
-			$unexpected_error = McpErrorFactory::internal_error( $request_id, 'Handler error occurred' );
-
-			return array( 'error' => $unexpected_error->getError()->toArray() );
+			$error = $this->error_object( McpErrorFactory::internal_error( $request_id, 'Handler error occurred' ) );
+			if ( isset( $protocol ) && $protocol instanceof McpProtocolContext ) {
+				$error = $this->normalize_protocol_error( $protocol, $method, $request_id, $error );
+			}
+			return array( 'error' => $error );
 		}
+	}
+
+	/**
+	 * Resolve the exact request protocol or return an error object.
+	 *
+	 * @param string      $method Method name.
+	 * @param array       $params Request params.
+	 * @param string|null $explicit_version Transport-selected legacy revision.
+	 * @param string|int|null $request_id JSON-RPC request ID.
+	 * @return \WP\MCP\Core\McpProtocolContext|array<string, mixed>
+	 */
+	private function resolve_protocol_context( string $method, array $params, ?string $explicit_version, $request_id ) {
+		if ( 'initialize' === $method ) {
+			$requested = isset( $params['protocolVersion'] ) && is_string( $params['protocolVersion'] )
+				? $params['protocolVersion']
+				: '';
+			return McpProtocolContext::for_version( McpVersionNegotiator::negotiate( $requested ) );
+		}
+
+		$metadata_version = $params['_meta']['io.modelcontextprotocol/protocolVersion'] ?? null;
+		$requested        = is_string( $metadata_version ) ? $metadata_version : $explicit_version;
+
+		if ( null === $requested && 'server/discover' === $method ) {
+			$requested = McpVersionNegotiator::MODERN_PROTOCOL_VERSION;
+		}
+		if ( null === $requested ) {
+			$requested = McpVersionNegotiator::LEGACY_PROTOCOL_VERSION;
+		}
+
+		if ( ! McpVersionNegotiator::is_supported( $requested ) ) {
+			$error = $this->error_object(
+				McpErrorFactory::unsupported_protocol_version( $request_id, $requested, McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS )
+			);
+			return $this->normalize_protocol_error(
+				McpProtocolContext::for_version( McpVersionNegotiator::MODERN_PROTOCOL_VERSION ),
+				$method,
+				$request_id,
+				$error
+			);
+		}
+
+		$capabilities = $params['_meta']['io.modelcontextprotocol/clientCapabilities'] ?? array();
+		if ( ! is_array( $capabilities ) ) {
+			$capabilities = array();
+		}
+
+		return McpProtocolContext::for_version( $requested, $capabilities );
+	}
+
+	private function method_is_supported( string $method, McpProtocolContext $protocol ): bool {
+		$common = array(
+			'tools/list',
+			'tools/call',
+			'resources/list',
+			'resources/templates/list',
+			'resources/read',
+			'prompts/list',
+			'prompts/get',
+		);
+		if ( in_array( $method, $common, true ) ) {
+			return true;
+		}
+		if ( $protocol->is_modern() ) {
+			return 'server/discover' === $method;
+		}
+
+		return in_array( $method, array( 'initialize', 'ping', 'tools/list/all' ), true );
+	}
+
+	/**
+	 * Validate an exact request envelope before handler execution.
+	 *
+	 * @param string|int|null $request_id JSON-RPC request ID.
+	 * @return array<string, mixed>|null
+	 */
+	private function validate_request( McpProtocolContext $protocol, string $method, array $params, $request_id ): ?array {
+		$type_names = $protocol->is_modern()
+			? array(
+				'server/discover'          => 'DiscoverRequest',
+				'tools/list'               => 'ListToolsRequest',
+				'tools/call'               => 'CallToolRequest',
+				'resources/list'           => 'ListResourcesRequest',
+				'resources/templates/list' => 'ListResourceTemplatesRequest',
+				'resources/read'           => 'ReadResourceRequest',
+				'prompts/list'             => 'ListPromptsRequest',
+				'prompts/get'              => 'GetPromptRequest',
+			)
+			: array(
+				'initialize'               => 'InitializeRequest',
+				'ping'                     => 'PingRequest',
+				'tools/list'               => 'ListToolsRequest',
+				'tools/list/all'           => 'ListToolsRequest',
+				'tools/call'               => 'CallToolRequest',
+				'resources/list'           => 'ListResourcesRequest',
+				'resources/templates/list' => 'ListResourceTemplatesRequest',
+				'resources/read'           => 'ReadResourceRequest',
+				'prompts/list'             => 'ListPromptsRequest',
+				'prompts/get'              => 'GetPromptRequest',
+			);
+
+		$type_name = $type_names[ $method ] ?? null;
+		if ( null === $type_name ) {
+			return $this->error_object( McpErrorFactory::method_not_found( $request_id, $method ) );
+		}
+
+		$wire = array(
+			'jsonrpc' => '2.0',
+			'id'      => $request_id,
+			'method'  => 'tools/list/all' === $method ? 'tools/list' : $method,
+		);
+		if ( $protocol->is_modern() || ! empty( $params ) || in_array( $method, array( 'initialize', 'tools/call', 'resources/read', 'prompts/get' ), true ) ) {
+			$wire['params'] = $this->normalize_known_objects( $params );
+		}
+
+		try {
+			$protocol->get_schema()->type( $type_name )->fromValue( $wire );
+		} catch ( \WP\McpSchema\Runtime\ValidationException $exception ) {
+			return $this->error_object( McpErrorFactory::invalid_params( $request_id, $exception->getMessage() ) );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Apply revision-specific protocol error policy and serialize the complete
+	 * JSON-RPC error envelope through the selected catalog.
+	 *
+	 * @param string|int|null    $request_id Request ID.
+	 * @param array<string,mixed> $error Handler error object.
+	 * @return array<string,mixed>
+	 */
+	private function normalize_protocol_error( McpProtocolContext $protocol, string $method, $request_id, array $error ): array {
+		$code = isset( $error['code'] ) && is_numeric( $error['code'] ) ? (int) $error['code'] : McpErrorFactory::INTERNAL_ERROR;
+		if (
+			( 'tools/call' === $method && McpErrorFactory::TOOL_NOT_FOUND === $code )
+			|| ( 'prompts/get' === $method && McpErrorFactory::PROMPT_NOT_FOUND === $code )
+			|| ( $protocol->is_modern() && 'resources/read' === $method && McpErrorFactory::RESOURCE_NOT_FOUND === $code )
+		) {
+			$error = McpErrorFactory::create_error(
+				McpErrorFactory::INVALID_PARAMS,
+				(string) ( $error['message'] ?? 'Invalid params' ),
+				$error['data'] ?? null
+			);
+		}
+
+		$envelope = array(
+			'jsonrpc' => '2.0',
+			'error'   => $this->normalize_known_objects( $error ),
+		);
+		if ( null !== $request_id ) {
+			$envelope['id'] = $request_id;
+		}
+		$record = $protocol->get_schema()->type( 'JSONRPCErrorResponse' )->fromValue( $envelope );
+		$wire   = $record->toWireArray();
+
+		return isset( $wire['error'] ) && is_array( $wire['error'] ) ? $wire['error'] : $error;
+	}
+
+	/**
+	 * Dispatch revision-neutral handlers.
+	 *
+	 * @param string|null $new_session_id Newly created session ID.
+	 * @param string|int|null $request_id JSON-RPC request ID.
+	 * @return mixed
+	 */
+	private function dispatch(
+		McpProtocolContext $protocol,
+		string $method,
+		array $params,
+		$request_id,
+		McpContinuationContext $continuation,
+		?HttpRequestContext $http_context,
+		?string &$new_session_id
+	) {
+		switch ( $method ) {
+			case 'initialize':
+				return $this->handle_initialize_with_session( $params, $request_id, $http_context, $new_session_id );
+			case 'server/discover':
+				return $this->discover_result();
+			case 'ping':
+				return $this->context->system_handler->ping();
+			case 'tools/list':
+				return $this->context->tools_handler->list_tools();
+			case 'tools/list/all':
+				return $this->context->tools_handler->list_all_tools();
+			case 'tools/call':
+				return $this->context->tools_handler->call_tool( $params, $request_id, $continuation );
+			case 'resources/list':
+				return $this->context->resources_handler->list_resources();
+			case 'resources/templates/list':
+				return $this->context->resources_handler->list_resource_templates();
+			case 'resources/read':
+				return $this->context->resources_handler->read_resource( $params, $request_id, $continuation );
+			case 'prompts/list':
+				return $this->context->prompts_handler->list_prompts();
+			case 'prompts/get':
+				return $this->context->prompts_handler->get_prompt( $params, $request_id, $continuation );
+		}
+
+		return McpErrorFactory::method_not_found( $request_id, $method );
+	}
+
+	/** @return array<string, mixed> */
+	private function discover_result(): array {
+		return array(
+			'supportedVersions' => McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS,
+			'capabilities'      => $this->server_capabilities(),
+			'instructions'      => $this->context->mcp_server->get_server_description(),
+		);
+	}
+
+	/** @return array<string, mixed> */
+	private function server_capabilities(): array {
+		return array(
+			'prompts'   => new \stdClass(),
+			'resources' => new \stdClass(),
+			'tools'     => new \stdClass(),
+		);
+	}
+
+	/**
+	 * Encode one handler outcome through the exact selected schema catalog.
+	 *
+	 * @param mixed $handler_result Revision-neutral handler result.
+	 * @return array<string, mixed>
+	 */
+	private function encode_result( McpProtocolContext $protocol, string $method, $handler_result ): array {
+		if ( $handler_result instanceof McpExecutionResult && $handler_result->is_input_required() ) {
+			return $this->encode_input_required( $protocol, $method, $handler_result );
+		}
+		if ( $handler_result instanceof McpExecutionResult ) {
+			$handler_result = $handler_result->get_value();
+		}
+		if ( ! is_array( $handler_result ) ) {
+			throw new \UnexpectedValueException( sprintf( 'Handler for %s returned %s.', $method, gettype( $handler_result ) ) );
+		}
+
+		$type_names = array(
+			'initialize'               => 'InitializeResult',
+			'server/discover'          => 'DiscoverResult',
+			'ping'                     => 'EmptyResult',
+			'tools/list'               => 'ListToolsResult',
+			'tools/list/all'           => 'ListToolsResult',
+			'tools/call'               => 'CallToolResult',
+			'resources/list'           => 'ListResourcesResult',
+			'resources/templates/list' => 'ListResourceTemplatesResult',
+			'resources/read'           => 'ReadResourceResult',
+			'prompts/list'             => 'ListPromptsResult',
+			'prompts/get'              => 'GetPromptResult',
+		);
+		$type_name  = $type_names[ $method ];
+		$wire       = $handler_result;
+
+		if ( $protocol->is_modern() ) {
+			$wire['resultType'] = 'complete';
+			$wire['_meta']      = array(
+				'io.modelcontextprotocol/serverInfo' => array(
+					'name'    => $this->context->mcp_server->get_server_name(),
+					'version' => $this->context->mcp_server->get_server_version(),
+				),
+			);
+			if ( in_array( $method, array( 'server/discover', 'tools/list', 'resources/list', 'resources/templates/list', 'resources/read', 'prompts/list' ), true ) ) {
+				$wire['ttlMs']      = 0;
+				$wire['cacheScope'] = 'private';
+			}
+		}
+
+		$wire   = $this->normalize_known_objects( $wire, ! $protocol->is_modern() );
+		$record = $protocol->get_schema()->type( $type_name )->fromValue( empty( $wire ) ? new \stdClass() : $wire );
+
+		return $this->public_result_array( $record->toWireArray() );
+	}
+
+	/**
+	 * Validate the complete JSON-RPC success envelope without changing the
+	 * transport-facing bare-result compatibility contract.
+	 *
+	 * @param string|int|null    $request_id JSON-RPC request ID.
+	 * @param array<string,mixed> $result Encoded result.
+	 */
+	private function validate_result_response( McpProtocolContext $protocol, string $method, $request_id, array $result ): void {
+		$type_name = 'JSONRPCResultResponse';
+		if ( $protocol->is_modern() ) {
+			$type_name = array(
+				'server/discover'          => 'DiscoverResultResponse',
+				'tools/list'               => 'ListToolsResultResponse',
+				'tools/call'               => 'CallToolResultResponse',
+				'resources/list'           => 'ListResourcesResultResponse',
+				'resources/templates/list' => 'ListResourceTemplatesResultResponse',
+				'resources/read'           => 'ReadResourceResultResponse',
+				'prompts/list'             => 'ListPromptsResultResponse',
+				'prompts/get'              => 'GetPromptResultResponse',
+			)[ $method ] ?? 'JSONRPCResultResponse';
+		}
+
+		$protocol->get_schema()->type( $type_name )->fromValue(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => $request_id,
+				'result'  => empty( $result ) ? new \stdClass() : $this->normalize_known_objects( $result ),
+			)
+		);
+	}
+
+	/** @return array<string, mixed> */
+	private function encode_input_required( McpProtocolContext $protocol, string $method, McpExecutionResult $result ): array {
+		if ( ! $protocol->is_modern() || ! in_array( $method, array( 'tools/call', 'resources/read', 'prompts/get' ), true ) ) {
+			throw new \UnexpectedValueException( 'Input-required results are not supported for this method or protocol revision.' );
+		}
+
+		$wire = array( 'resultType' => 'input_required' );
+		if ( ! empty( $result->get_input_requests() ) ) {
+			$wire['inputRequests'] = $result->get_input_requests();
+		}
+		if ( null !== $result->get_request_state() ) {
+			$wire['requestState'] = $result->get_request_state();
+		}
+		$wire['_meta'] = array(
+			'io.modelcontextprotocol/serverInfo' => array(
+				'name'    => $this->context->mcp_server->get_server_name(),
+				'version' => $this->context->mcp_server->get_server_version(),
+			),
+		);
+
+		$record = $protocol->get_schema()->type( 'InputRequiredResult' )->fromValue( $this->normalize_known_objects( $wire ) );
+
+		return $this->public_result_array( $record->toWireArray() );
+	}
+
+	/**
+	 * @param array<string, mixed> $input_requests Embedded MCP requests.
+	 * @param array<string, mixed> $capabilities Per-request client capabilities.
+	 */
+	private function find_missing_input_request_capability( array $input_requests, array $capabilities ): ?string {
+		foreach ( $input_requests as $input_request ) {
+			if ( ! is_array( $input_request ) || ! isset( $input_request['method'] ) || ! is_string( $input_request['method'] ) ) {
+				continue;
+			}
+			$required = array(
+				'elicitation/create'     => 'elicitation',
+				'sampling/createMessage' => 'sampling',
+				'roots/list'             => 'roots',
+			)[ $input_request['method'] ] ?? null;
+			if ( null !== $required && ! array_key_exists( $required, $capabilities ) ) {
+				return $required;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Convert legacy empty arrays only at known object/map-shaped public boundaries.
+	 *
+	 * @param mixed $value Value to normalize.
+	 * @return mixed
+	 */
+	private function normalize_known_objects( $value, bool $legacy_structured_content = false, ?string $key = null ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+		$object_keys = array(
+			'_meta',
+			'capabilities',
+			'clientCapabilities',
+			'arguments',
+			'inputSchema',
+			'outputSchema',
+			'properties',
+			'patternProperties',
+			'annotations',
+			'requestedSchema',
+			'inputRequests',
+			'inputResponses',
+			'experimental',
+			'form',
+			'url',
+			'io.modelcontextprotocol/clientCapabilities',
+			'io.modelcontextprotocol/serverInfo',
+		);
+		if ( $legacy_structured_content ) {
+			$object_keys[] = 'structuredContent';
+		}
+		if ( array() === $value && null !== $key && in_array( $key, $object_keys, true ) ) {
+			return new \stdClass();
+		}
+
+		$result = array();
+		foreach ( $value as $item_key => $item ) {
+			$result[ $item_key ] = $this->normalize_known_objects( $item, $legacy_structured_content, (string) $item_key );
+		}
+		return $result;
+	}
+
+	/**
+	 * Preserve empty JSON objects while keeping historical non-empty nested
+	 * response records accessible as associative arrays to custom transports.
+	 *
+	 * @param mixed $value Wire value.
+	 * @return mixed
+	 */
+	private function public_result_value( $value ) {
+		if ( $value instanceof \stdClass ) {
+			$properties = get_object_vars( $value );
+			if ( empty( $properties ) ) {
+				return $value;
+			}
+			$value = $properties;
+		}
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$result = array();
+		foreach ( $value as $key => $item ) {
+			$result[ $key ] = $this->public_result_value( $item );
+		}
+
+		return $result;
+	}
+
+	/** @param array<string,mixed> $wire @return array<string,mixed> */
+	private function public_result_array( array $wire ): array {
+		$result = $this->public_result_value( $wire );
+
+		return is_array( $result ) ? $result : array();
+	}
+
+	/** @param array<string, mixed> $response Full error envelope or error object. */
+	private function error_object( array $response ): array {
+		$error = $response['error'] ?? $response;
+		return is_array( $error ) ? $error : array(
+			'code'    => McpErrorFactory::INTERNAL_ERROR,
+			'message' => 'Internal error',
+		);
+	}
+
+	/**
+	 * Record and return a router error shape.
+	 *
+	 * @param array<string, mixed> $error Error object.
+	 * @param array<string, mixed> $common_tags Common tags.
+	 * @param array<string, mixed> $component_tags Component tags.
+	 * @return array{error: array<string, mixed>}
+	 */
+	private function record_error_result( array $error, array $common_tags, array $component_tags, float $start_time ): array {
+		$duration               = ( microtime( true ) - $start_time ) * 1000;
+		$tags                   = array_merge( $common_tags, $component_tags, array( 'status' => 'error' ) );
+		$tags['error_code']     = $error['code'] ?? McpErrorFactory::INTERNAL_ERROR;
+		$tags['failure_reason'] = $error['message'] ?? 'Unknown error';
+		$this->context->observability_handler->record_event( 'mcp.request', $tags, $duration );
+
+		return array( 'error' => $error );
 	}
 
 	/**
@@ -313,19 +808,21 @@ class RequestRouter {
 	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext|null $http_context HTTP context for session management.
 	 * @param string|null $new_session_id Newly created session id, if any.
 	 *
-	 * @return \WP\McpSchema\Common\AbstractDataTransferObject
+	 * @return array<string, mixed>
 	 */
-	private function handle_initialize_with_session( array $params, $request_id, ?HttpRequestContext $http_context, ?string &$new_session_id = null ): AbstractDataTransferObject {
+	private function handle_initialize_with_session( array $params, $request_id, ?HttpRequestContext $http_context, ?string &$new_session_id = null ): array {
 		// Extract client protocol version from params, defaulting to empty string if missing.
 		$client_version = isset( $params['protocolVersion'] ) && is_string( $params['protocolVersion'] ) ? $params['protocolVersion'] : '';
 
-		// Get the initialize response from the handler (returns InitializeResult DTO).
+		// Get the revision-neutral initialize result from the handler.
 		$init_result = $this->context->initialize_handler->handle( $client_version );
 
 		// Handle session creation if HTTP context is provided.
-		// InitializeResult DTO never has errors - errors would be thrown as exceptions.
+		// InitializeResult never has errors - errors would be thrown as exceptions.
 		if ( $http_context && ! $http_context->session_id ) {
-			$session_result = HttpSessionValidator::create_session_with_error_handler( $params, $this->context->error_handler );
+			$session_params                    = $params;
+			$session_params['protocolVersion'] = (string) ( $init_result['protocolVersion'] ?? McpVersionNegotiator::LEGACY_PROTOCOL_VERSION );
+			$session_result                    = HttpSessionValidator::create_session_with_error_handler( $session_params, $this->context->error_handler );
 
 			if ( is_array( $session_result ) ) {
 				$error = $session_result['error'] ?? array();
@@ -342,18 +839,6 @@ class RequestRouter {
 		}
 
 		return $init_result;
-	}
-
-	/**
-	 * Create a method not found error with generic format.
-	 *
-	 * @param string $method The method that was not found.
-	 * @param mixed $request_id The request ID.
-	 *
-	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
-	 */
-	private function create_method_not_found_error( string $method, $request_id ): JSONRPCErrorResponse {
-		return McpErrorFactory::method_not_found( $request_id, $method );
 	}
 
 	/**

--- a/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/Transport/Infrastructure/RequestRouter.php
@@ -46,7 +46,7 @@ class RequestRouter {
 	 * Route a request to the appropriate handler.
 	 *
 	 * @param string $method The MCP method name.
-	 * @param array $params The request parameters.
+	 * @param mixed $params Request parameters or a lossless transport carrier.
 	 * @param mixed $request_id The request ID (for JSON-RPC) - string, number, or null.
 	 * @param string $transport_name Transport name for observability.
 	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext|null $http_context HTTP context for session management.
@@ -55,7 +55,7 @@ class RequestRouter {
 	 */
 	public function route_request(
 		string $method,
-		array $params,
+		$params,
 		$request_id = 0,
 		string $transport_name = 'unknown',
 		?HttpRequestContext $http_context = null,
@@ -63,6 +63,14 @@ class RequestRouter {
 	): array {
 		// Track request start time.
 		$start_time = microtime( true );
+
+		$is_wire_params = $params instanceof JsonRpcRequestParams;
+		$params_present = $is_wire_params ? $params->is_present() : true;
+		$wire_params    = $is_wire_params ? $params->get_value() : $params;
+		$params         = $this->callback_params( $wire_params );
+		if ( ! is_array( $params ) ) {
+			$params = array();
+		}
 
 		$new_session_id = null;
 		$component_tags = $this->resolve_component_observability_context( $method, $params );
@@ -93,7 +101,14 @@ class RequestRouter {
 				);
 			}
 
-			$request_error = $this->validate_request( $protocol, $method, $params, $request_id );
+			$request_error = $this->validate_request(
+				$protocol,
+				$method,
+				$wire_params,
+				$request_id,
+				$is_wire_params,
+				$params_present
+			);
 			if ( null !== $request_error ) {
 				return $this->record_error_result(
 					$this->normalize_protocol_error( $protocol, $method, $request_id, $request_error ),
@@ -287,10 +302,18 @@ class RequestRouter {
 	/**
 	 * Validate an exact request envelope before handler execution.
 	 *
+	 * @param mixed           $params Raw or programmatic request params.
 	 * @param string|int|null $request_id JSON-RPC request ID.
 	 * @return array<string, mixed>|null
 	 */
-	private function validate_request( McpProtocolContext $protocol, string $method, array $params, $request_id ): ?array {
+	private function validate_request(
+		McpProtocolContext $protocol,
+		string $method,
+		$params,
+		$request_id,
+		bool $preserve_wire_identity = false,
+		bool $params_present = true
+	): ?array {
 		$type_names = $protocol->is_modern()
 			? array(
 				'server/discover'          => 'DiscoverRequest',
@@ -320,13 +343,16 @@ class RequestRouter {
 			return $this->error_object( McpErrorFactory::method_not_found( $request_id, $method ) );
 		}
 
-		$wire = array(
+		$wire            = array(
 			'jsonrpc' => '2.0',
 			'id'      => $request_id,
 			'method'  => 'tools/list/all' === $method ? 'tools/list' : $method,
 		);
-		if ( $protocol->is_modern() || ! empty( $params ) || in_array( $method, array( 'initialize', 'tools/call', 'resources/read', 'prompts/get' ), true ) ) {
-			$wire['params'] = $this->normalize_known_objects( $params );
+		$requires_params = $protocol->is_modern() || in_array( $method, array( 'initialize', 'tools/call', 'resources/read', 'prompts/get' ), true );
+		if ( ( $preserve_wire_identity && $params_present ) || ( ! $preserve_wire_identity && ( $requires_params || ! empty( $params ) ) ) ) {
+			$wire['params'] = $preserve_wire_identity
+				? $params
+				: $this->normalize_public_request_params( $method, is_array( $params ) ? $params : array() );
 		}
 
 		try {
@@ -359,15 +385,25 @@ class RequestRouter {
 				$error['data'] ?? null
 			);
 		}
+		$code = isset( $error['code'] ) && is_numeric( $error['code'] ) ? (int) $error['code'] : McpErrorFactory::INTERNAL_ERROR;
 
 		$envelope = array(
 			'jsonrpc' => '2.0',
-			'error'   => $this->normalize_known_objects( $error ),
+			'error'   => $error,
 		);
 		if ( null !== $request_id ) {
 			$envelope['id'] = $request_id;
 		}
-		$record = $protocol->get_schema()->type( 'JSONRPCErrorResponse' )->fromValue( $envelope );
+		$type_name = 'JSONRPCErrorResponse';
+		if ( $protocol->is_modern() ) {
+			$type_name = array(
+				McpErrorFactory::HEADER_MISMATCH => 'HeaderMismatchError',
+				McpErrorFactory::MISSING_REQUIRED_CLIENT_CAPABILITY => 'MissingRequiredClientCapabilityError',
+				McpErrorFactory::UNSUPPORTED_PROTOCOL_VERSION => 'UnsupportedProtocolVersionError',
+			)[ $code ] ?? 'JSONRPCErrorResponse';
+		}
+
+		$record = $protocol->get_schema()->type( $type_name )->fromValue( $envelope );
 		$wire   = $record->toWireArray();
 
 		return isset( $wire['error'] ) && is_array( $wire['error'] ) ? $wire['error'] : $error;
@@ -482,7 +518,7 @@ class RequestRouter {
 			}
 		}
 
-		$wire   = $this->normalize_known_objects( $wire, ! $protocol->is_modern() );
+		$wire   = $this->normalize_public_result( $method, $wire, $protocol->is_modern() );
 		$record = $protocol->get_schema()->type( $type_name )->fromValue( empty( $wire ) ? new \stdClass() : $wire );
 
 		return $this->public_result_array( $record->toWireArray() );
@@ -514,7 +550,7 @@ class RequestRouter {
 			array(
 				'jsonrpc' => '2.0',
 				'id'      => $request_id,
-				'result'  => empty( $result ) ? new \stdClass() : $this->normalize_known_objects( $result ),
+				'result'  => empty( $result ) ? new \stdClass() : $result,
 			)
 		);
 	}
@@ -539,7 +575,7 @@ class RequestRouter {
 			),
 		);
 
-		$record = $protocol->get_schema()->type( 'InputRequiredResult' )->fromValue( $this->normalize_known_objects( $wire ) );
+		$record = $protocol->get_schema()->type( 'InputRequiredResult' )->fromValue( $this->normalize_input_required_result( $wire ) );
 
 		return $this->public_result_array( $record->toWireArray() );
 	}
@@ -567,46 +603,263 @@ class RequestRouter {
 	}
 
 	/**
-	 * Convert legacy empty arrays only at known object/map-shaped public boundaries.
+	 * Convert callback-facing objects to arrays after lossless schema validation.
 	 *
 	 * @param mixed $value Value to normalize.
 	 * @return mixed
 	 */
-	private function normalize_known_objects( $value, bool $legacy_structured_content = false, ?string $key = null ) {
+	private function callback_params( $value ) {
+		if ( $value instanceof \stdClass ) {
+			$value = get_object_vars( $value );
+		}
 		if ( ! is_array( $value ) ) {
 			return $value;
 		}
-		$object_keys = array(
-			'_meta',
-			'capabilities',
-			'clientCapabilities',
-			'arguments',
-			'inputSchema',
-			'outputSchema',
-			'properties',
-			'patternProperties',
-			'annotations',
-			'requestedSchema',
-			'inputRequests',
-			'inputResponses',
-			'experimental',
-			'form',
-			'url',
-			'io.modelcontextprotocol/clientCapabilities',
-			'io.modelcontextprotocol/serverInfo',
-		);
-		if ( $legacy_structured_content ) {
-			$object_keys[] = 'structuredContent';
-		}
-		if ( array() === $value && null !== $key && in_array( $key, $object_keys, true ) ) {
-			return new \stdClass();
-		}
 
 		$result = array();
-		foreach ( $value as $item_key => $item ) {
-			$result[ $item_key ] = $this->normalize_known_objects( $item, $legacy_structured_content, (string) $item_key );
+		foreach ( $value as $key => $item ) {
+			$result[ $key ] = $this->callback_params( $item );
 		}
 		return $result;
+	}
+
+	/**
+	 * Normalize only documented object-shaped request fields for PHP callers.
+	 *
+	 * Raw transport requests bypass this compatibility boundary and retain their
+	 * exact JSON object/list identity for schema validation.
+	 *
+	 * @param array<string,mixed> $params Programmatic request params.
+	 * @return array<string,mixed>
+	 */
+	private function normalize_public_request_params( string $method, array $params ): array {
+		if ( 'initialize' === $method ) {
+			$this->normalize_empty_object_field( $params, 'capabilities' );
+			$this->normalize_capabilities( $params, 'capabilities' );
+			$this->normalize_empty_object_field( $params, 'clientInfo' );
+		}
+
+		$this->normalize_request_meta( $params );
+		if ( in_array( $method, array( 'tools/call', 'prompts/get' ), true ) ) {
+			$this->normalize_empty_object_field( $params, 'arguments' );
+		}
+		if ( in_array( $method, array( 'tools/call', 'resources/read', 'prompts/get' ), true ) ) {
+			$this->normalize_empty_object_field( $params, 'inputResponses' );
+		}
+
+		return $params;
+	}
+
+	/** @param array<string,mixed> $params */
+	private function normalize_request_meta( array &$params ): void {
+		$this->normalize_empty_object_field( $params, '_meta' );
+		if ( ! isset( $params['_meta'] ) || ! is_array( $params['_meta'] ) ) {
+			return;
+		}
+		$meta =& $params['_meta'];
+		$this->normalize_empty_object_field( $meta, 'io.modelcontextprotocol/clientCapabilities' );
+		$this->normalize_empty_object_field( $meta, 'io.modelcontextprotocol/clientInfo' );
+		$this->normalize_capabilities( $meta, 'io.modelcontextprotocol/clientCapabilities' );
+	}
+
+	/** @param array<string,mixed> $container */
+	private function normalize_capabilities( array &$container, string $key ): void {
+		if ( ! isset( $container[ $key ] ) || ! is_array( $container[ $key ] ) ) {
+			return;
+		}
+		$capabilities =& $container[ $key ];
+		foreach ( array( 'elicitation', 'experimental', 'roots', 'sampling', 'tasks' ) as $capability ) {
+			$this->normalize_empty_object_field( $capabilities, $capability );
+		}
+		if ( ! isset( $capabilities['elicitation'] ) || ! is_array( $capabilities['elicitation'] ) ) {
+			return;
+		}
+
+		$this->normalize_empty_object_field( $capabilities['elicitation'], 'form' );
+		$this->normalize_empty_object_field( $capabilities['elicitation'], 'url' );
+	}
+
+	/**
+	 * Normalize only exact result fields whose public PHP shape predates the
+	 * descriptor model. Opaque payloads such as structuredContent stay untouched.
+	 *
+	 * @param array<string,mixed> $wire Result data.
+	 * @return array<string,mixed>
+	 */
+	private function normalize_public_result( string $method, array $wire, bool $modern ): array {
+		$this->normalize_empty_object_field( $wire, '_meta' );
+		if ( 'initialize' === $method || 'server/discover' === $method ) {
+			$this->normalize_empty_object_field( $wire, 'capabilities' );
+			$this->normalize_capabilities( $wire, 'capabilities' );
+			$this->normalize_empty_object_field( $wire, 'serverInfo' );
+		}
+		if ( ! $modern && 'tools/call' === $method ) {
+			$this->normalize_empty_object_field( $wire, 'structuredContent' );
+		}
+		if ( isset( $wire['_meta'] ) && is_array( $wire['_meta'] ) ) {
+			$this->normalize_empty_object_field( $wire['_meta'], 'io.modelcontextprotocol/serverInfo' );
+		}
+		if ( 'tools/list' === $method && isset( $wire['tools'] ) && is_array( $wire['tools'] ) ) {
+			foreach ( $wire['tools'] as &$tool ) {
+				if ( ! is_array( $tool ) ) {
+					continue;
+				}
+
+				$this->normalize_tool_definition( $tool );
+			}
+			unset( $tool );
+		}
+		if ( 'resources/list' === $method && isset( $wire['resources'] ) && is_array( $wire['resources'] ) ) {
+			foreach ( $wire['resources'] as &$resource ) {
+				if ( ! is_array( $resource ) ) {
+					continue;
+				}
+
+				$this->normalize_empty_object_field( $resource, '_meta' );
+				$this->normalize_empty_object_field( $resource, 'annotations' );
+			}
+			unset( $resource );
+		}
+		if ( 'prompts/list' === $method && isset( $wire['prompts'] ) && is_array( $wire['prompts'] ) ) {
+			foreach ( $wire['prompts'] as &$prompt ) {
+				if ( ! is_array( $prompt ) ) {
+					continue;
+				}
+
+				$this->normalize_empty_object_field( $prompt, '_meta' );
+			}
+			unset( $prompt );
+		}
+
+		return $wire;
+	}
+
+	/** @param array<string,mixed> $tool */
+	private function normalize_tool_definition( array &$tool ): void {
+		foreach ( array( '_meta', 'annotations', 'execution', 'inputSchema', 'outputSchema' ) as $field ) {
+			$this->normalize_empty_object_field( $tool, $field );
+		}
+		foreach ( array( 'inputSchema', 'outputSchema' ) as $schema_field ) {
+			if ( ! isset( $tool[ $schema_field ] ) || ! is_array( $tool[ $schema_field ] ) ) {
+				continue;
+			}
+			foreach ( array( '$defs', 'definitions', 'patternProperties', 'properties' ) as $object_field ) {
+				$this->normalize_empty_object_field( $tool[ $schema_field ], $object_field );
+			}
+		}
+	}
+
+	/** @param array<string,mixed> $wire @return array<string,mixed> */
+	private function normalize_input_required_result( array $wire ): array {
+		$this->normalize_empty_object_field( $wire, '_meta' );
+		if ( isset( $wire['_meta'] ) && is_array( $wire['_meta'] ) ) {
+			$this->normalize_empty_object_field( $wire['_meta'], 'io.modelcontextprotocol/serverInfo' );
+		}
+		$this->normalize_empty_object_field( $wire, 'inputRequests' );
+		if ( isset( $wire['inputRequests'] ) && is_array( $wire['inputRequests'] ) ) {
+			foreach ( $wire['inputRequests'] as &$request ) {
+				if ( ! is_array( $request ) ) {
+					continue;
+				}
+				$this->normalize_empty_object_field( $request, 'params' );
+				if ( ! isset( $request['params'] ) || ! is_array( $request['params'] ) ) {
+					continue;
+				}
+
+				$params =& $request['params'];
+				$this->normalize_empty_object_field( $params, 'requestedSchema' );
+				if ( isset( $params['requestedSchema'] ) && is_array( $params['requestedSchema'] ) ) {
+					$this->normalize_empty_object_field( $params['requestedSchema'], 'properties' );
+				}
+				if ( 'sampling/createMessage' === ( $request['method'] ?? null ) ) {
+					foreach ( array( 'metadata', 'modelPreferences', 'toolChoice' ) as $object_field ) {
+						$this->normalize_empty_object_field( $params, $object_field );
+					}
+					if ( isset( $params['modelPreferences']['hints'] ) && is_array( $params['modelPreferences']['hints'] ) ) {
+						foreach ( $params['modelPreferences']['hints'] as &$hint ) {
+							if ( array() !== $hint ) {
+								continue;
+							}
+
+							$hint = new \stdClass();
+						}
+						unset( $hint );
+					}
+					if ( isset( $params['tools'] ) && is_array( $params['tools'] ) ) {
+						foreach ( $params['tools'] as &$tool ) {
+							if ( ! is_array( $tool ) ) {
+								continue;
+							}
+
+							$this->normalize_tool_definition( $tool );
+						}
+						unset( $tool );
+					}
+					if ( isset( $params['messages'] ) && is_array( $params['messages'] ) ) {
+						foreach ( $params['messages'] as &$message ) {
+							if ( ! is_array( $message ) ) {
+								continue;
+							}
+							$this->normalize_empty_object_field( $message, '_meta' );
+							if ( ! array_key_exists( 'content', $message ) ) {
+								continue;
+							}
+
+							$this->normalize_sampling_content( $message['content'] );
+						}
+						unset( $message );
+					}
+				}
+				if ( ! ( 'roots/list' === ( $request['method'] ?? null ) ) ) {
+					continue;
+				}
+
+				$this->normalize_empty_object_field( $params, '_meta' );
+			}
+			unset( $request );
+		}
+
+		return $wire;
+	}
+
+	/** @param mixed $content */
+	private function normalize_sampling_content( &$content ): void {
+		if ( ! is_array( $content ) ) {
+			return;
+		}
+		if ( $this->is_list_array( $content ) ) {
+			foreach ( $content as &$block ) {
+				$this->normalize_sampling_content( $block );
+			}
+			unset( $block );
+			return;
+		}
+
+		$this->normalize_empty_object_field( $content, '_meta' );
+		$this->normalize_empty_object_field( $content, 'annotations' );
+		if ( 'tool_use' === ( $content['type'] ?? null ) ) {
+			$this->normalize_empty_object_field( $content, 'input' );
+		}
+		if ( 'resource' === ( $content['type'] ?? null ) && isset( $content['resource'] ) && is_array( $content['resource'] ) ) {
+			$this->normalize_empty_object_field( $content['resource'], '_meta' );
+		}
+		if ( ! ( 'tool_result' === ( $content['type'] ?? null ) ) || ! isset( $content['content'] ) || ! is_array( $content['content'] ) ) {
+			return;
+		}
+
+		foreach ( $content['content'] as &$result_block ) {
+			$this->normalize_sampling_content( $result_block );
+		}
+		unset( $result_block );
+	}
+
+	/** @param array<string,mixed> $container */
+	private function normalize_empty_object_field( array &$container, string $key ): void {
+		if ( ! isset( $container[ $key ] ) || array() !== $container[ $key ] ) {
+			return;
+		}
+
+		$container[ $key ] = new \stdClass();
 	}
 
 	/**
@@ -622,6 +875,9 @@ class RequestRouter {
 			if ( empty( $properties ) ) {
 				return $value;
 			}
+			if ( $this->is_list_array( $properties ) ) {
+				return $value;
+			}
 			$value = $properties;
 		}
 		if ( ! is_array( $value ) ) {
@@ -634,6 +890,11 @@ class RequestRouter {
 		}
 
 		return $result;
+	}
+
+	/** @param array<mixed> $value */
+	private function is_list_array( array $value ): bool {
+		return array() === $value || array_keys( $value ) === range( 0, count( $value ) - 1 );
 	}
 
 	/** @param array<string,mixed> $wire @return array<string,mixed> */

--- a/tests/phpunit/Fixtures/LegacyPromptBuilder.php
+++ b/tests/phpunit/Fixtures/LegacyPromptBuilder.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Baseline-compatible third-party prompt builder fixture.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Fixtures;
+
+use WP\MCP\Domain\Prompts\Contracts\McpPromptBuilderInterface;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
+
+final class LegacyPromptBuilder implements McpPromptBuilderInterface {
+
+	public function build(): Prompt {
+		return Prompt::fromArray( array( 'name' => 'legacy-builder-prompt' ) );
+	}
+
+	public function get_name(): string {
+		return 'legacy-builder-prompt';
+	}
+
+	public function get_title(): ?string {
+		return null;
+	}
+
+	public function get_description(): ?string {
+		return null;
+	}
+
+	public function get_arguments(): array {
+		return array();
+	}
+
+	public function handle( array $arguments ): array {
+		return array( 'messages' => array() );
+	}
+
+	public function has_permission( array $arguments ): bool {
+		return true;
+	}
+}

--- a/tests/phpunit/Integration/BuilderPromptExecutionTest.php
+++ b/tests/phpunit/Integration/BuilderPromptExecutionTest.php
@@ -7,9 +7,6 @@ namespace WP\MCP\Tests\Integration;
 use WP\MCP\Domain\Prompts\McpPromptBuilder;
 use WP\MCP\Handlers\Prompts\PromptsHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
-use WP\McpSchema\Server\Prompts\DTO\GetPromptResult;
-use WP\McpSchema\Server\Prompts\DTO\PromptMessage;
 
 // Test prompt that requires admin permissions
 class AdminOnlyPrompt extends McpPromptBuilder {
@@ -76,16 +73,15 @@ final class BuilderPromptExecutionTest extends TestCase {
 			)
 		);
 
-		// Builder prompts return GetPromptResult DTO.
 		// The arbitrary result is wrapped as JSON in a text message.
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$this->assertIsArray( $result );
+		$messages = $result['messages'];
 		$this->assertNotEmpty( $messages );
-		$this->assertContainsOnlyInstancesOf( PromptMessage::class, $messages );
+		$this->assertContainsOnly( 'array', $messages );
 
 		// The wrapped content contains the original data as JSON.
-		$content = $messages[0]->getContent();
-		$text    = $content->toArray()['text'] ?? '';
+		$content = $messages[0]['content'];
+		$text    = $content['text'] ?? '';
 		$this->assertStringContainsString( 'Hello from open prompt!', $text );
 	}
 
@@ -102,11 +98,9 @@ final class BuilderPromptExecutionTest extends TestCase {
 			)
 		);
 
-		// Should return permission denied error as JSONRPCErrorResponse.
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertStringContainsString( 'Access denied', $error->getMessage() );
+		$this->assertIsArray( $result );
+		$this->assertSame( -32008, $result['error']['code'] );
+		$this->assertStringContainsString( 'Access denied', $result['error']['message'] );
 	}
 
 	public function test_mixed_ability_and_builder_prompts(): void {

--- a/tests/phpunit/Integration/ErrorHandlingIntegrationTest.php
+++ b/tests/phpunit/Integration/ErrorHandlingIntegrationTest.php
@@ -13,12 +13,11 @@ use WP\MCP\Infrastructure\ErrorHandling\NullMcpErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
 
 final class ErrorHandlingIntegrationTest extends TestCase {
 
 	public function test_error_factory_creates_consistent_errors(): void {
-		// Test that all error factory methods return DTOs with consistent structure
+		// Test that all error factory methods return arrays with consistent structure.
 		$errors = array(
 			McpErrorFactory::missing_parameter( 1, 'test' ),
 			McpErrorFactory::method_not_found( 2, 'test/method' ),
@@ -35,23 +34,11 @@ final class ErrorHandlingIntegrationTest extends TestCase {
 		);
 
 		foreach ( $errors as $error ) {
-			// McpErrorFactory now returns DTOs
-			$this->assertInstanceOf( JSONRPCErrorResponse::class, $error );
-			$this->assertSame( '2.0', $error->getJsonrpc() );
-			$this->assertNotNull( $error->getId() );
-			$this->assertNotNull( $error->getError() );
-			$this->assertIsNumeric( $error->getError()->getCode() );
-			$this->assertIsString( $error->getError()->getMessage() );
-			$this->assertNotEmpty( $error->getError()->getMessage() );
-
-			// Verify toArray() produces correct structure
-			$array = $error->toArray();
-			$this->assertArrayHasKey( 'jsonrpc', $array );
-			$this->assertSame( '2.0', $array['jsonrpc'] );
-			$this->assertArrayHasKey( 'id', $array );
-			$this->assertArrayHasKey( 'error', $array );
-			$this->assertArrayHasKey( 'code', $array['error'] );
-			$this->assertArrayHasKey( 'message', $array['error'] );
+			$this->assertSame( '2.0', $error['jsonrpc'] );
+			$this->assertNotNull( $error['id'] );
+			$this->assertIsInt( $error['error']['code'] );
+			$this->assertIsString( $error['error']['message'] );
+			$this->assertNotEmpty( $error['error']['message'] );
 		}
 	}
 
@@ -88,15 +75,14 @@ final class ErrorHandlingIntegrationTest extends TestCase {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 
-		// Test missing parameter error
-		// ToolsHandler now returns DTOs, convert to array for testing.
-		$result = $handler->call_tool( array( 'params' => array() ) )->toArray();
+		// Test missing parameter error.
+		$result = $handler->call_tool( array( 'params' => array() ) );
 		$this->assertArrayHasKey( 'error', $result );
 		$this->assertArrayHasKey( 'code', $result['error'] );
 		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $result['error']['code'] );
 
 		// Test tool not found error
-		$result = $handler->call_tool( array( 'params' => array( 'name' => 'nonexistent-tool' ) ) )->toArray();
+		$result = $handler->call_tool( array( 'params' => array( 'name' => 'nonexistent-tool' ) ) );
 		$this->assertArrayHasKey( 'error', $result );
 		$this->assertArrayHasKey( 'code', $result['error'] );
 		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $result['error']['code'] );
@@ -106,9 +92,8 @@ final class ErrorHandlingIntegrationTest extends TestCase {
 		$server  = $this->makeServer( array( 'test/permission-exception' ) );
 		$handler = new ToolsHandler( $server );
 
-		// This should trigger an error and log it
-		// ToolsHandler now returns DTOs, convert to array for testing.
-		$result = $handler->call_tool( array( 'params' => array( 'name' => 'test-permission-exception' ) ) )->toArray();
+		// This should trigger an error and log it.
+		$result = $handler->call_tool( array( 'params' => array( 'name' => 'test-permission-exception' ) ) );
 
 		// Permission exceptions are tool execution errors (isError: true)
 		$this->assertArrayHasKey( 'isError', $result );
@@ -130,15 +115,17 @@ final class ErrorHandlingIntegrationTest extends TestCase {
 		);
 		$this->assertTrue( McpErrorFactory::validate_jsonrpc_message( $valid_message ) );
 
-		// Invalid version - now returns DTO instead of array
+		// Invalid version returns a complete error envelope.
 		$invalid_message = array(
 			'jsonrpc' => '1.0',
 			'method'  => 'test',
 			'id'      => 1,
 		);
 		$result          = McpErrorFactory::validate_jsonrpc_message( $invalid_message );
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertNotNull( $result->getError() );
+		$this->assertIsArray( $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 
 		// Missing method (but has id and result - response message)
 		$response_message = array(
@@ -148,15 +135,17 @@ final class ErrorHandlingIntegrationTest extends TestCase {
 		);
 		$this->assertTrue( McpErrorFactory::validate_jsonrpc_message( $response_message ) );
 
-		// Completely invalid - now returns DTO
+		// Completely invalid.
 		$invalid_message = array(
 			'jsonrpc' => '2.0',
 			'id'      => 1,
 			// No method, result, or error
 		);
 		$result = McpErrorFactory::validate_jsonrpc_message( $invalid_message );
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertNotNull( $result->getError() );
+		$this->assertIsArray( $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 	}
 
 	public function test_error_codes_are_properly_defined(): void {

--- a/tests/phpunit/Integration/HttpTransportTest.php
+++ b/tests/phpunit/Integration/HttpTransportTest.php
@@ -84,6 +84,7 @@ final class HttpTransportTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -127,6 +128,7 @@ final class HttpTransportTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -166,6 +168,7 @@ final class HttpTransportTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -281,6 +284,7 @@ final class HttpTransportTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -347,6 +351,7 @@ final class HttpTransportTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -411,6 +416,7 @@ final class HttpTransportTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -444,6 +450,7 @@ final class HttpTransportTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -962,6 +969,11 @@ final class HttpTransportTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
+					'clientInfo'      => array(
+						'name'    => 'test-client',
+						'version' => '1.0.0',
+					),
 				),
 			)
 		);

--- a/tests/phpunit/Integration/HttpTransportTest.php
+++ b/tests/phpunit/Integration/HttpTransportTest.php
@@ -521,7 +521,14 @@ final class HttpTransportTest extends TestCase {
 				'jsonrpc' => '2.0',
 				'id'      => 1,
 				'method'  => 'initialize',
-				'params'  => array(),
+				'params'  => array(
+					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
+					'clientInfo'      => array(
+						'name'    => 'origin-test-client',
+						'version' => '1.0.0',
+					),
+				),
 			)
 		);
 		$request->set_header( 'Origin', 'https://malicious-site.com' );
@@ -1008,9 +1015,33 @@ final class HttpTransportTest extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/test-mcp' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_header( 'Accept', 'application/json, text/event-stream' );
-		$request->set_body( wp_json_encode( $body ) );
+		$request->set_body( wp_json_encode( $this->normalizeTestWireObjects( $body ) ) );
 
 		return $request;
+	}
+
+	/** @param mixed $value @return mixed */
+	private function normalizeTestWireObjects( $value, ?string $key = null ) {
+		$object_keys = array(
+			'_meta',
+			'arguments',
+			'capabilities',
+			'io.modelcontextprotocol/clientCapabilities',
+			'params',
+		);
+		if ( array() === $value && null !== $key && in_array( $key, $object_keys, true ) ) {
+			return new \stdClass();
+		}
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$result = array();
+		foreach ( $value as $item_key => $item ) {
+			$result[ $item_key ] = $this->normalizeTestWireObjects( $item, (string) $item_key );
+		}
+
+		return $result;
 	}
 
 	private function createTransportContext( McpServer $server ): McpTransportContext {

--- a/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
+++ b/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
@@ -11,6 +11,8 @@ namespace WP\MCP\Tests\Unit\Cli;
 
 use WP\MCP\Cli\StdioServerBridge;
 use WP\MCP\Core\McpServer;
+use WP\MCP\Core\McpVersionNegotiator;
+use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
@@ -77,6 +79,7 @@ final class StdioServerBridgeTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -318,6 +321,8 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	public function test_handle_request_with_tools_list(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
@@ -341,12 +346,14 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	public function test_handle_request_with_object_params(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
 		$handle_request_method->setAccessible( true );
 
-		// Test with object params (should be converted to array)
+		// Object params are decoded to an array, then validated against the exact request schema.
 		$json_input = wp_json_encode(
 			array(
 				'jsonrpc' => '2.0',
@@ -360,10 +367,12 @@ final class StdioServerBridgeTest extends TestCase {
 
 		$this->assertIsString( $result );
 		$response = json_decode( $result, true );
-		$this->assertArrayHasKey( 'result', $response );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response['error']['code'] );
 	}
 
 	public function test_handle_request_with_non_array_params(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
@@ -388,6 +397,8 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	public function test_handle_request_with_exception_in_routing(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
@@ -425,6 +436,8 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	public function test_bridge_handles_request_ids(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
@@ -559,6 +572,8 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	public function test_handle_request_with_string_id(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
@@ -605,6 +620,8 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	public function test_handle_request_with_resources_list(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
@@ -628,6 +645,8 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	public function test_handle_request_with_prompts_list(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
@@ -651,6 +670,8 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	public function test_handle_request_with_unknown_method(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
@@ -674,6 +695,8 @@ final class StdioServerBridgeTest extends TestCase {
 	}
 
 	public function test_handle_request_with_missing_params(): void {
+		$this->initialize_legacy();
+
 		// Use reflection to access private method
 		$reflection            = new \ReflectionClass( $this->bridge );
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
@@ -694,6 +717,156 @@ final class StdioServerBridgeTest extends TestCase {
 		$this->assertIsString( $result );
 		$response = json_decode( $result, true );
 		// Should succeed since ping doesn't need params
+		$this->assertArrayHasKey( 'result', $response );
+	}
+
+	public function test_legacy_stdio_requires_initialize_before_requests(): void {
+		$response = $this->handle(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 80,
+				'method'  => 'tools/list',
+				'params'  => array(),
+			)
+		);
+
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $response['error']['code'] );
+		$this->assertStringContainsString( 'must initialize', $response['error']['message'] );
+	}
+
+	public function test_legacy_stdio_initialize_falls_back_then_enables_session_flow(): void {
+		$initialize = $this->handle(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 81,
+				'method'  => 'initialize',
+				'params'  => array(
+					'protocolVersion' => '2024-11-05',
+					'capabilities'    => array(),
+					'clientInfo'      => array(
+						'name'    => 'legacy-stdio-client',
+						'version' => '1.0.0',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION, $initialize['result']['protocolVersion'] );
+
+		$ping = $this->handle(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 82,
+				'method'  => 'ping',
+			)
+		);
+		$this->assertSame( array(), $ping['result'] );
+	}
+
+	public function test_modern_stdio_discovery_is_stateless(): void {
+		$params = $this->modern_params();
+		$params['_meta']['io.modelcontextprotocol/clientInfo'] = array(
+			'name'    => 'modern-stdio-client',
+			'version' => '1.0.0',
+		);
+		$response = $this->handle(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 83,
+				'method'  => 'server/discover',
+				'params'  => $params,
+			)
+		);
+
+		$this->assertSame( 'complete', $response['result']['resultType'] );
+		$this->assertSame( McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS, $response['result']['supportedVersions'] );
+		$this->assertSame( 0, $response['result']['ttlMs'] );
+		$this->assertSame( 'private', $response['result']['cacheScope'] );
+	}
+
+	public function test_modern_stdio_request_does_not_require_initialize(): void {
+		$response = $this->handle(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 84,
+				'method'  => 'tools/list',
+				'params'  => $this->modern_params(),
+			)
+		);
+
+		$this->assertSame( 'complete', $response['result']['resultType'] );
+		$this->assertArrayHasKey( 'tools', $response['result'] );
+	}
+
+	public function test_modern_stdio_rejects_unadvertised_revision(): void {
+		$params = $this->modern_params();
+		$params['_meta']['io.modelcontextprotocol/protocolVersion'] = '2099-01-01';
+		$response = $this->handle(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 85,
+				'method'  => 'tools/list',
+				'params'  => $params,
+			)
+		);
+
+		$this->assertSame( McpErrorFactory::UNSUPPORTED_PROTOCOL_VERSION, $response['error']['code'] );
+		$this->assertSame( '2099-01-01', $response['error']['data']['requested'] );
+	}
+
+	public function test_modern_stdio_does_not_expose_legacy_ping(): void {
+		$response = $this->handle(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 86,
+				'method'  => 'ping',
+				'params'  => $this->modern_params(),
+			)
+		);
+
+		$this->assertSame( McpErrorFactory::METHOD_NOT_FOUND, $response['error']['code'] );
+	}
+
+	/** @param array<string, mixed> $request */
+	private function handle( array $request ): array {
+		$reflection = new \ReflectionClass( $this->bridge );
+		$method     = $reflection->getMethod( 'handle_request' );
+		$method->setAccessible( true );
+		$response = $method->invoke( $this->bridge, wp_json_encode( $request ) );
+		$decoded  = json_decode( $response, true );
+
+		$this->assertIsArray( $decoded );
+
+		return $decoded;
+	}
+
+	/** @return array<string, mixed> */
+	private function modern_params(): array {
+		return array(
+			'_meta' => array(
+				'io.modelcontextprotocol/protocolVersion' => McpVersionNegotiator::MODERN_PROTOCOL_VERSION,
+				'io.modelcontextprotocol/clientCapabilities' => array(),
+			),
+		);
+	}
+
+	private function initialize_legacy(): void {
+		$response = $this->handle(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 'test-initialize',
+				'method'  => 'initialize',
+				'params'  => array(
+					'protocolVersion' => McpVersionNegotiator::LEGACY_PROTOCOL_VERSION,
+					'capabilities'    => array(),
+					'clientInfo'      => array(
+						'name'    => 'legacy-test-client',
+						'version' => '1.0.0',
+					),
+				),
+			)
+		);
+
 		$this->assertArrayHasKey( 'result', $response );
 	}
 }

--- a/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
+++ b/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
@@ -79,7 +79,7 @@ final class StdioServerBridgeTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
-					'capabilities'    => array(),
+					'capabilities'    => new \stdClass(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -151,7 +151,7 @@ final class StdioServerBridgeTest extends TestCase {
 				'jsonrpc' => '1.0', // Invalid version
 				'id'      => 1,
 				'method'  => 'initialize',
-				'params'  => array(),
+				'params'  => new \stdClass(),
 			)
 		);
 
@@ -333,7 +333,7 @@ final class StdioServerBridgeTest extends TestCase {
 				'jsonrpc' => '2.0',
 				'id'      => 2,
 				'method'  => 'tools/list',
-				'params'  => array(),
+				'params'  => new \stdClass(),
 			)
 		);
 
@@ -378,7 +378,7 @@ final class StdioServerBridgeTest extends TestCase {
 		$handle_request_method = $reflection->getMethod( 'handle_request' );
 		$handle_request_method->setAccessible( true );
 
-		// Test with string params (should be converted to empty array)
+		// Scalar params violate the exact request schema.
 		$json_input = wp_json_encode(
 			array(
 				'jsonrpc' => '2.0',
@@ -392,8 +392,7 @@ final class StdioServerBridgeTest extends TestCase {
 
 		$this->assertIsString( $result );
 		$response = json_decode( $result, true );
-		// Should still work since ping doesn't require specific params
-		$this->assertArrayHasKey( 'result', $response );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response['error']['code'] );
 	}
 
 	public function test_handle_request_with_exception_in_routing(): void {
@@ -449,7 +448,7 @@ final class StdioServerBridgeTest extends TestCase {
 				'jsonrpc' => '2.0',
 				'id'      => 42,
 				'method'  => 'ping',
-				'params'  => array(),
+				'params'  => new \stdClass(),
 			)
 		);
 
@@ -536,7 +535,7 @@ final class StdioServerBridgeTest extends TestCase {
 				'jsonrpc' => '2.0',
 				'id'      => 1,
 				'method'  => 12345, // Non-string method
-				'params'  => array(),
+				'params'  => new \stdClass(),
 			)
 		);
 
@@ -632,7 +631,7 @@ final class StdioServerBridgeTest extends TestCase {
 				'jsonrpc' => '2.0',
 				'id'      => 3,
 				'method'  => 'resources/list',
-				'params'  => array(),
+				'params'  => new \stdClass(),
 			)
 		);
 
@@ -657,7 +656,7 @@ final class StdioServerBridgeTest extends TestCase {
 				'jsonrpc' => '2.0',
 				'id'      => 4,
 				'method'  => 'prompts/list',
-				'params'  => array(),
+				'params'  => new \stdClass(),
 			)
 		);
 
@@ -827,17 +826,127 @@ final class StdioServerBridgeTest extends TestCase {
 		$this->assertSame( McpErrorFactory::METHOD_NOT_FOUND, $response['error']['code'] );
 	}
 
+	public function test_raw_stdio_rejects_legacy_capabilities_list(): void {
+		$response = $this->handleRaw(
+			'{"jsonrpc":"2.0","id":87,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":[],"clientInfo":{"name":"raw-client","version":"1.0.0"}}}'
+		);
+
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response['error']['code'] );
+	}
+
+	public function test_raw_stdio_accepts_modern_client_capabilities_object(): void {
+		$response = $this->handleRaw(
+			'{"jsonrpc":"2.0","id":88,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}'
+		);
+
+		$this->assertArrayHasKey( 'result', $response );
+		$this->assertSame( 'complete', $response['result']['resultType'] );
+	}
+
+	public function test_raw_stdio_rejects_modern_object_fields_encoded_as_lists(): void {
+		$client_capabilities = $this->handleRaw(
+			'{"jsonrpc":"2.0","id":89,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":[]}}}'
+		);
+		$arguments           = $this->handleRaw(
+			'{"jsonrpc":"2.0","id":90,"method":"tools/call","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"name":"test-always-allowed","arguments":[]}}'
+		);
+		$input_responses     = $this->handleRaw(
+			'{"jsonrpc":"2.0","id":91,"method":"tools/call","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"name":"test-always-allowed","arguments":{},"inputResponses":[],"requestState":"opaque"}}'
+		);
+
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $client_capabilities['error']['code'] );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $arguments['error']['code'] );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $input_responses['error']['code'] );
+	}
+
+	public function test_modern_request_does_not_replace_initialized_legacy_revision(): void {
+		$this->initialize_legacy();
+		$modern = $this->handleRaw(
+			'{"jsonrpc":"2.0","id":92,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}'
+		);
+		$legacy = $this->handle(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 93,
+				'method'  => 'ping',
+			)
+		);
+
+		$this->assertSame( 'complete', $modern['result']['resultType'] );
+		$this->assertSame( array(), $legacy['result'] );
+	}
+
+	public function test_modern_stdio_response_preserves_numeric_key_objects(): void {
+		$filter = static fn() => array(
+			'numeric' => (object) array( 0 => 'zero' ),
+		);
+		add_filter( 'mcp_adapter_tool_call_result', $filter );
+
+		try {
+			$reflection = new \ReflectionClass( $this->bridge );
+			$method     = $reflection->getMethod( 'handle_request' );
+			$method->setAccessible( true );
+			$response = $method->invoke(
+				$this->bridge,
+				'{"jsonrpc":"2.0","id":94,"method":"tools/call","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"name":"test-always-allowed","arguments":{}}}'
+			);
+
+			$this->assertIsString( $response );
+			$this->assertStringContainsString( '"numeric":{"0":"zero"}', $response );
+			$this->assertStringNotContainsString( '"numeric":["zero"]', $response );
+		} finally {
+			remove_filter( 'mcp_adapter_tool_call_result', $filter );
+		}
+	}
+
 	/** @param array<string, mixed> $request */
 	private function handle( array $request ): array {
 		$reflection = new \ReflectionClass( $this->bridge );
 		$method     = $reflection->getMethod( 'handle_request' );
 		$method->setAccessible( true );
-		$response = $method->invoke( $this->bridge, wp_json_encode( $request ) );
+		$response = $method->invoke( $this->bridge, wp_json_encode( $this->normalizeTestWireObjects( $request ) ) );
 		$decoded  = json_decode( $response, true );
 
 		$this->assertIsArray( $decoded );
 
 		return $decoded;
+	}
+
+	/** @return array<string,mixed> */
+	private function handleRaw( string $json ): array {
+		$reflection = new \ReflectionClass( $this->bridge );
+		$method     = $reflection->getMethod( 'handle_request' );
+		$method->setAccessible( true );
+		$response = $method->invoke( $this->bridge, $json );
+		$decoded  = json_decode( $response, true );
+
+		$this->assertIsArray( $decoded );
+
+		return $decoded;
+	}
+
+	/** @param mixed $value @return mixed */
+	private function normalizeTestWireObjects( $value, ?string $key = null ) {
+		$object_keys = array(
+			'_meta',
+			'arguments',
+			'capabilities',
+			'io.modelcontextprotocol/clientCapabilities',
+			'params',
+		);
+		if ( array() === $value && null !== $key && in_array( $key, $object_keys, true ) ) {
+			return new \stdClass();
+		}
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$result = array();
+		foreach ( $value as $item_key => $item ) {
+			$result[ $item_key ] = $this->normalizeTestWireObjects( $item, (string) $item_key );
+		}
+
+		return $result;
 	}
 
 	/** @return array<string, mixed> */

--- a/tests/phpunit/Unit/Core/McpComponentRegistryTest.php
+++ b/tests/phpunit/Unit/Core/McpComponentRegistryTest.php
@@ -15,9 +15,6 @@ use WP\MCP\Domain\Prompts\McpPromptBuilder;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 // Test prompt builder for registry testing
 // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
@@ -109,8 +106,8 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertArrayHasKey( 'test-always-allowed', $tools );
 
 		$tool = $tools['test-always-allowed'];
-		$this->assertInstanceOf( ToolDto::class, $tool );
-		$this->assertEquals( 'test-always-allowed', $tool->getName() );
+		$this->assertIsArray( $tool );
+		$this->assertSame( 'test-always-allowed', $tool['name'] );
 
 		// Verify observability event was recorded
 		$events = DummyObservabilityHandler::$events;
@@ -195,7 +192,7 @@ final class McpComponentRegistryTest extends TestCase {
 
 		// Get the first resource
 		$resource = array_values( $resources )[0];
-		$this->assertInstanceOf( ResourceDto::class, $resource );
+		$this->assertIsArray( $resource );
 
 		// Verify observability event was recorded
 		$events = DummyObservabilityHandler::$events;
@@ -250,7 +247,7 @@ final class McpComponentRegistryTest extends TestCase {
 
 		// Get the first prompt
 		$prompt = array_values( $prompts )[0];
-		$this->assertInstanceOf( PromptDto::class, $prompt );
+		$this->assertIsArray( $prompt );
 
 		// Verify observability event was recorded
 		$events = DummyObservabilityHandler::$events;
@@ -279,7 +276,7 @@ final class McpComponentRegistryTest extends TestCase {
 		$this->assertArrayHasKey( 'test-registry-prompt', $prompts );
 
 		$prompt = $prompts['test-registry-prompt'];
-		$this->assertInstanceOf( PromptDto::class, $prompt );
+		$this->assertIsArray( $prompt );
 		$this->assertNotNull( $this->registry->get_prompt_builder( 'test-registry-prompt' ) );
 
 		// Verify observability event was recorded
@@ -332,7 +329,7 @@ final class McpComponentRegistryTest extends TestCase {
 
 		$mcp_tool = $this->registry->get_mcp_tool( 'test-always-allowed' );
 		$this->assertInstanceOf( \WP\MCP\Domain\Tools\McpTool::class, $mcp_tool );
-		$this->assertEquals( 'test-always-allowed', $mcp_tool->get_protocol_dto()->getName() );
+		$this->assertSame( 'test-always-allowed', $mcp_tool->get_protocol_data()['name'] );
 
 		$nonexistent = $this->registry->get_mcp_tool( 'nonexistent' );
 		$this->assertNull( $nonexistent );
@@ -545,8 +542,6 @@ final class McpComponentRegistryTest extends TestCase {
 		);
 		$this->assertNotEmpty( $failure_event );
 	}
-
-	// Note: DTO schema validation is handled by the php-mcp-schema DTO constructors.
 
 	public function test_register_resources_skips_non_strings(): void {
 		$this->registry->register_resources( array( 123, null, array(), 'test/resource' ) );

--- a/tests/phpunit/Unit/Core/McpVersionNegotiatorTest.php
+++ b/tests/phpunit/Unit/Core/McpVersionNegotiatorTest.php
@@ -5,141 +5,77 @@
  * @package WP\MCP\Tests\Unit\Core
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WP\MCP\Tests\Unit\Core;
 
 use WP\MCP\Core\McpVersionNegotiator;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\McpConstants;
 
 /**
  * @since 0.5.0
  */
 final class McpVersionNegotiatorTest extends TestCase {
 
-	/**
-	 * Test that negotiating with each supported version echoes back the client version.
-	 *
-	 * @dataProvider data_supported_versions
-	 *
-	 * @param string $version A supported protocol version.
-	 */
-	public function test_negotiate_withSupportedVersion_returnsClientVersion( string $version ): void {
-		$this->assertSame( $version, McpVersionNegotiator::negotiate( $version ) );
+	public function test_negotiate_echoes_the_legacy_initialize_revision(): void {
+		$this->assertSame(
+			McpVersionNegotiator::LEGACY_PROTOCOL_VERSION,
+			McpVersionNegotiator::negotiate( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION )
+		);
 	}
 
 	/**
-	 * Data provider for supported protocol versions.
+	 * The modern revision is stateless and does not use initialize. A client
+	 * attempting to initialize with any other revision must receive the one
+	 * legacy revision this server can negotiate.
 	 *
-	 * @return array<string, array{string}>
+	 * @dataProvider data_non_legacy_initialize_versions
 	 */
-	public function data_supported_versions(): array {
-		$data = array();
-		foreach ( McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS as $version ) {
-			$data[ $version ] = array( $version );
-		}
-		return $data;
+	public function test_negotiate_falls_back_to_legacy_for_non_legacy_initialize_versions( string $version ): void {
+		$this->assertSame( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION, McpVersionNegotiator::negotiate( $version ) );
 	}
 
-	/**
-	 * Test that negotiating with an unsupported version returns the latest supported version.
-	 */
-	public function test_negotiate_withUnsupportedVersion_returnsLatest(): void {
-		$latest = McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS[0];
-
-		$this->assertSame( $latest, McpVersionNegotiator::negotiate( '9999-99-99' ) );
+	/** @return array<string, array{string}> */
+	public function data_non_legacy_initialize_versions(): array {
+		return array(
+			'modern revision'      => array( McpVersionNegotiator::MODERN_PROTOCOL_VERSION ),
+			'unsupported revision' => array( '9999-99-99' ),
+			'missing revision'     => array( '' ),
+		);
 	}
 
-	/**
-	 * Test that negotiating with an empty string returns the latest supported version.
-	 */
-	public function test_negotiate_withEmptyString_returnsLatest(): void {
-		$latest = McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS[0];
-
-		$this->assertSame( $latest, McpVersionNegotiator::negotiate( '' ) );
-	}
-
-	/**
-	 * Test that is_supported returns true for a supported version.
-	 *
-	 * @dataProvider data_supported_versions
-	 *
-	 * @param string $version A supported protocol version.
-	 */
-	public function test_is_supported_withSupportedVersion_returnsTrue( string $version ): void {
+	/** @dataProvider data_supported_versions */
+	public function test_is_supported_accepts_each_exact_runtime_revision( string $version ): void {
 		$this->assertTrue( McpVersionNegotiator::is_supported( $version ) );
+		$this->assertSame( $version, McpVersionNegotiator::schema_revision( $version ) );
 	}
 
-	/**
-	 * Test that is_supported returns false for an unsupported version.
-	 */
-	public function test_is_supported_withUnsupportedVersion_returnsFalse(): void {
-		$this->assertFalse( McpVersionNegotiator::is_supported( '9999-99-99' ) );
+	/** @return array<string, array{string}> */
+	public function data_supported_versions(): array {
+		return array(
+			'2026 stateless' => array( McpVersionNegotiator::MODERN_PROTOCOL_VERSION ),
+			'2025 session'   => array( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION ),
+		);
 	}
 
-	/**
-	 * Test that the latest supported version matches the schema package constant.
-	 *
-	 * McpConstants::LATEST_PROTOCOL_VERSION comes from the php-mcp-schema vendor
-	 * package. If that package updates its constant but SUPPORTED_PROTOCOL_VERSIONS
-	 * is not updated, this test will catch the drift.
-	 */
-	public function test_latestSupportedVersion_matchesMcpConstantsLatest(): void {
+	public function test_supported_versions_are_exact_and_newest_first(): void {
 		$this->assertSame(
-			McpConstants::LATEST_PROTOCOL_VERSION,
-			McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS[0],
-			'SUPPORTED_PROTOCOL_VERSIONS[0] must match McpConstants::LATEST_PROTOCOL_VERSION. '
-			. 'If the php-mcp-schema package was updated, add the new version to SUPPORTED_PROTOCOL_VERSIONS.'
+			array(
+				'2026-07-28',
+				'2025-11-25',
+			),
+			McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS
 		);
 	}
 
-	/**
-	 * Test that SUPPORTED_PROTOCOL_VERSIONS contains exactly the expected set.
-	 *
-	 * This explicit assertion prevents silent test-suite shrinkage: if a version
-	 * is accidentally removed from the constant the data-provider-based tests
-	 * would simply run fewer cases without failing. Locking the list here forces
-	 * a deliberate test update whenever versions are added or removed.
-	 */
-	public function test_supported_versions_containsExactExpectedSet(): void {
-		$expected = array(
-			'2025-11-25',
-			'2025-06-18',
-			'2024-11-05',
-		);
-
-		$this->assertSame(
-			$expected,
-			McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS,
-			'SUPPORTED_PROTOCOL_VERSIONS does not match the expected set. '
-			. 'If a version was intentionally added or removed, update this test.'
-		);
+	public function test_is_supported_rejects_unadvertised_revision(): void {
+		$this->assertFalse( McpVersionNegotiator::is_supported( '2025-06-18' ) );
 	}
 
-	/**
-	 * Test that the first element in SUPPORTED_PROTOCOL_VERSIONS is the latest version.
-	 *
-	 * The constant must be ordered newest-first so that index [0] is always
-	 * the latest protocol version the server supports.
-	 */
-	public function test_supported_versions_firstElementIsLatest(): void {
-		$versions = McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS;
+	public function test_schema_revision_rejects_unadvertised_revision(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Unsupported MCP protocol version: 2025-06-18' );
 
-		$this->assertNotEmpty( $versions, 'SUPPORTED_PROTOCOL_VERSIONS must not be empty.' );
-
-		$sorted = $versions;
-		usort(
-			$sorted,
-			static function ( string $a, string $b ): int {
-				return strcmp( $b, $a );
-			}
-		);
-
-		$this->assertSame(
-			$sorted[0],
-			$versions[0],
-			'The first element of SUPPORTED_PROTOCOL_VERSIONS must be the latest (newest) version.'
-		);
+		McpVersionNegotiator::schema_revision( '2025-06-18' );
 	}
 }

--- a/tests/phpunit/Unit/Domain/Prompts/McpPromptValidatorTest.php
+++ b/tests/phpunit/Unit/Domain/Prompts/McpPromptValidatorTest.php
@@ -7,7 +7,6 @@ namespace WP\MCP\Tests\Unit\Domain\Prompts;
 use WP\MCP\Domain\Prompts\McpPrompt;
 use WP\MCP\Domain\Prompts\McpPromptValidator;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 
 /**
  * Tests for McpPromptValidator class.
@@ -17,48 +16,42 @@ use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 final class McpPromptValidatorTest extends TestCase {
 
 	// =========================================================================
-	// validate_prompt_dto Tests
+	// validate_prompt_data Tests
 	// =========================================================================
 
-	public function test_validate_prompt_dto_with_valid_prompt(): void {
-		$prompt = PromptDto::fromArray(
-			array(
-				'name' => 'test-prompt',
-			)
+	public function test_validate_prompt_data_with_valid_prompt(): void {
+		$prompt = array(
+			'name' => 'test-prompt',
 		);
 
-		$result = McpPromptValidator::validate_prompt_dto( $prompt );
+		$result = McpPromptValidator::validate_prompt_data( $prompt );
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_prompt_dto_rejects_invalid_name(): void {
-		$prompt = PromptDto::fromArray(
-			array(
-				'name' => 'invalid/name',
-			)
+	public function test_validate_prompt_data_rejects_invalid_name(): void {
+		$prompt = array(
+			'name' => 'invalid/name',
 		);
 
-		$result = McpPromptValidator::validate_prompt_dto( $prompt );
+		$result = McpPromptValidator::validate_prompt_data( $prompt );
 		$this->assertWPError( $result );
 		$this->assertSame( 'mcp_prompt_validation_failed', $result->get_error_code() );
 		$this->assertStringContainsString( 'Prompt name', $result->get_error_message() );
 	}
 
-	public function test_validate_prompt_dto_rejects_invalid_icons(): void {
-		$prompt = PromptDto::fromArray(
-			array(
-				'name'  => 'test-prompt',
-				'icons' => array(
-					array(
-						'src'      => 'https://example.com/icon.png',
-						'mimeType' => 'image/png',
-					),
-					array( 'src' => 'invalid-url' ), // Invalid src
+	public function test_validate_prompt_data_rejects_invalid_icons(): void {
+		$prompt = array(
+			'name'  => 'test-prompt',
+			'icons' => array(
+				array(
+					'src'      => 'https://example.com/icon.png',
+					'mimeType' => 'image/png',
 				),
-			)
+				array( 'src' => 'invalid-url' ), // Invalid src
+			),
 		);
 
-		$result = McpPromptValidator::validate_prompt_dto( $prompt );
+		$result = McpPromptValidator::validate_prompt_data( $prompt );
 		$this->assertWPError( $result );
 		$this->assertStringContainsString( 'Icon at index 1', $result->get_error_message() );
 	}
@@ -714,11 +707,11 @@ final class McpPromptValidatorTest extends TestCase {
 
 	public function test_validate_prompt_instance_with_invalid_prompt(): void {
 		// We cannot create an McpPrompt with invalid name via fromArray
-		// because the Prompt DTO allows any name. Instead, let's test
-		// validate_prompt_dto directly with an invalid name
-		$prompt_dto = PromptDto::fromArray( array( 'name' => 'invalid/name' ) );
+		// because the protocol data may contain any name. Instead, let's test
+		// validate_prompt_data directly with an invalid name
+		$prompt_data = array( 'name' => 'invalid/name' );
 
-		$result = McpPromptValidator::validate_prompt_dto( $prompt_dto );
+		$result = McpPromptValidator::validate_prompt_data( $prompt_data );
 		$this->assertWPError( $result );
 		$this->assertSame( 'mcp_prompt_validation_failed', $result->get_error_code() );
 	}

--- a/tests/phpunit/Unit/Domain/Resources/McpResourceValidatorTest.php
+++ b/tests/phpunit/Unit/Domain/Resources/McpResourceValidatorTest.php
@@ -6,7 +6,6 @@ namespace WP\MCP\Tests\Unit\Domain\Resources;
 
 use WP\MCP\Domain\Resources\McpResourceValidator;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
 /**
  * Tests for McpResourceValidator class.
@@ -16,127 +15,111 @@ use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 final class McpResourceValidatorTest extends TestCase {
 
 	// =========================================================================
-	// validate_resource_dto Tests
+	// validate_resource_metadata Tests
 	// =========================================================================
 
-	public function test_validate_resource_dto_with_valid_resource(): void {
-		$resource = ResourceDto::fromArray(
-			array(
-				'uri'  => 'test://resource',
-				'name' => 'test-resource',
-			)
+	public function test_validate_resource_metadata_with_valid_resource(): void {
+		$resource = array(
+			'uri'  => 'test://resource',
+			'name' => 'test-resource',
 		);
 
-		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$result = McpResourceValidator::validate_resource_metadata( $resource );
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_resource_dto_rejects_invalid_uri(): void {
-		$resource = ResourceDto::fromArray(
-			array(
-				'uri'  => 'not a valid uri',
-				'name' => 'test-resource',
-			)
+	public function test_validate_resource_metadata_rejects_invalid_uri(): void {
+		$resource = array(
+			'uri'  => 'not a valid uri',
+			'name' => 'test-resource',
 		);
 
-		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$result = McpResourceValidator::validate_resource_metadata( $resource );
 		$this->assertWPError( $result );
 		$this->assertSame( 'mcp_resource_validation_failed', $result->get_error_code() );
 		$this->assertStringContainsString( 'URI must be a valid URI', $result->get_error_message() );
 	}
 
-	public function test_validate_resource_dto_accepts_any_mime_type_string(): void {
-		$resource = ResourceDto::fromArray(
-			array(
-				'uri'      => 'test://resource',
-				'name'     => 'test-resource',
-				'mimeType' => 'invalid-mime',
-			)
+	public function test_validate_resource_metadata_accepts_any_mime_type_string(): void {
+		$resource = array(
+			'uri'      => 'test://resource',
+			'name'     => 'test-resource',
+			'mimeType' => 'invalid-mime',
 		);
 
-		$this->assertTrue( McpResourceValidator::validate_resource_dto( $resource ) );
+		$this->assertTrue( McpResourceValidator::validate_resource_metadata( $resource ) );
 	}
 
-	public function test_validate_resource_dto_accepts_valid_mime_type(): void {
-		$resource = ResourceDto::fromArray(
-			array(
-				'uri'      => 'test://resource',
-				'name'     => 'test-resource',
-				'mimeType' => 'application/json',
-			)
+	public function test_validate_resource_metadata_accepts_valid_mime_type(): void {
+		$resource = array(
+			'uri'      => 'test://resource',
+			'name'     => 'test-resource',
+			'mimeType' => 'application/json',
 		);
 
-		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$result = McpResourceValidator::validate_resource_metadata( $resource );
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_resource_dto_rejects_invalid_icons(): void {
-		$resource = ResourceDto::fromArray(
-			array(
-				'uri'   => 'test://resource',
-				'name'  => 'test-resource',
-				'icons' => array(
-					array(
-						'src'      => 'https://example.com/icon.png',
-						'mimeType' => 'image/png',
-					),
-					array( 'src' => 'invalid-url' ), // Invalid src
+	public function test_validate_resource_metadata_rejects_invalid_icons(): void {
+		$resource = array(
+			'uri'   => 'test://resource',
+			'name'  => 'test-resource',
+			'icons' => array(
+				array(
+					'src'      => 'https://example.com/icon.png',
+					'mimeType' => 'image/png',
 				),
-			)
+				array( 'src' => 'invalid-url' ), // Invalid src
+			),
 		);
 
-		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$result = McpResourceValidator::validate_resource_metadata( $resource );
 		$this->assertWPError( $result );
 		$this->assertStringContainsString( 'Icon at index 1', $result->get_error_message() );
 	}
 
-	public function test_validate_resource_dto_rejects_invalid_annotation_values(): void {
-		// Note: The DTO validates structure (e.g., audience must be array).
+	public function test_validate_resource_metadata_rejects_invalid_annotation_values(): void {
+		// Validate annotation semantics independently of schema hydration.
 		// Our validator tests for invalid VALUES within valid structure.
-		$resource = ResourceDto::fromArray(
-			array(
-				'uri'         => 'test://resource',
-				'name'        => 'test-resource',
-				'annotations' => array(
-					'audience' => array( 'admin' ), // Invalid role - should be 'user' or 'assistant'
-				),
-			)
+		$resource = array(
+			'uri'         => 'test://resource',
+			'name'        => 'test-resource',
+			'annotations' => array(
+				'audience' => array( 'admin' ), // Invalid role - should be 'user' or 'assistant'
+			),
 		);
 
-		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$result = McpResourceValidator::validate_resource_metadata( $resource );
 		$this->assertWPError( $result );
 		$this->assertStringContainsString( 'valid roles', $result->get_error_message() );
 	}
 
-	public function test_validate_resource_dto_rejects_invalid_annotation_priority(): void {
-		$resource = ResourceDto::fromArray(
-			array(
-				'uri'         => 'test://resource',
-				'name'        => 'test-resource',
-				'annotations' => array(
-					'priority' => 1.5, // Out of range - should be 0.0 to 1.0
-				),
-			)
+	public function test_validate_resource_metadata_rejects_invalid_annotation_priority(): void {
+		$resource = array(
+			'uri'         => 'test://resource',
+			'name'        => 'test-resource',
+			'annotations' => array(
+				'priority' => 1.5, // Out of range - should be 0.0 to 1.0
+			),
 		);
 
-		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$result = McpResourceValidator::validate_resource_metadata( $resource );
 		$this->assertWPError( $result );
 		$this->assertStringContainsString( 'priority must be between', $result->get_error_message() );
 	}
 
-	public function test_validate_resource_dto_accepts_valid_annotations(): void {
-		$resource = ResourceDto::fromArray(
-			array(
-				'uri'         => 'test://resource',
-				'name'        => 'test-resource',
-				'annotations' => array(
-					'audience' => array( 'user', 'assistant' ),
-					'priority' => 0.8,
-				),
-			)
+	public function test_validate_resource_metadata_accepts_valid_annotations(): void {
+		$resource = array(
+			'uri'         => 'test://resource',
+			'name'        => 'test-resource',
+			'annotations' => array(
+				'audience' => array( 'user', 'assistant' ),
+				'priority' => 0.8,
+			),
 		);
 
-		$result = McpResourceValidator::validate_resource_dto( $resource );
+		$result = McpResourceValidator::validate_resource_metadata( $resource );
 		$this->assertTrue( $result );
 	}
 

--- a/tests/phpunit/Unit/Domain/Tools/McpToolValidatorTest.php
+++ b/tests/phpunit/Unit/Domain/Tools/McpToolValidatorTest.php
@@ -6,7 +6,6 @@ namespace WP\MCP\Tests\Unit\Domain\Tools;
 
 use WP\MCP\Domain\Tools\McpToolValidator;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 /**
  * Tests for McpToolValidator class.
@@ -16,91 +15,81 @@ use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 final class McpToolValidatorTest extends TestCase {
 
 	// =========================================================================
-	// validate_tool_dto Tests
+	// validate_tool_data Tests
 	// =========================================================================
 
-	public function test_validate_tool_dto_with_valid_tool(): void {
-		$tool = ToolDto::fromArray(
-			array(
-				'name'        => 'test-tool',
-				'inputSchema' => array( 'type' => 'object' ),
-			)
+	public function test_validate_tool_data_with_valid_tool(): void {
+		$tool = array(
+			'name'        => 'test-tool',
+			'inputSchema' => array( 'type' => 'object' ),
 		);
 
-		$result = McpToolValidator::validate_tool_dto( $tool );
+		$result = McpToolValidator::validate_tool_data( $tool );
 		$this->assertTrue( $result );
 	}
 
-	public function test_validate_tool_dto_rejects_invalid_name(): void {
-		$tool = ToolDto::fromArray(
-			array(
-				'name'        => 'invalid/name',
-				'inputSchema' => array( 'type' => 'object' ),
-			)
+	public function test_validate_tool_data_rejects_invalid_name(): void {
+		$tool = array(
+			'name'        => 'invalid/name',
+			'inputSchema' => array( 'type' => 'object' ),
 		);
 
-		$result = McpToolValidator::validate_tool_dto( $tool );
+		$result = McpToolValidator::validate_tool_data( $tool );
 		$this->assertWPError( $result );
 		$this->assertSame( 'mcp_tool_validation_failed', $result->get_error_code() );
 		$this->assertStringContainsString( 'Tool name', $result->get_error_message() );
 	}
 
-	public function test_validate_tool_dto_rejects_invalid_icons(): void {
-		$tool = ToolDto::fromArray(
-			array(
-				'name'        => 'test-tool',
-				'inputSchema' => array( 'type' => 'object' ),
-				'icons'       => array(
-					array(
-						'src'      => 'https://example.com/icon.png',
-						'mimeType' => 'image/png',
-					),
-					array( 'src' => 'invalid-url' ), // Invalid src
+	public function test_validate_tool_data_rejects_invalid_icons(): void {
+		$tool = array(
+			'name'        => 'test-tool',
+			'inputSchema' => array( 'type' => 'object' ),
+			'icons'       => array(
+				array(
+					'src'      => 'https://example.com/icon.png',
+					'mimeType' => 'image/png',
 				),
-			)
+				array( 'src' => 'invalid-url' ), // Invalid src
+			),
 		);
 
-		$result = McpToolValidator::validate_tool_dto( $tool );
+		$result = McpToolValidator::validate_tool_data( $tool );
 		$this->assertWPError( $result );
 		$this->assertStringContainsString( 'Icon at index 1', $result->get_error_message() );
 	}
 
-	public function test_validate_tool_dto_validates_input_schema(): void {
-		$tool = ToolDto::fromArray(
-			array(
-				'name'        => 'test-tool',
-				'inputSchema' => array(
-					'type'       => 'object',
-					'properties' => array(
-						'test_prop' => array( 'type' => 'string' ),
-					),
-					'required'   => array( 'nonexistent_prop' ), // Required prop not in properties
+	public function test_validate_tool_data_validates_input_schema(): void {
+		$tool = array(
+			'name'        => 'test-tool',
+			'inputSchema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'test_prop' => array( 'type' => 'string' ),
 				),
-			)
+				'required'   => array( 'nonexistent_prop' ), // Required prop not in properties
+			),
 		);
 
-		$result = McpToolValidator::validate_tool_dto( $tool );
+		$result = McpToolValidator::validate_tool_data( $tool );
 		$this->assertWPError( $result );
 		$this->assertStringContainsString( 'inputSchema', $result->get_error_message() );
 		$this->assertStringContainsString( 'does not exist in properties', $result->get_error_message() );
 	}
 
-	public function test_validate_tool_dto_validates_output_schema(): void {
-		$tool = ToolDto::fromArray(
-			array(
-				'name'         => 'test-tool',
-				'inputSchema'  => array( 'type' => 'object' ),
-				'outputSchema' => array(
-					'type'       => 'object',
-					'properties' => array(
-						'result' => array( 'type' => 'string' ),
-					),
-					'required'   => array( 'missing_field' ), // Required prop not in properties
+	public function test_validate_tool_data_validates_output_schema(): void {
+		$tool = array(
+			'name'         => 'test-tool',
+			'inputSchema'  => array( 'type' => 'object' ),
+			'outputSchema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'result' => array( 'type' => 'string' ),
 				),
-			)
+				'required'   => array( 'missing_field' ), // Required prop not in properties
+			),
 		);
 
-		$result = McpToolValidator::validate_tool_dto( $tool );
+		$result = McpToolValidator::validate_tool_data( $tool );
 		$this->assertWPError( $result );
 		$this->assertStringContainsString( 'outputSchema', $result->get_error_message() );
 		$this->assertStringContainsString( 'does not exist in properties', $result->get_error_message() );

--- a/tests/phpunit/Unit/Domain/Utils/ContentBlockHelperTest.php
+++ b/tests/phpunit/Unit/Domain/Utils/ContentBlockHelperTest.php
@@ -11,278 +11,93 @@ namespace WP\MCP\Tests\Unit\Domain\Utils;
 
 use WP\MCP\Domain\Utils\ContentBlockHelper;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\Content\DTO\AudioContent;
-use WP\McpSchema\Common\Content\DTO\ImageContent;
-use WP\McpSchema\Common\Content\DTO\TextContent;
-use WP\McpSchema\Common\Protocol\DTO\Annotations;
-use WP\McpSchema\Common\Protocol\DTO\BlobResourceContents;
-use WP\McpSchema\Common\Protocol\DTO\EmbeddedResource;
-use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
-use WP\McpSchema\Common\Protocol\Union\ContentBlockInterface;
 
 /**
  * Test class for ContentBlockHelper.
  */
 final class ContentBlockHelperTest extends TestCase {
 
-	/**
-	 * Test that text() creates a TextContent DTO.
-	 */
-	public function test_text_creates_text_content_dto(): void {
-		$content = ContentBlockHelper::text( 'Hello, World!' );
-
-		$this->assertInstanceOf( TextContent::class, $content );
-		$this->assertInstanceOf( ContentBlockInterface::class, $content );
-		$this->assertSame( 'text', $content->getType() );
-		$this->assertSame( 'Hello, World!', $content->getText() );
-		$this->assertNull( $content->getAnnotations() );
-		$this->assertNull( $content->get_meta() );
+	public function test_text_returns_revision_neutral_content_data(): void {
+		$this->assertSame(
+			array(
+				'type' => 'text',
+				'text' => 'Hello, World!',
+			),
+			ContentBlockHelper::text( 'Hello, World!' )
+		);
 	}
 
-	/**
-	 * Test that text() creates a TextContent with empty string.
-	 */
-	public function test_text_accepts_empty_string(): void {
-		$content = ContentBlockHelper::text( '' );
+	public function test_text_accepts_empty_string_and_optional_fields(): void {
+		$annotations = array(
+			'audience' => array( 'user' ),
+			'priority' => 0.8,
+		);
+		$content     = ContentBlockHelper::text( '', $annotations, array( 'key' => 'value' ) );
 
-		$this->assertInstanceOf( TextContent::class, $content );
-		$this->assertSame( '', $content->getText() );
+		$this->assertSame( '', $content['text'] );
+		$this->assertSame( $annotations, $content['annotations'] );
+		$this->assertSame( array( 'key' => 'value' ), $content['_meta'] );
 	}
 
-	/**
-	 * Test that text() creates a TextContent with annotations.
-	 */
-	public function test_text_with_annotations(): void {
-		$annotations = new Annotations( array( 'user' ), 0.8 );
-		$content     = ContentBlockHelper::text( 'Test message', $annotations );
-
-		$this->assertInstanceOf( TextContent::class, $content );
-		$this->assertSame( 'Test message', $content->getText() );
-		$this->assertSame( $annotations, $content->getAnnotations() );
+	public function test_image_returns_revision_neutral_content_data(): void {
+		$this->assertSame(
+			array(
+				'type'     => 'image',
+				'data'     => 'base64data',
+				'mimeType' => 'image/png',
+			),
+			ContentBlockHelper::image( 'base64data', 'image/png' )
+		);
 	}
 
-	/**
-	 * Test that text() creates a TextContent with _meta.
-	 */
-	public function test_text_with_meta(): void {
-		$meta    = array( 'key' => 'value' );
-		$content = ContentBlockHelper::text( 'Test message', null, $meta );
-
-		$this->assertInstanceOf( TextContent::class, $content );
-		$this->assertSame( $meta, $content->get_meta() );
+	public function test_audio_returns_revision_neutral_content_data(): void {
+		$this->assertSame(
+			array(
+				'type'     => 'audio',
+				'data'     => 'base64audiodata',
+				'mimeType' => 'audio/mp3',
+			),
+			ContentBlockHelper::audio( 'base64audiodata', 'audio/mp3' )
+		);
 	}
 
-	/**
-	 * Test that text() toArray produces valid structure.
-	 */
-	public function test_text_to_array_produces_valid_structure(): void {
-		$content = ContentBlockHelper::text( 'Hello' );
-		$array   = $content->toArray();
-
-		$this->assertArrayHasKey( 'type', $array );
-		$this->assertArrayHasKey( 'text', $array );
-		$this->assertSame( 'text', $array['type'] );
-		$this->assertSame( 'Hello', $array['text'] );
-	}
-
-	/**
-	 * Test that image() creates an ImageContent DTO.
-	 */
-	public function test_image_creates_image_content_dto(): void {
-		$content = ContentBlockHelper::image( 'base64data', 'image/png' );
-
-		$this->assertInstanceOf( ImageContent::class, $content );
-		$this->assertInstanceOf( ContentBlockInterface::class, $content );
-		$this->assertSame( 'image', $content->getType() );
-		$this->assertSame( 'base64data', $content->getData() );
-		$this->assertSame( 'image/png', $content->getMimeType() );
-		$this->assertNull( $content->getAnnotations() );
-		$this->assertNull( $content->get_meta() );
-	}
-
-	/**
-	 * Test that image() creates an ImageContent with annotations.
-	 */
-	public function test_image_with_annotations(): void {
-		$annotations = new Annotations( array( 'user' ), 1.0 );
-		$content     = ContentBlockHelper::image( 'data', 'image/jpeg', $annotations );
-
-		$this->assertInstanceOf( ImageContent::class, $content );
-		$this->assertSame( $annotations, $content->getAnnotations() );
-	}
-
-	/**
-	 * Test that image() toArray produces valid structure.
-	 */
-	public function test_image_to_array_produces_valid_structure(): void {
-		$content = ContentBlockHelper::image( 'base64data', 'image/png' );
-		$array   = $content->toArray();
-
-		$this->assertArrayHasKey( 'type', $array );
-		$this->assertArrayHasKey( 'data', $array );
-		$this->assertArrayHasKey( 'mimeType', $array );
-		$this->assertSame( 'image', $array['type'] );
-		$this->assertSame( 'base64data', $array['data'] );
-		$this->assertSame( 'image/png', $array['mimeType'] );
-	}
-
-	/**
-	 * Test that audio() creates an AudioContent DTO.
-	 */
-	public function test_audio_creates_audio_content_dto(): void {
-		$content = ContentBlockHelper::audio( 'base64audiodata', 'audio/mp3' );
-
-		$this->assertInstanceOf( AudioContent::class, $content );
-		$this->assertInstanceOf( ContentBlockInterface::class, $content );
-		$this->assertSame( 'audio', $content->getType() );
-		$this->assertSame( 'base64audiodata', $content->getData() );
-		$this->assertSame( 'audio/mp3', $content->getMimeType() );
-		$this->assertNull( $content->getAnnotations() );
-		$this->assertNull( $content->get_meta() );
-	}
-
-	/**
-	 * Test that audio() creates an AudioContent with annotations.
-	 */
-	public function test_audio_with_annotations(): void {
-		$annotations = new Annotations( array( 'assistant' ), 0.5 );
-		$content     = ContentBlockHelper::audio( 'data', 'audio/wav', $annotations );
-
-		$this->assertInstanceOf( AudioContent::class, $content );
-		$this->assertSame( $annotations, $content->getAnnotations() );
-	}
-
-	/**
-	 * Test that audio() toArray produces valid structure.
-	 */
-	public function test_audio_to_array_produces_valid_structure(): void {
-		$content = ContentBlockHelper::audio( 'audiodata', 'audio/ogg' );
-		$array   = $content->toArray();
-
-		$this->assertArrayHasKey( 'type', $array );
-		$this->assertArrayHasKey( 'data', $array );
-		$this->assertArrayHasKey( 'mimeType', $array );
-		$this->assertSame( 'audio', $array['type'] );
-		$this->assertSame( 'audiodata', $array['data'] );
-		$this->assertSame( 'audio/ogg', $array['mimeType'] );
-	}
-
-	/**
-	 * Test that embeddedTextResource() creates an EmbeddedResource with TextResourceContents.
-	 */
-	public function test_embedded_text_resource_creates_embedded_resource_dto(): void {
-		$content = ContentBlockHelper::embedded_text_resource( 'file:///test.txt', 'Hello content' );
-
-		$this->assertInstanceOf( EmbeddedResource::class, $content );
-		$this->assertInstanceOf( ContentBlockInterface::class, $content );
-		$this->assertSame( 'resource', $content->getType() );
-
-		$resource = $content->getResource();
-		$this->assertInstanceOf( TextResourceContents::class, $resource );
-		$this->assertSame( 'file:///test.txt', $resource->getUri() );
-		$this->assertSame( 'Hello content', $resource->getText() );
-	}
-
-	/**
-	 * Test that embeddedTextResource() accepts optional mimeType.
-	 */
-	public function test_embedded_text_resource_with_mime_type(): void {
-		$content  = ContentBlockHelper::embedded_text_resource( 'file:///test.json', '{}', 'application/json' );
-		$resource = $content->getResource();
-
-		$this->assertSame( 'application/json', $resource->getMimeType() );
-	}
-
-	/**
-	 * Test that embeddedTextResource() with annotations.
-	 */
-	public function test_embedded_text_resource_with_annotations(): void {
-		$annotations = new Annotations( array( 'user' ) );
-		$content     = ContentBlockHelper::embedded_text_resource( 'file:///test.txt', 'content', null, $annotations );
-
-		$this->assertSame( $annotations, $content->getAnnotations() );
-	}
-
-	/**
-	 * Test that embeddedBlobResource() creates an EmbeddedResource with BlobResourceContents.
-	 */
-	public function test_embedded_blob_resource_creates_embedded_resource_dto(): void {
-		$content = ContentBlockHelper::embedded_blob_resource( 'file:///image.png', 'base64blob', 'image/png' );
-
-		$this->assertInstanceOf( EmbeddedResource::class, $content );
-		$this->assertInstanceOf( ContentBlockInterface::class, $content );
-		$this->assertSame( 'resource', $content->getType() );
-
-		$resource = $content->getResource();
-		$this->assertInstanceOf( BlobResourceContents::class, $resource );
-		$this->assertSame( 'file:///image.png', $resource->getUri() );
-		$this->assertSame( 'base64blob', $resource->getBlob() );
-		$this->assertSame( 'image/png', $resource->getMimeType() );
-	}
-
-	/**
-	 * Test that embeddedBlobResource() with annotations.
-	 */
-	public function test_embedded_blob_resource_with_annotations(): void {
-		$annotations = new Annotations( array( 'assistant' ), 0.9 );
-		$content     = ContentBlockHelper::embedded_blob_resource( 'file:///doc.pdf', 'data', 'application/pdf', $annotations );
-
-		$this->assertSame( $annotations, $content->getAnnotations() );
-	}
-
-	/**
-	 * Test that embeddedTextResource() puts each _meta on its own level of the DTO tree.
-	 */
-	public function test_embedded_text_resource_sets_block_and_resource_meta_independently(): void {
+	public function test_embedded_text_resource_preserves_nested_shape(): void {
 		$content = ContentBlockHelper::embedded_text_resource(
 			'ui://example/app',
 			'<!doctype html>',
 			'text/html;profile=mcp-app',
-			null,
+			array( 'audience' => array( 'user' ) ),
 			array( 'block' => 'level' ),
 			array( 'ui' => array( 'prefersBorder' => true ) )
 		);
 
-		$this->assertSame( array( 'block' => 'level' ), $content->get_meta() );
-
-		$resource = $content->getResource();
-		$this->assertSame( array( 'ui' => array( 'prefersBorder' => true ) ), $resource->get_meta() );
+		$this->assertSame( 'resource', $content['type'] );
+		$this->assertSame( 'ui://example/app', $content['resource']['uri'] );
+		$this->assertSame( '<!doctype html>', $content['resource']['text'] );
+		$this->assertSame( 'text/html;profile=mcp-app', $content['resource']['mimeType'] );
+		$this->assertSame( array( 'block' => 'level' ), $content['_meta'] );
+		$this->assertSame( array( 'ui' => array( 'prefersBorder' => true ) ), $content['resource']['_meta'] );
 	}
 
-	/**
-	 * Test that embeddedBlobResource() puts each _meta on its own level of the DTO tree.
-	 */
-	public function test_embedded_blob_resource_sets_block_and_resource_meta_independently(): void {
+	public function test_embedded_blob_resource_preserves_nested_shape(): void {
 		$content = ContentBlockHelper::embedded_blob_resource(
 			'file:///doc.pdf',
-			'data',
+			'base64blob',
 			'application/pdf',
 			null,
 			array( 'block' => 'level' ),
 			array( 'pages' => 3 )
 		);
 
-		$this->assertSame( array( 'block' => 'level' ), $content->get_meta() );
-
-		$resource = $content->getResource();
-		$this->assertSame( array( 'pages' => 3 ), $resource->get_meta() );
+		$this->assertSame( 'resource', $content['type'] );
+		$this->assertSame( 'file:///doc.pdf', $content['resource']['uri'] );
+		$this->assertSame( 'base64blob', $content['resource']['blob'] );
+		$this->assertSame( 'application/pdf', $content['resource']['mimeType'] );
+		$this->assertSame( array( 'block' => 'level' ), $content['_meta'] );
+		$this->assertSame( array( 'pages' => 3 ), $content['resource']['_meta'] );
 	}
 
-	/**
-	 * Test that a list-shaped _meta is treated as absent by text().
-	 *
-	 * A list serializes to a JSON array, and MCP declares `_meta` a JSON object.
-	 */
-	public function test_text_with_list_shaped_meta_omits_meta(): void {
-		$content = ContentBlockHelper::text( 'Test message', null, array( 'first', 'second' ) );
-
-		$this->assertNull( $content->get_meta() );
-	}
-
-	/**
-	 * Test that embeddedTextResource() drops a list-shaped _meta on both levels of the DTO tree.
-	 */
-	public function test_embedded_text_resource_with_list_shaped_meta_omits_meta_on_both_levels(): void {
+	public function test_list_shaped_meta_is_omitted_on_both_levels(): void {
 		$content = ContentBlockHelper::embedded_text_resource(
 			'ui://example/app',
 			'<!doctype html>',
@@ -292,98 +107,36 @@ final class ContentBlockHelperTest extends TestCase {
 			array( 'resource', 'level' )
 		);
 
-		$this->assertNull( $content->get_meta() );
-		$this->assertNull( $content->getResource()->get_meta() );
+		$this->assertArrayNotHasKey( '_meta', $content );
+		$this->assertArrayNotHasKey( '_meta', $content['resource'] );
 	}
 
-	/**
-	 * Test that errorText() creates a TextContent for error messages.
-	 */
-	public function test_error_text_creates_text_content_dto(): void {
-		$content = ContentBlockHelper::error_text( 'Something went wrong' );
-
-		$this->assertInstanceOf( TextContent::class, $content );
-		$this->assertSame( 'text', $content->getType() );
-		$this->assertSame( 'Something went wrong', $content->getText() );
-	}
-
-	/**
-	 * Test that jsonText() creates a TextContent with JSON-encoded data.
-	 */
-	public function test_json_text_creates_text_content_with_json(): void {
-		$data    = array(
-			'key'    => 'value',
-			'nested' => array( 'a' => 1 ),
+	public function test_error_text_delegates_to_text_shape(): void {
+		$this->assertSame(
+			array(
+				'type' => 'text',
+				'text' => 'Something went wrong',
+			),
+			ContentBlockHelper::error_text( 'Something went wrong' )
 		);
-		$content = ContentBlockHelper::json_text( $data );
-
-		$this->assertInstanceOf( TextContent::class, $content );
-		$this->assertSame( 'text', $content->getType() );
-		$this->assertSame( '{"key":"value","nested":{"a":1}}', $content->getText() );
 	}
 
-	/**
-	 * Test that jsonText() handles encoding options.
-	 */
-	public function test_json_text_with_pretty_print(): void {
-		$data    = array( 'key' => 'value' );
-		$content = ContentBlockHelper::json_text( $data, JSON_PRETTY_PRINT );
+	public function test_json_text_encodes_data_and_honors_flags(): void {
+		$content = ContentBlockHelper::json_text( array( 'key' => 'value' ), JSON_PRETTY_PRINT );
 
-		$this->assertInstanceOf( TextContent::class, $content );
-		$expected = "{\n    \"key\": \"value\"\n}";
-		$this->assertSame( $expected, $content->getText() );
+		$this->assertSame( 'text', $content['type'] );
+		$this->assertSame( "{\n    \"key\": \"value\"\n}", $content['text'] );
 	}
 
-	/**
-	 * Test that toArrayList() converts array of DTOs to array format.
-	 */
-	public function test_to_array_list_converts_dtos_to_arrays(): void {
+	public function test_to_array_list_returns_a_reindexed_list(): void {
 		$blocks = array(
-			ContentBlockHelper::text( 'First' ),
-			ContentBlockHelper::text( 'Second' ),
+			5 => ContentBlockHelper::text( 'First' ),
+			9 => ContentBlockHelper::image( 'imgdata', 'image/png' ),
 		);
 
 		$arrays = ContentBlockHelper::to_array_list( $blocks );
 
-		$this->assertCount( 2, $arrays );
-		$this->assertSame(
-			array(
-				'type' => 'text',
-				'text' => 'First',
-			),
-			$arrays[0]
-		);
-		$this->assertSame(
-			array(
-				'type' => 'text',
-				'text' => 'Second',
-			),
-			$arrays[1]
-		);
-	}
-
-	/**
-	 * Test that toArrayList() handles empty array.
-	 */
-	public function test_to_array_list_handles_empty_array(): void {
-		$arrays = ContentBlockHelper::to_array_list( array() );
-
-		$this->assertIsArray( $arrays );
-		$this->assertEmpty( $arrays );
-	}
-
-	/**
-	 * Test that toArrayList() handles mixed content types.
-	 */
-	public function test_to_array_list_handles_mixed_content_types(): void {
-		$blocks = array(
-			ContentBlockHelper::text( 'Message' ),
-			ContentBlockHelper::image( 'imgdata', 'image/png' ),
-		);
-
-		$arrays = ContentBlockHelper::to_array_list( $blocks );
-
-		$this->assertCount( 2, $arrays );
+		$this->assertSame( array( 0, 1 ), array_keys( $arrays ) );
 		$this->assertSame( 'text', $arrays[0]['type'] );
 		$this->assertSame( 'image', $arrays[1]['type'] );
 	}

--- a/tests/phpunit/Unit/ErrorHandlers/ErrorEnvelopeTest.php
+++ b/tests/phpunit/Unit/ErrorHandlers/ErrorEnvelopeTest.php
@@ -6,155 +6,53 @@ namespace WP\MCP\Tests\Unit\ErrorHandlers;
 
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
 
 /**
  * Tests for McpErrorFactory error envelope structure.
- *
- * Note: McpErrorFactory now returns typed DTOs (JSONRPCErrorResponse) instead of arrays.
- * These tests verify that the DTOs contain the correct data and can be serialized properly.
  */
 final class ErrorEnvelopeTest extends TestCase {
 
 	public function test_error_envelopes_have_consistent_shape(): void {
-		$err = McpErrorFactory::missing_parameter( 0, 'name' );
+		$error = McpErrorFactory::missing_parameter( 0, 'name' );
 
-		// Verify it's a DTO
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-
-		// Verify DTO properties
-		$this->assertSame( '2.0', $err->getJsonrpc() );
-		$this->assertNotNull( $err->getError() );
-		$this->assertNotNull( $err->getError()->getCode() );
-		$this->assertNotNull( $err->getError()->getMessage() );
-
-		// Verify toArray() produces consistent structure
-		$arr = $err->toArray();
-		$this->assertArrayHasKey( 'jsonrpc', $arr );
-		$this->assertSame( '2.0', $arr['jsonrpc'] );
-		$this->assertArrayHasKey( 'error', $arr );
-		$this->assertArrayHasKey( 'code', $arr['error'] );
-		$this->assertArrayHasKey( 'message', $arr['error'] );
+		$this->assertSame( '2.0', $error['jsonrpc'] );
+		$this->assertSame( 0, $error['id'] );
+		$this->assertIsInt( $error['error']['code'] );
+		$this->assertIsString( $error['error']['message'] );
 	}
 
 	/**
-	 * Test missing_parameter() convenience wrapper.
-	 * Note: This uses the standard INVALID_PARAMS error code.
+	 * @dataProvider provide_convenience_error_envelopes
+	 *
+	 * @param array{jsonrpc: string, error: array{code: int, message: string}, id: int} $error Error response.
+	 * @param int                                                                      $expected_id Expected request ID.
+	 * @param int                                                                      $expected_code Expected error code.
+	 * @param string                                                                   $expected_message Expected message fragment.
 	 */
-	public function test_missing_parameter_error(): void {
-		$err = McpErrorFactory::missing_parameter( 123, 'test_param' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 123, $err->getId() );
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'test_param', $err->getError()->getMessage() );
-	}
-
-	public function test_method_not_found_error(): void {
-		$err = McpErrorFactory::method_not_found( 456, 'test/method' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 456, $err->getId() );
-		$this->assertSame( McpErrorFactory::METHOD_NOT_FOUND, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'test/method', $err->getError()->getMessage() );
-	}
-
-	public function test_internal_error(): void {
-		$err = McpErrorFactory::internal_error( 789, 'Something went wrong' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 789, $err->getId() );
-		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'Something went wrong', $err->getError()->getMessage() );
-	}
-
-	public function test_tool_not_found_error(): void {
-		$err = McpErrorFactory::tool_not_found( 101, 'missing-tool' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 101, $err->getId() );
-		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'missing-tool', $err->getError()->getMessage() );
-	}
-
-	public function test_resource_not_found_error(): void {
-		$err = McpErrorFactory::resource_not_found( 102, 'missing-resource' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 102, $err->getId() );
-		$this->assertSame( McpErrorFactory::RESOURCE_NOT_FOUND, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'missing-resource', $err->getError()->getMessage() );
-	}
-
-	public function test_prompt_not_found_error(): void {
-		$err = McpErrorFactory::prompt_not_found( 103, 'missing-prompt' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 103, $err->getId() );
-		$this->assertSame( McpErrorFactory::PROMPT_NOT_FOUND, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'missing-prompt', $err->getError()->getMessage() );
-	}
-
-	public function test_permission_denied_error(): void {
-		$err = McpErrorFactory::permission_denied( 104, 'Access denied' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 104, $err->getId() );
-		$this->assertSame( McpErrorFactory::PERMISSION_DENIED, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'Access denied', $err->getError()->getMessage() );
-	}
-
-	public function test_unauthorized_error(): void {
-		$err = McpErrorFactory::unauthorized( 105, 'Not logged in' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 105, $err->getId() );
-		$this->assertSame( McpErrorFactory::UNAUTHORIZED, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'Not logged in', $err->getError()->getMessage() );
-	}
-
-	public function test_parse_error(): void {
-		$err = McpErrorFactory::parse_error( 106, 'Invalid JSON' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 106, $err->getId() );
-		$this->assertSame( McpErrorFactory::PARSE_ERROR, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'Invalid JSON', $err->getError()->getMessage() );
-	}
-
-	public function test_invalid_request_error(): void {
-		$err = McpErrorFactory::invalid_request( 107, 'Missing field' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 107, $err->getId() );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'Missing field', $err->getError()->getMessage() );
+	public function test_convenience_error_envelopes( array $error, int $expected_id, int $expected_code, string $expected_message ): void {
+		$this->assertSame( $expected_id, $error['id'] );
+		$this->assertSame( $expected_code, $error['error']['code'] );
+		$this->assertStringContainsString( $expected_message, $error['error']['message'] );
 	}
 
 	/**
-	 * Test invalid_params() method.
-	 * Note: missing_parameter() is a convenience wrapper that also uses this error code.
+	 * @return array<string, array{array<string, mixed>, int, int, string}>
 	 */
-	public function test_invalid_params_error(): void {
-		$err = McpErrorFactory::invalid_params( 108, 'Wrong type' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 108, $err->getId() );
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'Wrong type', $err->getError()->getMessage() );
-	}
-
-	/**
-	 * Test mcp_disabled() convenience wrapper.
-	 * Note: This uses the standard SERVER_ERROR error code.
-	 */
-	public function test_mcp_disabled_error(): void {
-		$err = McpErrorFactory::mcp_disabled( 109 );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $err );
-		$this->assertSame( 109, $err->getId() );
-		$this->assertSame( McpErrorFactory::SERVER_ERROR, $err->getError()->getCode() );
-		$this->assertStringContainsString( 'disabled', $err->getError()->getMessage() );
+	public function provide_convenience_error_envelopes(): array {
+		return array(
+			'missing parameter'  => array( McpErrorFactory::missing_parameter( 123, 'test_param' ), 123, McpErrorFactory::INVALID_PARAMS, 'test_param' ),
+			'method not found'   => array( McpErrorFactory::method_not_found( 456, 'test/method' ), 456, McpErrorFactory::METHOD_NOT_FOUND, 'test/method' ),
+			'internal error'     => array( McpErrorFactory::internal_error( 789, 'Something went wrong' ), 789, McpErrorFactory::INTERNAL_ERROR, 'Something went wrong' ),
+			'tool not found'     => array( McpErrorFactory::tool_not_found( 101, 'missing-tool' ), 101, McpErrorFactory::TOOL_NOT_FOUND, 'missing-tool' ),
+			'resource not found' => array( McpErrorFactory::resource_not_found( 102, 'missing-resource' ), 102, McpErrorFactory::RESOURCE_NOT_FOUND, 'missing-resource' ),
+			'prompt not found'   => array( McpErrorFactory::prompt_not_found( 103, 'missing-prompt' ), 103, McpErrorFactory::PROMPT_NOT_FOUND, 'missing-prompt' ),
+			'permission denied'  => array( McpErrorFactory::permission_denied( 104, 'Access denied' ), 104, McpErrorFactory::PERMISSION_DENIED, 'Access denied' ),
+			'unauthorized'       => array( McpErrorFactory::unauthorized( 105, 'Not logged in' ), 105, McpErrorFactory::UNAUTHORIZED, 'Not logged in' ),
+			'parse error'        => array( McpErrorFactory::parse_error( 106, 'Invalid JSON' ), 106, McpErrorFactory::PARSE_ERROR, 'Invalid JSON' ),
+			'invalid request'    => array( McpErrorFactory::invalid_request( 107, 'Missing field' ), 107, McpErrorFactory::INVALID_REQUEST, 'Missing field' ),
+			'invalid params'     => array( McpErrorFactory::invalid_params( 108, 'Wrong type' ), 108, McpErrorFactory::INVALID_PARAMS, 'Wrong type' ),
+			'mcp disabled'       => array( McpErrorFactory::mcp_disabled( 109 ), 109, McpErrorFactory::SERVER_ERROR, 'disabled' ),
+		);
 	}
 
 	public function test_jsonrpc_message_validation_valid(): void {
@@ -164,11 +62,10 @@ final class ErrorEnvelopeTest extends TestCase {
 			'id'      => 1,
 		);
 
-		$result = McpErrorFactory::validate_jsonrpc_message( $valid_message );
-		$this->assertTrue( $result );
+		$this->assertTrue( McpErrorFactory::validate_jsonrpc_message( $valid_message ) );
 	}
 
-	public function test_jsonrpc_message_validation_invalid_version(): void {
+	public function test_jsonrpc_message_validation_invalid_version_returns_array(): void {
 		$invalid_message = array(
 			'jsonrpc' => '1.0',
 			'method'  => 'test',
@@ -176,20 +73,24 @@ final class ErrorEnvelopeTest extends TestCase {
 		);
 
 		$result = McpErrorFactory::validate_jsonrpc_message( $invalid_message );
-		// Now returns a DTO on error, not an array
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertNotNull( $result->getError() );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 	}
 
-	public function test_jsonrpc_message_validation_missing_method(): void {
+	public function test_jsonrpc_message_validation_missing_payload_returns_array(): void {
 		$invalid_message = array(
 			'jsonrpc' => '2.0',
 			'id'      => 1,
 		);
 
 		$result = McpErrorFactory::validate_jsonrpc_message( $invalid_message );
-		// Now returns a DTO on error, not an array
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertNotNull( $result->getError() );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 	}
 }

--- a/tests/phpunit/Unit/ErrorHandling/ErrorResponseConsistencyTest.php
+++ b/tests/phpunit/Unit/ErrorHandling/ErrorResponseConsistencyTest.php
@@ -38,10 +38,9 @@ final class ErrorResponseConsistencyTest extends TestCase {
 		$resources_handler = new ResourcesHandler( $this->server );
 
 		// Test parameter validation errors (INVALID_PARAMS) from all handlers.
-		// All handlers now return DTOs, convert to array for consistent testing.
-		$tools_error     = $tools_handler->call_tool( array( 'params' => array() ) )->toArray(); // Missing 'name'
-		$prompts_error   = $prompts_handler->get_prompt( array( 'params' => array() ) )->toArray(); // Missing 'name'
-		$resources_error = $resources_handler->read_resource( array( 'params' => array() ) )->toArray(); // Missing 'uri'
+		$tools_error     = $tools_handler->call_tool( array( 'params' => array() ) ); // Missing 'name'.
+		$prompts_error   = $prompts_handler->get_prompt( array( 'params' => array() ) ); // Missing 'name'.
+		$resources_error = $resources_handler->read_resource( array( 'params' => array() ) ); // Missing 'uri'.
 
 		$errors = array( $tools_error, $prompts_error, $resources_error );
 
@@ -49,8 +48,7 @@ final class ErrorResponseConsistencyTest extends TestCase {
 			$this->assertArrayHasKey( 'error', $error );
 			$this->assertArrayHasKey( 'code', $error['error'] );
 			$this->assertArrayHasKey( 'message', $error['error'] );
-			// Note: Error codes are now float (from DTOs) for JSON number compatibility.
-			$this->assertIsNumeric( $error['error']['code'] );
+			$this->assertIsInt( $error['error']['code'] );
 			$this->assertIsString( $error['error']['message'] );
 		}
 	}
@@ -61,10 +59,9 @@ final class ErrorResponseConsistencyTest extends TestCase {
 		$resources_handler = new ResourcesHandler( $this->server );
 
 		// Test "not found" errors from all handlers.
-		// All handlers now return DTOs, convert to array for consistent testing.
-		$tool_not_found     = $tools_handler->call_tool( array( 'params' => array( 'name' => 'nonexistent_tool' ) ) )->toArray();
-		$prompt_not_found   = $prompts_handler->get_prompt( array( 'params' => array( 'name' => 'nonexistent_prompt' ) ) )->toArray();
-		$resource_not_found = $resources_handler->read_resource( array( 'params' => array( 'uri' => 'nonexistent://resource' ) ) )->toArray();
+		$tool_not_found     = $tools_handler->call_tool( array( 'params' => array( 'name' => 'nonexistent_tool' ) ) );
+		$prompt_not_found   = $prompts_handler->get_prompt( array( 'params' => array( 'name' => 'nonexistent_prompt' ) ) );
+		$resource_not_found = $resources_handler->read_resource( array( 'params' => array( 'uri' => 'nonexistent://resource' ) ) );
 
 		$errors = array( $tool_not_found, $prompt_not_found, $resource_not_found );
 
@@ -72,8 +69,7 @@ final class ErrorResponseConsistencyTest extends TestCase {
 			$this->assertArrayHasKey( 'error', $error );
 			$this->assertArrayHasKey( 'code', $error['error'] );
 			$this->assertArrayHasKey( 'message', $error['error'] );
-			// Note: Error codes are now float (from DTOs) for JSON number compatibility.
-			$this->assertIsNumeric( $error['error']['code'] );
+			$this->assertIsInt( $error['error']['code'] );
 			$this->assertIsString( $error['error']['message'] );
 
 			// All "not found" errors should have negative codes (MCP convention).
@@ -142,11 +138,10 @@ final class ErrorResponseConsistencyTest extends TestCase {
 		$resources_handler = new ResourcesHandler( $this->server );
 
 		// Test parameter validation error messages (INVALID_PARAMS error code).
-		// All handlers now return DTOs, convert to array for consistent testing.
 		$errors = array(
-			$tools_handler->call_tool( array( 'params' => array() ) )->toArray(), // Missing name
-			$prompts_handler->get_prompt( array( 'params' => array() ) )->toArray(), // Missing name
-			$resources_handler->read_resource( array( 'params' => array() ) )->toArray(), // Missing uri
+			$tools_handler->call_tool( array( 'params' => array() ) ), // Missing name.
+			$prompts_handler->get_prompt( array( 'params' => array() ) ), // Missing name.
+			$resources_handler->read_resource( array( 'params' => array() ) ), // Missing uri.
 		);
 
 		foreach ( $errors as $error ) {

--- a/tests/phpunit/Unit/Handlers/InitializeHandlerTest.php
+++ b/tests/phpunit/Unit/Handlers/InitializeHandlerTest.php
@@ -5,14 +5,11 @@ declare(strict_types=1);
 namespace WP\MCP\Tests\Unit\Handlers;
 
 use WP\MCP\Core\McpServer;
+use WP\MCP\Core\McpVersionNegotiator;
 use WP\MCP\Handlers\Initialize\InitializeHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\Lifecycle\DTO\Implementation;
-use WP\McpSchema\Common\McpConstants;
-use WP\McpSchema\Common\Protocol\DTO\InitializeResult;
-use WP\McpSchema\Server\Lifecycle\DTO\ServerCapabilities;
 
 final class InitializeHandlerTest extends TestCase {
 
@@ -30,27 +27,30 @@ final class InitializeHandlerTest extends TestCase {
 		);
 
 		$handler = new InitializeHandler( $server );
-		$result  = $handler->handle( McpConstants::LATEST_PROTOCOL_VERSION );
+		$result  = $handler->handle( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION );
 
-		// Returns InitializeResult DTO.
-		$this->assertInstanceOf( InitializeResult::class, $result );
-		$this->assertSame( McpConstants::LATEST_PROTOCOL_VERSION, $result->getProtocolVersion() );
-
-		// Server info.
-		$server_info = $result->getServerInfo();
-		$this->assertInstanceOf( Implementation::class, $server_info );
-		$this->assertSame( 'Test Server', $server_info->getName() );
-		$this->assertSame( '1.0.0', $server_info->getVersion() );
-
-		// Capabilities.
-		$capabilities = $result->getCapabilities();
-		$this->assertInstanceOf( ServerCapabilities::class, $capabilities );
-
-		// Instructions.
-		$this->assertSame( 'Desc', $result->getInstructions() );
+		$this->assertSame(
+			array(
+				'protocolVersion' => McpVersionNegotiator::LEGACY_PROTOCOL_VERSION,
+				'capabilities'    => array(
+					'prompts'   => array( 'listChanged' => false ),
+					'resources' => array(
+						'subscribe'   => false,
+						'listChanged' => false,
+					),
+					'tools'     => array( 'listChanged' => false ),
+				),
+				'serverInfo'      => array(
+					'name'    => 'Test Server',
+					'version' => '1.0.0',
+				),
+				'instructions'    => 'Desc',
+			),
+			$result
+		);
 	}
 
-	public function test_handle_returns_dto_that_converts_to_correct_array(): void {
+	public function test_handle_returns_correct_array(): void {
 		$server = new McpServer(
 			'test',
 			'mcp/v1',
@@ -64,13 +64,10 @@ final class InitializeHandlerTest extends TestCase {
 		);
 
 		$handler = new InitializeHandler( $server );
-		$result  = $handler->handle( McpConstants::LATEST_PROTOCOL_VERSION );
-
-		// Verify that toArray() produces expected structure.
-		$array = $result->toArray();
+		$array   = $handler->handle( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION );
 
 		$this->assertIsArray( $array );
-		$this->assertSame( McpConstants::LATEST_PROTOCOL_VERSION, $array['protocolVersion'] );
+		$this->assertSame( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION, $array['protocolVersion'] );
 		$this->assertSame( 'Test Server', $array['serverInfo']['name'] );
 		$this->assertSame( '1.0.0', $array['serverInfo']['version'] );
 		$this->assertIsArray( $array['capabilities'] );
@@ -115,11 +112,11 @@ final class InitializeHandlerTest extends TestCase {
 		);
 
 		$handler = new InitializeHandler( $server );
-		$result  = $handler->handle( McpConstants::LATEST_PROTOCOL_VERSION );
+		$result  = $handler->handle( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION );
 
 		// Simulate the JSON-RPC response serialization chain.
-		$result_array = $result->toArray();
-		$json         = json_encode( $result_array, JSON_THROW_ON_ERROR );
+		$json = wp_json_encode( $result );
+		$this->assertIsString( $json );
 
 		// Decode as stdClass objects (not associative arrays) to verify JSON types.
 		$decoded = json_decode( $json, false, 512, JSON_THROW_ON_ERROR );
@@ -169,15 +166,14 @@ final class InitializeHandlerTest extends TestCase {
 		);
 
 		$handler = new InitializeHandler( $server );
-		$result  = $handler->handle( '2025-06-18' );
+		$result  = $handler->handle( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION );
 
-		$this->assertInstanceOf( InitializeResult::class, $result );
-		$this->assertSame( '2025-06-18', $result->getProtocolVersion() );
+		$this->assertSame( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION, $result['protocolVersion'] );
 
 		// Verify other fields are still correct.
-		$this->assertSame( 'Test Server', $result->getServerInfo()->getName() );
-		$this->assertSame( '1.0.0', $result->getServerInfo()->getVersion() );
-		$this->assertSame( 'Desc', $result->getInstructions() );
+		$this->assertSame( 'Test Server', $result['serverInfo']['name'] );
+		$this->assertSame( '1.0.0', $result['serverInfo']['version'] );
+		$this->assertSame( 'Desc', $result['instructions'] );
 	}
 
 	public function test_handle_withUnsupportedVersion_negotiatesToLatest(): void {
@@ -196,11 +192,10 @@ final class InitializeHandlerTest extends TestCase {
 		$handler = new InitializeHandler( $server );
 		$result  = $handler->handle( '9999-99-99' );
 
-		$this->assertInstanceOf( InitializeResult::class, $result );
-		$this->assertSame( McpConstants::LATEST_PROTOCOL_VERSION, $result->getProtocolVersion() );
+		$this->assertSame( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION, $result['protocolVersion'] );
 
 		// Verify other fields are still correct.
-		$this->assertSame( 'Test Server', $result->getServerInfo()->getName() );
+		$this->assertSame( 'Test Server', $result['serverInfo']['name'] );
 	}
 
 	public function test_handle_withEmptyVersion_negotiatesToLatest(): void {
@@ -219,11 +214,10 @@ final class InitializeHandlerTest extends TestCase {
 		$handler = new InitializeHandler( $server );
 		$result  = $handler->handle( '' );
 
-		$this->assertInstanceOf( InitializeResult::class, $result );
-		$this->assertSame( McpConstants::LATEST_PROTOCOL_VERSION, $result->getProtocolVersion() );
+		$this->assertSame( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION, $result['protocolVersion'] );
 
 		// Verify other fields are still correct.
-		$this->assertSame( 'Test Server', $result->getServerInfo()->getName() );
+		$this->assertSame( 'Test Server', $result['serverInfo']['name'] );
 	}
 
 	public function test_handle_applies_initialize_response_filter(): void {
@@ -239,18 +233,17 @@ final class InitializeHandlerTest extends TestCase {
 			DummyObservabilityHandler::class,
 		);
 
-		$filter = static function ( InitializeResult $result ): InitializeResult {
-			$data                 = $result->toArray();
-			$data['instructions'] = 'Custom instructions';
+		$filter = static function ( array $result ): array {
+			$result['instructions'] = 'Custom instructions';
 
-			return InitializeResult::fromArray( $data );
+			return $result;
 		};
 		add_filter( 'mcp_adapter_initialize_response', $filter );
 
 		$handler = new InitializeHandler( $server );
-		$result  = $handler->handle( McpConstants::LATEST_PROTOCOL_VERSION );
+		$result  = $handler->handle( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION );
 
-		$this->assertSame( 'Custom instructions', $result->getInstructions() );
+		$this->assertSame( 'Custom instructions', $result['instructions'] );
 
 		remove_filter( 'mcp_adapter_initialize_response', $filter );
 	}

--- a/tests/phpunit/Unit/Handlers/InitializeHandlerTest.php
+++ b/tests/phpunit/Unit/Handlers/InitializeHandlerTest.php
@@ -10,6 +10,7 @@ use WP\MCP\Handlers\Initialize\InitializeHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Common\Protocol\DTO\InitializeResult;
 
 final class InitializeHandlerTest extends TestCase {
 
@@ -233,10 +234,12 @@ final class InitializeHandlerTest extends TestCase {
 			DummyObservabilityHandler::class,
 		);
 
-		$filter = static function ( array $result ): array {
-			$result['instructions'] = 'Custom instructions';
+		$filter = function ( InitializeResult $result ): InitializeResult {
+			$this->assertSame( 'Original instructions', $result->getInstructions() );
+			$data                 = $result->toArray();
+			$data['instructions'] = 'Custom instructions';
 
-			return $result;
+			return InitializeResult::fromArray( $data );
 		};
 		add_filter( 'mcp_adapter_initialize_response', $filter );
 

--- a/tests/phpunit/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/phpunit/Unit/Handlers/PromptsHandlerTest.php
@@ -10,6 +10,7 @@ use WP\MCP\Domain\Prompts\McpPrompt;
 use WP\MCP\Handlers\Prompts\PromptsHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
 use WP_Error;
 
 final class PromptsHandlerTest extends TestCase {
@@ -41,6 +42,24 @@ final class PromptsHandlerTest extends TestCase {
 		$this->assertSame( $expected, $result );
 	}
 
+	public function test_completed_execution_result_uses_existing_prompt_normalization(): void {
+		$prompt = McpPrompt::fromArray(
+			array(
+				'name'       => 'completed-prompt',
+				'handler'    => static fn(): McpExecutionResult => McpExecutionResult::complete( array( 'text' => 'done' ) ),
+				'permission' => '__return_true',
+			)
+		);
+		$this->assertInstanceOf( McpPrompt::class, $prompt );
+
+		$result = ( new PromptsHandler( $this->makeServer( array(), array(), array( $prompt ) ) ) )->get_prompt(
+			array( 'name' => 'completed-prompt' ),
+			1
+		);
+
+		$this->assertSame( 'done', $result['messages'][0]['content']['text'] );
+	}
+
 	public function test_list_prompts_returns_registered_prompts(): void {
 		wp_set_current_user( 1 );
 		$server  = $this->makeServer( array(), array(), array( 'test/prompt' ) );
@@ -56,7 +75,10 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
 		$handler = new PromptsHandler( $server );
 
-		$filter = static function (): array {
+		$filter = function ( array $prompts ): array {
+			$this->assertInstanceOf( Prompt::class, $prompts[0] );
+			$this->assertSame( 'test-always-allowed', $prompts[0]->getName() );
+
 			return array();
 		};
 		add_filter( 'mcp_adapter_prompts_list', $filter );

--- a/tests/phpunit/Unit/Handlers/PromptsHandlerTest.php
+++ b/tests/phpunit/Unit/Handlers/PromptsHandlerTest.php
@@ -4,17 +4,42 @@ declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Handlers;
 
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
+use WP\MCP\Domain\Prompts\McpPrompt;
 use WP\MCP\Handlers\Prompts\PromptsHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
-use WP\McpSchema\Server\Prompts\DTO\GetPromptResult;
-use WP\McpSchema\Server\Prompts\DTO\ListPromptsResult;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
-use WP\McpSchema\Server\Prompts\DTO\PromptMessage;
 use WP_Error;
 
 final class PromptsHandlerTest extends TestCase {
+
+	public function test_continuation_context_and_result_pass_through_unchanged(): void {
+		$received_context = null;
+		$expected         = McpExecutionResult::input_required( array(), 'prompt-state' );
+		$prompt           = McpPrompt::fromArray(
+			array(
+				'name'       => 'continuing-prompt',
+				'handler'    => static function ( array $arguments, McpContinuationContext $context ) use ( &$received_context, $expected ): McpExecutionResult {
+					$received_context = $context;
+
+					return $expected;
+				},
+				'permission' => '__return_true',
+			)
+		);
+		$this->assertInstanceOf( McpPrompt::class, $prompt );
+
+		$context = new McpContinuationContext( array(), 'previous-prompt-state' );
+		$result  = ( new PromptsHandler( $this->makeServer( array(), array(), array( $prompt ) ) ) )->get_prompt(
+			array( 'name' => 'continuing-prompt' ),
+			1,
+			$context
+		);
+
+		$this->assertSame( $context, $received_context );
+		$this->assertSame( $expected, $result );
+	}
 
 	public function test_list_prompts_returns_registered_prompts(): void {
 		wp_set_current_user( 1 );
@@ -22,11 +47,9 @@ final class PromptsHandlerTest extends TestCase {
 		$handler = new PromptsHandler( $server );
 		$result  = $handler->list_prompts();
 
-		// Returns ListPromptsResult DTO.
-		$this->assertInstanceOf( ListPromptsResult::class, $result );
-		$prompts = $result->getPrompts();
+		$prompts = $result['prompts'];
 		$this->assertNotEmpty( $prompts );
-		$this->assertContainsOnlyInstancesOf( PromptDto::class, $prompts );
+		$this->assertContainsOnly( 'array', $prompts );
 	}
 
 	public function test_list_prompts_applies_prompts_list_filter(): void {
@@ -39,8 +62,7 @@ final class PromptsHandlerTest extends TestCase {
 		add_filter( 'mcp_adapter_prompts_list', $filter );
 
 		$result = $handler->list_prompts();
-		$this->assertInstanceOf( ListPromptsResult::class, $result );
-		$this->assertEmpty( $result->getPrompts() );
+		$this->assertEmpty( $result['prompts'] );
 
 		remove_filter( 'mcp_adapter_prompts_list', $filter );
 	}
@@ -50,11 +72,8 @@ final class PromptsHandlerTest extends TestCase {
 		$handler = new PromptsHandler( $server );
 		$result  = $handler->get_prompt( array( 'params' => array() ) );
 
-		// Missing name is a protocol error - returns JSONRPCErrorResponse.
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32602, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 	}
 
 	public function test_get_prompt_unknown_returns_error(): void {
@@ -62,11 +81,8 @@ final class PromptsHandlerTest extends TestCase {
 		$handler = new PromptsHandler( $server );
 		$result  = $handler->get_prompt( array( 'params' => array( 'name' => 'unknown' ) ) );
 
-		// Prompt not found is a protocol error - returns JSONRPCErrorResponse.
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32004, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 	}
 
 	public function test_get_prompt_success_runs_ability(): void {
@@ -81,11 +97,9 @@ final class PromptsHandlerTest extends TestCase {
 			)
 		);
 
-		// Successful execution returns GetPromptResult DTO.
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertNotEmpty( $messages );
-		$this->assertContainsOnlyInstancesOf( PromptMessage::class, $messages );
+		$this->assertContainsOnly( 'array', $messages );
 	}
 
 	public function test_get_prompt_does_not_require_ability_lookup_at_runtime(): void {
@@ -134,9 +148,7 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$this->assertNotEmpty( $result->getMessages() );
+		$this->assertNotEmpty( $result['messages'] );
 	}
 
 	public function test_get_prompt_with_wp_error_from_execute(): void {
@@ -182,11 +194,8 @@ final class PromptsHandlerTest extends TestCase {
 			)
 		);
 
-		// WP_Error from execute is a protocol error - returns JSONRPCErrorResponse.
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32603, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 
 		// Clean up.
 		wp_unregister_ability( 'test/wp-error-prompt-execute' );
@@ -235,11 +244,8 @@ final class PromptsHandlerTest extends TestCase {
 			)
 		);
 
-		// Exception is a protocol error - returns JSONRPCErrorResponse.
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32603, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 
 		// Clean up.
 		wp_unregister_ability( 'test/prompt-execute-exception' );
@@ -249,9 +255,11 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/always-allowed' ) );
 		$handler = new PromptsHandler( $server );
 
-		$received_args = null;
-		$filter        = static function ( array $arguments, string $prompt_name ) use ( &$received_args ): array {
-			$received_args = $arguments;
+		$received_args        = null;
+		$received_prompt_name = null;
+		$filter               = static function ( array $arguments, string $prompt_name ) use ( &$received_args, &$received_prompt_name ): array {
+			$received_args        = $arguments;
+			$received_prompt_name = $prompt_name;
 
 			return $arguments;
 		};
@@ -268,6 +276,7 @@ final class PromptsHandlerTest extends TestCase {
 
 		$this->assertIsArray( $received_args );
 		$this->assertSame( 'value', $received_args['key'] );
+		$this->assertSame( 'test-always-allowed', $received_prompt_name );
 
 		remove_filter( 'mcp_adapter_pre_prompt_get', $filter );
 	}
@@ -290,12 +299,8 @@ final class PromptsHandlerTest extends TestCase {
 			)
 		);
 
-		// Short-circuit returns JSONRPCErrorResponse with internal_error code.
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertSame( -32603, $error->getCode() );
-		$this->assertStringContainsString( 'Prompt access blocked', $error->getMessage() );
+		$this->assertSame( -32603, $result['error']['code'] );
+		$this->assertStringContainsString( 'Prompt access blocked', $result['error']['message'] );
 
 		remove_filter( 'mcp_adapter_pre_prompt_get', $filter );
 	}
@@ -382,7 +387,7 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/tier1-prompt' ) );
 		$handler = new PromptsHandler( $server );
 
-		$result = $handler->get_prompt(
+		$result   = $handler->get_prompt(
 			array(
 				'params' => array(
 					'name'      => 'test-tier1-prompt',
@@ -390,12 +395,10 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertCount( 2, $messages );
-		$this->assertEquals( 'user', $messages[0]->getRole() );
-		$this->assertEquals( 'assistant', $messages[1]->getRole() );
+		$this->assertEquals( 'user', $messages[0]['role'] );
+		$this->assertEquals( 'assistant', $messages[1]['role'] );
 
 		wp_unregister_ability( 'test/tier1-prompt' );
 	}
@@ -434,7 +437,7 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/tier2-prompt' ) );
 		$handler = new PromptsHandler( $server );
 
-		$result = $handler->get_prompt(
+		$result   = $handler->get_prompt(
 			array(
 				'params' => array(
 					'name'      => 'test-tier2-prompt',
@@ -442,15 +445,13 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( 'user', $messages[0]->getRole() );
+		$this->assertEquals( 'user', $messages[0]['role'] );
 
-		$content = $messages[0]->getContent();
-		$this->assertEquals( 'text', $content->getType() );
-		$this->assertEquals( 'Simple text response', $content->getText() );
+		$content = $messages[0]['content'];
+		$this->assertEquals( 'text', $content['type'] );
+		$this->assertEquals( 'Simple text response', $content['text'] );
 
 		wp_unregister_ability( 'test/tier2-prompt' );
 	}
@@ -493,7 +494,7 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/tier3-prompt' ) );
 		$handler = new PromptsHandler( $server );
 
-		$result = $handler->get_prompt(
+		$result   = $handler->get_prompt(
 			array(
 				'params' => array(
 					'name'      => 'test-tier3-prompt',
@@ -501,15 +502,13 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( 'assistant', $messages[0]->getRole() );
+		$this->assertEquals( 'assistant', $messages[0]['role'] );
 
-		$content = $messages[0]->getContent();
-		$this->assertEquals( 'text', $content->getType() );
-		$this->assertEquals( 'Assistant message', $content->getText() );
+		$content = $messages[0]['content'];
+		$this->assertEquals( 'text', $content['type'] );
+		$this->assertEquals( 'Assistant message', $content['text'] );
 
 		wp_unregister_ability( 'test/tier3-prompt' );
 	}
@@ -552,7 +551,7 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/tier4-prompt' ) );
 		$handler = new PromptsHandler( $server );
 
-		$result = $handler->get_prompt(
+		$result   = $handler->get_prompt(
 			array(
 				'params' => array(
 					'name'      => 'test-tier4-prompt',
@@ -560,20 +559,18 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertCount( 3, $messages );
 
 		// All messages should have 'user' role (default).
 		foreach ( $messages as $message ) {
-			$this->assertEquals( 'user', $message->getRole() );
+			$this->assertEquals( 'user', $message['role'] );
 		}
 
 		// Verify message content.
-		$this->assertEquals( 'First message', $messages[0]->getContent()->getText() );
-		$this->assertEquals( 'Second message', $messages[1]->getContent()->getText() );
-		$this->assertEquals( 'Third message', $messages[2]->getContent()->getText() );
+		$this->assertEquals( 'First message', $messages[0]['content']['text'] );
+		$this->assertEquals( 'Second message', $messages[1]['content']['text'] );
+		$this->assertEquals( 'Third message', $messages[2]['content']['text'] );
 
 		wp_unregister_ability( 'test/tier4-prompt' );
 	}
@@ -616,7 +613,7 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/tier4-role-prompt' ) );
 		$handler = new PromptsHandler( $server );
 
-		$result = $handler->get_prompt(
+		$result   = $handler->get_prompt(
 			array(
 				'params' => array(
 					'name'      => 'test-tier4-role-prompt',
@@ -624,14 +621,12 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertCount( 2, $messages );
 
 		// All messages should have 'assistant' role.
 		foreach ( $messages as $message ) {
-			$this->assertEquals( 'assistant', $message->getRole() );
+			$this->assertEquals( 'assistant', $message['role'] );
 		}
 
 		wp_unregister_ability( 'test/tier4-role-prompt' );
@@ -674,7 +669,7 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/tier5-prompt' ) );
 		$handler = new PromptsHandler( $server );
 
-		$result = $handler->get_prompt(
+		$result   = $handler->get_prompt(
 			array(
 				'params' => array(
 					'name'      => 'test-tier5-prompt',
@@ -682,17 +677,15 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( 'user', $messages[0]->getRole() );
+		$this->assertEquals( 'user', $messages[0]['role'] );
 
 		// Content should be JSON-encoded.
-		$content = $messages[0]->getContent();
-		$this->assertEquals( 'text', $content->getType() );
+		$content = $messages[0]['content'];
+		$this->assertEquals( 'text', $content['type'] );
 
-		$decoded = json_decode( $content->getText(), true );
+		$decoded = json_decode( $content['text'], true );
 		$this->assertEquals( 'custom_value', $decoded['custom_key'] );
 		$this->assertEquals( 123, $decoded['nested']['data'] );
 
@@ -742,9 +735,7 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$this->assertEquals( 'Custom runtime description', $result->getDescription() );
+		$this->assertEquals( 'Custom runtime description', $result['description'] );
 
 		wp_unregister_ability( 'test/description-prompt' );
 	}
@@ -787,7 +778,7 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/invalid-role-prompt' ) );
 		$handler = new PromptsHandler( $server );
 
-		$result = $handler->get_prompt(
+		$result   = $handler->get_prompt(
 			array(
 				'params' => array(
 					'name'      => 'test-invalid-role-prompt',
@@ -795,12 +786,10 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertCount( 1, $messages );
 		// Invalid role should fall back to 'user'.
-		$this->assertEquals( 'user', $messages[0]->getRole() );
+		$this->assertEquals( 'user', $messages[0]['role'] );
 
 		wp_unregister_ability( 'test/invalid-role-prompt' );
 	}
@@ -848,7 +837,7 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/image-content-prompt' ) );
 		$handler = new PromptsHandler( $server );
 
-		$result = $handler->get_prompt(
+		$result   = $handler->get_prompt(
 			array(
 				'params' => array(
 					'name'      => 'test-image-content-prompt',
@@ -856,13 +845,11 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertCount( 1, $messages );
 
-		$content = $messages[0]->getContent();
-		$this->assertEquals( 'image', $content->getType() );
+		$content = $messages[0]['content'];
+		$this->assertEquals( 'image', $content['type'] );
 
 		wp_unregister_ability( 'test/image-content-prompt' );
 	}
@@ -909,7 +896,7 @@ final class PromptsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array(), array(), array( 'test/invalid-content-prompt' ) );
 		$handler = new PromptsHandler( $server );
 
-		$result = $handler->get_prompt(
+		$result   = $handler->get_prompt(
 			array(
 				'params' => array(
 					'name'      => 'test-invalid-content-prompt',
@@ -917,17 +904,15 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
-		$messages = $result->getMessages();
+		$messages = $result['messages'];
 		$this->assertCount( 1, $messages );
 
 		// Invalid content type should be converted to text.
-		$content = $messages[0]->getContent();
-		$this->assertEquals( 'text', $content->getType() );
+		$content = $messages[0]['content'];
+		$this->assertEquals( 'text', $content['type'] );
 
 		// The text should be JSON-encoded original content.
-		$decoded = json_decode( $content->getText(), true );
+		$decoded = json_decode( $content['text'], true );
 		$this->assertEquals( 'invalid_type', $decoded['type'] );
 		$this->assertEquals( 'some value', $decoded['value'] );
 
@@ -947,11 +932,8 @@ final class PromptsHandlerTest extends TestCase {
 			1
 		);
 
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertSame( -32602, $error->getCode() );
-		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
+		$this->assertSame( -32602, $result['error']['code'] );
+		$this->assertStringContainsString( 'arguments must be an object', $result['error']['message'] );
 	}
 
 	public function test_get_prompt_with_integer_arguments_returns_invalid_params_error(): void {
@@ -967,11 +949,8 @@ final class PromptsHandlerTest extends TestCase {
 			1
 		);
 
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertSame( -32602, $error->getCode() );
-		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
+		$this->assertSame( -32602, $result['error']['code'] );
+		$this->assertStringContainsString( 'arguments must be an object', $result['error']['message'] );
 	}
 
 	public function test_get_prompt_with_null_arguments_succeeds(): void {
@@ -987,7 +966,7 @@ final class PromptsHandlerTest extends TestCase {
 		);
 
 		// null arguments should default to empty array and succeed.
-		$this->assertInstanceOf( GetPromptResult::class, $result );
+		$this->assertNotEmpty( $result['messages'] );
 	}
 
 	public function test_get_prompt_with_missing_arguments_succeeds(): void {
@@ -1002,7 +981,7 @@ final class PromptsHandlerTest extends TestCase {
 		);
 
 		// Missing arguments should default to empty array and succeed.
-		$this->assertInstanceOf( GetPromptResult::class, $result );
+		$this->assertNotEmpty( $result['messages'] );
 	}
 
 	public function test_list_prompts_with_filter_returning_non_array_falls_back_to_original(): void {
@@ -1016,9 +995,7 @@ final class PromptsHandlerTest extends TestCase {
 
 		DummyErrorHandler::reset();
 		$result = $handler->list_prompts();
-
-		$this->assertInstanceOf( ListPromptsResult::class, $result );
-		$this->assertNotEmpty( $result->getPrompts() );
+		$this->assertNotEmpty( $result['prompts'] );
 
 		$this->assertNotEmpty( DummyErrorHandler::$logs );
 		$last_log = end( DummyErrorHandler::$logs );
@@ -1037,8 +1014,7 @@ final class PromptsHandlerTest extends TestCase {
 
 	/**
 	 * The nested form of a resource content block has two levels that each carry
-	 * `_meta`, and the DTO never sees the inner one - EmbeddedResource takes the
-	 * resource contents as given.
+	 * `_meta`; the handler validates each independently.
 	 */
 	public function test_embedded_resource_contents_meta_that_is_a_list_is_omitted(): void {
 		$result = $this->get_prompt_returning(
@@ -1059,8 +1035,6 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
 
 		$block = $this->first_content_block( $result );
 		$this->assertArrayNotHasKey( '_meta', $block );
@@ -1087,8 +1061,6 @@ final class PromptsHandlerTest extends TestCase {
 				),
 			)
 		);
-
-		$this->assertInstanceOf( GetPromptResult::class, $result );
 		$this->assertSame( array( 'block' => 'level' ), $this->first_content_block( $result )['_meta'] );
 		$this->assertSame(
 			array( 'ui' => array( 'prefersBorder' => true ) ),
@@ -1102,7 +1074,7 @@ final class PromptsHandlerTest extends TestCase {
 	 *
 	 * @param array $shape The prompt result to normalize.
 	 *
-	 * @return \WP\McpSchema\Server\Prompts\DTO\GetPromptResult|\WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array
 	 */
 	private function get_prompt_returning( array $shape ) {
 		$server  = $this->makeServer( array(), array(), array( 'test/prompt' ) );
@@ -1131,11 +1103,11 @@ final class PromptsHandlerTest extends TestCase {
 	/**
 	 * The emitted array of the first message's content block.
 	 *
-	 * @param \WP\McpSchema\Server\Prompts\DTO\GetPromptResult $result The prompt result.
+	 * @param array $result The prompt result.
 	 *
 	 * @return array
 	 */
-	private function first_content_block( GetPromptResult $result ): array {
-		return $result->getMessages()[0]->getContent()->toArray();
+	private function first_content_block( array $result ): array {
+		return $result['messages'][0]['content'];
 	}
 }

--- a/tests/phpunit/Unit/Handlers/ResourcesHandlerListTest.php
+++ b/tests/phpunit/Unit/Handlers/ResourcesHandlerListTest.php
@@ -9,6 +9,7 @@ use WP\MCP\Handlers\Resources\ResourcesHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Resources\DTO\Resource;
 
 final class ResourcesHandlerListTest extends TestCase {
 
@@ -61,7 +62,10 @@ final class ResourcesHandlerListTest extends TestCase {
 		$before = $handler->list_resources();
 		$this->assertNotEmpty( $before['resources'] );
 
-		$filter = static function (): array {
+		$filter = function ( array $resources ): array {
+			$this->assertInstanceOf( Resource::class, $resources[0] );
+			$this->assertSame( 'WordPress://local/resource-1', $resources[0]->getUri() );
+
 			return array();
 		};
 		add_filter( 'mcp_adapter_resources_list', $filter );

--- a/tests/phpunit/Unit/Handlers/ResourcesHandlerListTest.php
+++ b/tests/phpunit/Unit/Handlers/ResourcesHandlerListTest.php
@@ -9,13 +9,10 @@ use WP\MCP\Handlers\Resources\ResourcesHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Resources\DTO\ListResourceTemplatesResult;
-use WP\McpSchema\Server\Resources\DTO\ListResourcesResult;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
 final class ResourcesHandlerListTest extends TestCase {
 
-	public function test_list_resources_returns_dto(): void {
+	public function test_list_resources_returns_array(): void {
 		// Simulate logged-in for permission check.
 		wp_set_current_user( 1 );
 
@@ -36,16 +33,11 @@ final class ResourcesHandlerListTest extends TestCase {
 		$handler = new ResourcesHandler( $server );
 		$result  = $handler->list_resources();
 
-		// Verify it returns a ListResourcesResult DTO
-		$this->assertInstanceOf( ListResourcesResult::class, $result );
-
-		// Use DTO getter methods
-		$resources = $result->getResources();
+		$resources = $result['resources'];
 		$this->assertNotEmpty( $resources );
-		$this->assertContainsOnlyInstancesOf( ResourceDto::class, $resources );
+		$this->assertContainsOnly( 'array', $resources );
 
-		// Verify Resource DTO structure via toArray() for field checks
-		$resource_array = $resources[0]->toArray();
+		$resource_array = $resources[0];
 		$this->assertArrayHasKey( 'uri', $resource_array );
 		$this->assertArrayHasKey( 'name', $resource_array );
 	}
@@ -58,8 +50,7 @@ final class ResourcesHandlerListTest extends TestCase {
 
 		// The adapter has no resource-template concept, so the list is always empty,
 		// but the method must still respond so spec-compliant clients stop getting -32601.
-		$this->assertInstanceOf( ListResourceTemplatesResult::class, $result );
-		$this->assertSame( array(), $result->getResourceTemplates() );
+		$this->assertSame( array( 'resourceTemplates' => array() ), $result );
 	}
 
 	public function test_list_resources_applies_resources_list_filter(): void {
@@ -68,7 +59,7 @@ final class ResourcesHandlerListTest extends TestCase {
 
 		// Verify resources exist before filtering.
 		$before = $handler->list_resources();
-		$this->assertNotEmpty( $before->getResources() );
+		$this->assertNotEmpty( $before['resources'] );
 
 		$filter = static function (): array {
 			return array();
@@ -76,8 +67,7 @@ final class ResourcesHandlerListTest extends TestCase {
 		add_filter( 'mcp_adapter_resources_list', $filter );
 
 		$result = $handler->list_resources();
-		$this->assertInstanceOf( ListResourcesResult::class, $result );
-		$this->assertEmpty( $result->getResources() );
+		$this->assertSame( array( 'resources' => array() ), $result );
 
 		remove_filter( 'mcp_adapter_resources_list', $filter );
 	}
@@ -132,8 +122,7 @@ final class ResourcesHandlerListTest extends TestCase {
 		$result = $handler->list_resources();
 
 		// Verify the resource is in the list.
-		$this->assertInstanceOf( ListResourcesResult::class, $result );
-		$resources = $result->getResources();
+		$resources = $result['resources'];
 		$this->assertNotEmpty( $resources );
 
 		// Verify execute was NOT called.
@@ -150,12 +139,11 @@ final class ResourcesHandlerListTest extends TestCase {
 		$handler = new ResourcesHandler( $server );
 		$result  = $handler->list_resources();
 
-		$this->assertInstanceOf( ListResourcesResult::class, $result );
-		$resources = $result->getResources();
+		$resources = $result['resources'];
 		$this->assertNotEmpty( $resources );
 
 		// Verify the resource contains metadata fields.
-		$resource_array = $resources[0]->toArray();
+		$resource_array = $resources[0];
 
 		// Required metadata fields.
 		$this->assertArrayHasKey( 'uri', $resource_array );
@@ -183,8 +171,7 @@ final class ResourcesHandlerListTest extends TestCase {
 		DummyErrorHandler::reset();
 		$result = $handler->list_resources();
 
-		$this->assertInstanceOf( ListResourcesResult::class, $result );
-		$this->assertNotEmpty( $result->getResources() );
+		$this->assertNotEmpty( $result['resources'] );
 
 		$this->assertNotEmpty( DummyErrorHandler::$logs );
 		$last_log = end( DummyErrorHandler::$logs );

--- a/tests/phpunit/Unit/Handlers/ResourcesHandlerReadTest.php
+++ b/tests/phpunit/Unit/Handlers/ResourcesHandlerReadTest.php
@@ -42,6 +42,25 @@ final class ResourcesHandlerReadTest extends TestCase {
 		$this->assertSame( $expected, $result );
 	}
 
+	public function test_completed_execution_result_uses_existing_resource_normalization(): void {
+		$resource = McpResource::fromArray(
+			array(
+				'uri'        => 'test://completed-resource',
+				'name'       => 'Completed resource',
+				'handler'    => static fn(): McpExecutionResult => McpExecutionResult::complete( 'done' ),
+				'permission' => '__return_true',
+			)
+		);
+		$this->assertInstanceOf( McpResource::class, $resource );
+
+		$result = ( new ResourcesHandler( $this->makeServer( array(), array( $resource ) ) ) )->read_resource(
+			array( 'uri' => 'test://completed-resource' ),
+			1
+		);
+
+		$this->assertSame( 'done', $result['contents'][0]['text'] );
+	}
+
 	public function test_missing_uri_returns_error(): void {
 		wp_set_current_user( 1 );
 		$server  = $this->makeServer( array(), array( 'test/resource' ) );

--- a/tests/phpunit/Unit/Handlers/ResourcesHandlerReadTest.php
+++ b/tests/phpunit/Unit/Handlers/ResourcesHandlerReadTest.php
@@ -4,14 +4,43 @@ declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Handlers;
 
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
+use WP\MCP\Domain\Resources\McpResource;
 use WP\MCP\Handlers\Resources\ResourcesHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
-use WP\McpSchema\Common\Protocol\DTO\BlobResourceContents;
-use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
-use WP\McpSchema\Server\Resources\DTO\ReadResourceResult;
 
 final class ResourcesHandlerReadTest extends TestCase {
+
+	public function test_continuation_context_and_result_pass_through_unchanged(): void {
+		$received_context = null;
+		$expected         = McpExecutionResult::input_required(
+			array( 'choose' => array( 'method' => 'elicitation/create' ) )
+		);
+		$resource         = McpResource::fromArray(
+			array(
+				'uri'        => 'test://continuing-resource',
+				'name'       => 'Continuing resource',
+				'handler'    => static function ( array $arguments, McpContinuationContext $context ) use ( &$received_context, $expected ): McpExecutionResult {
+					$received_context = $context;
+
+					return $expected;
+				},
+				'permission' => '__return_true',
+			)
+		);
+		$this->assertInstanceOf( McpResource::class, $resource );
+
+		$context = new McpContinuationContext( array( 'choose' => 'one' ) );
+		$result  = ( new ResourcesHandler( $this->makeServer( array(), array( $resource ) ) ) )->read_resource(
+			array( 'uri' => 'test://continuing-resource' ),
+			1,
+			$context
+		);
+
+		$this->assertSame( $context, $received_context );
+		$this->assertSame( $expected, $result );
+	}
 
 	public function test_missing_uri_returns_error(): void {
 		wp_set_current_user( 1 );
@@ -19,11 +48,8 @@ final class ResourcesHandlerReadTest extends TestCase {
 		$handler = new ResourcesHandler( $server );
 		$result  = $handler->read_resource( array( 'params' => array() ) );
 
-		// Missing uri is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32602, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 	}
 
 	public function test_unknown_resource_returns_error(): void {
@@ -32,11 +58,8 @@ final class ResourcesHandlerReadTest extends TestCase {
 		$handler = new ResourcesHandler( $server );
 		$result  = $handler->read_resource( array( 'params' => array( 'uri' => 'WordPress://missing' ) ) );
 
-		// Resource not found is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32002, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 	}
 
 	public function test_successful_read_returns_contents(): void {
@@ -45,13 +68,9 @@ final class ResourcesHandlerReadTest extends TestCase {
 		$handler = new ResourcesHandler( $server );
 		$result  = $handler->read_resource( array( 'params' => array( 'uri' => 'WordPress://local/resource-1' ) ) );
 
-		// Successful read returns ReadResourceResult DTO
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		// Use DTO getter methods
-		$contents = $result->getContents();
+		$contents = $result['contents'];
 		$this->assertNotEmpty( $contents );
-		$this->assertInstanceOf( TextResourceContents::class, $contents[0] );
+		$this->assertArrayHasKey( 'text', $contents[0] );
 	}
 
 	public function test_read_resource_returns_blob_contents_for_blob_data(): void {
@@ -64,21 +83,15 @@ final class ResourcesHandlerReadTest extends TestCase {
 			array( 'params' => array( 'uri' => 'WordPress://local/resource-blob-content' ) )
 		);
 
-		// Successful read returns ReadResourceResult DTO.
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		$contents = $result->getContents();
+		$contents = $result['contents'];
 		$this->assertNotEmpty( $contents );
 
-		// Should be BlobResourceContents since ability returns blob data.
-		$this->assertInstanceOf( BlobResourceContents::class, $contents[0] );
-
 		// Verify blob content.
-		$blob = $contents[0]->getBlob();
+		$blob = $contents[0]['blob'];
 		$this->assertNotEmpty( $blob );
 
 		// Verify mimeType is preserved.
-		$this->assertSame( 'application/octet-stream', $contents[0]->getMimeType() );
+		$this->assertSame( 'application/octet-stream', $contents[0]['mimeType'] );
 	}
 
 	public function test_read_resource_handles_multiple_content_items(): void {
@@ -91,22 +104,16 @@ final class ResourcesHandlerReadTest extends TestCase {
 			array( 'params' => array( 'uri' => 'WordPress://local/resource-multiple-contents' ) )
 		);
 
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		$contents = $result->getContents();
+		$contents = $result['contents'];
 		$this->assertCount( 2, $contents, 'Should have 2 content items' );
 
-		// Both should be TextResourceContents.
-		$this->assertInstanceOf( TextResourceContents::class, $contents[0] );
-		$this->assertInstanceOf( TextResourceContents::class, $contents[1] );
-
 		// Verify content.
-		$this->assertSame( 'First content part', $contents[0]->getText() );
-		$this->assertSame( 'Second content part', $contents[1]->getText() );
+		$this->assertSame( 'First content part', $contents[0]['text'] );
+		$this->assertSame( 'Second content part', $contents[1]['text'] );
 
 		// Verify URIs are preserved.
-		$this->assertSame( 'WordPress://local/resource-multi/part1', $contents[0]->getUri() );
-		$this->assertSame( 'WordPress://local/resource-multi/part2', $contents[1]->getUri() );
+		$this->assertSame( 'WordPress://local/resource-multi/part1', $contents[0]['uri'] );
+		$this->assertSame( 'WordPress://local/resource-multi/part2', $contents[1]['uri'] );
 	}
 
 	public function test_read_resource_returns_text_with_custom_mimetype(): void {
@@ -119,17 +126,14 @@ final class ResourcesHandlerReadTest extends TestCase {
 			array( 'params' => array( 'uri' => 'WordPress://local/resource-text-with-mimetype' ) )
 		);
 
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		$contents = $result->getContents();
+		$contents = $result['contents'];
 		$this->assertNotEmpty( $contents );
-		$this->assertInstanceOf( TextResourceContents::class, $contents[0] );
 
 		// Verify mimeType is preserved.
-		$this->assertSame( 'application/json', $contents[0]->getMimeType() );
+		$this->assertSame( 'application/json', $contents[0]['mimeType'] );
 
 		// Verify content.
-		$this->assertSame( '{"key": "value"}', $contents[0]->getText() );
+		$this->assertSame( '{"key": "value"}', $contents[0]['text'] );
 	}
 
 	public function test_read_resource_wraps_plain_string_as_text(): void {
@@ -142,17 +146,14 @@ final class ResourcesHandlerReadTest extends TestCase {
 			array( 'params' => array( 'uri' => 'WordPress://local/resource-plain-string' ) )
 		);
 
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		$contents = $result->getContents();
+		$contents = $result['contents'];
 		$this->assertNotEmpty( $contents );
-		$this->assertInstanceOf( TextResourceContents::class, $contents[0] );
 
 		// Verify content is the plain string.
-		$this->assertSame( 'plain string content', $contents[0]->getText() );
+		$this->assertSame( 'plain string content', $contents[0]['text'] );
 
 		// Verify URI is the resource URI.
-		$this->assertSame( 'WordPress://local/resource-plain-string', $contents[0]->getUri() );
+		$this->assertSame( 'WordPress://local/resource-plain-string', $contents[0]['uri'] );
 	}
 
 	public function test_read_resource_with_lowercased_scheme_echoes_advertised_uri(): void {
@@ -169,13 +170,11 @@ final class ResourcesHandlerReadTest extends TestCase {
 			array( 'params' => array( 'uri' => 'wordpress://local/resource-plain-string' ) ) // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- The lowercase scheme is the point of the test.
 		);
 
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		$contents = $result->getContents();
+		$contents = $result['contents'];
 		$this->assertNotEmpty( $contents );
 		$this->assertSame(
 			'WordPress://local/resource-plain-string',
-			$contents[0]->getUri(),
+			$contents[0]['uri'],
 			'Read response must echo the advertised URI, not the client-lowercased scheme.'
 		);
 	}
@@ -186,8 +185,10 @@ final class ResourcesHandlerReadTest extends TestCase {
 		$handler = new ResourcesHandler( $server );
 
 		$received_params = null;
-		$filter          = static function ( array $params, string $uri ) use ( &$received_params ): array {
+		$received_uri    = null;
+		$filter          = static function ( array $params, string $uri ) use ( &$received_params, &$received_uri ): array {
 			$received_params = $params;
+			$received_uri    = $uri;
 
 			return $params;
 		};
@@ -200,6 +201,7 @@ final class ResourcesHandlerReadTest extends TestCase {
 		);
 
 		$this->assertIsArray( $received_params );
+		$this->assertSame( 'WordPress://local/resource-1', $received_uri );
 
 		remove_filter( 'mcp_adapter_pre_resource_read', $filter );
 	}
@@ -220,11 +222,7 @@ final class ResourcesHandlerReadTest extends TestCase {
 			)
 		);
 
-		// Short-circuit returns JSONRPCErrorResponse.
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertStringContainsString( 'Resource access blocked', $error->getMessage() );
+		$this->assertStringContainsString( 'Resource access blocked', $result['error']['message'] );
 
 		remove_filter( 'mcp_adapter_pre_resource_read', $filter );
 	}
@@ -289,14 +287,11 @@ final class ResourcesHandlerReadTest extends TestCase {
 			array( 'params' => array( 'uri' => 'WordPress://local/resource-object-result' ) )
 		);
 
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		$contents = $result->getContents();
+		$contents = $result['contents'];
 		$this->assertNotEmpty( $contents );
-		$this->assertInstanceOf( TextResourceContents::class, $contents[0] );
 
 		// Verify content is JSON-encoded.
-		$text = $contents[0]->getText();
+		$text = $contents[0]['text'];
 		$this->assertJson( $text );
 		$decoded = json_decode( $text, true );
 		$this->assertSame( 'ok', $decoded['status'] );
@@ -322,8 +317,7 @@ final class ResourcesHandlerReadTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertStringContainsString( 'Failed to read resource', $result->getError()->getMessage() );
+		$this->assertStringContainsString( 'Failed to read resource', $result['error']['message'] );
 
 		remove_filter( 'mcp_adapter_resource_read_result', $filter );
 	}
@@ -351,11 +345,8 @@ final class ResourcesHandlerReadTest extends TestCase {
 
 		remove_filter( 'mcp_adapter_resource_read_result', $filter );
 
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		$contents = $result->getContents();
-		$this->assertInstanceOf( TextResourceContents::class, $contents[0] );
-		$this->assertSame( array( 'ui' => array( 'prefersBorder' => true ) ), $contents[0]->get_meta() );
+		$contents = $result['contents'];
+		$this->assertSame( array( 'ui' => array( 'prefersBorder' => true ) ), $contents[0]['_meta'] );
 	}
 
 	public function test_read_resource_with_list_meta_omits_it_from_the_wire(): void {
@@ -380,13 +371,10 @@ final class ResourcesHandlerReadTest extends TestCase {
 
 		remove_filter( 'mcp_adapter_resource_read_result', $filter );
 
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		$contents = $result->getContents();
-		$this->assertNull( $contents[0]->get_meta() );
+		$contents = $result['contents'];
 
 		// MCP declares _meta as a JSON object; a list would serialize as `"_meta": ["a","b"]`.
-		$this->assertArrayNotHasKey( '_meta', $contents[0]->toArray() );
+		$this->assertArrayNotHasKey( '_meta', $contents[0] );
 	}
 
 	public function test_read_resource_with_blob_only_item_preserves_meta(): void {
@@ -411,11 +399,8 @@ final class ResourcesHandlerReadTest extends TestCase {
 
 		remove_filter( 'mcp_adapter_resource_read_result', $filter );
 
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		$contents = $result->getContents();
-		$this->assertInstanceOf( BlobResourceContents::class, $contents[0] );
-		$this->assertSame( 'WordPress://local/resource-1', $contents[0]->getUri() );
-		$this->assertSame( array( 'pages' => 3 ), $contents[0]->get_meta() );
+		$contents = $result['contents'];
+		$this->assertSame( 'WordPress://local/resource-1', $contents[0]['uri'] );
+		$this->assertSame( array( 'pages' => 3 ), $contents[0]['_meta'] );
 	}
 }

--- a/tests/phpunit/Unit/Handlers/ResourcesHandlerTest.php
+++ b/tests/phpunit/Unit/Handlers/ResourcesHandlerTest.php
@@ -11,11 +11,6 @@ namespace WP\MCP\Tests\Unit\Handlers;
 
 use WP\MCP\Handlers\Resources\ResourcesHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
-use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
-use WP\McpSchema\Server\Resources\DTO\ListResourcesResult;
-use WP\McpSchema\Server\Resources\DTO\ReadResourceResult;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 use WP_Error;
 
 /**
@@ -23,13 +18,13 @@ use WP_Error;
  */
 final class ResourcesHandlerTest extends TestCase {
 
-	public function test_list_resources_returns_dto(): void {
+	public function test_list_resources_returns_array(): void {
 		wp_set_current_user( 1 );
 		$server  = $this->makeServer( array(), array( 'test/resource' ), array() );
 		$handler = new ResourcesHandler( $server );
 		$result  = $handler->list_resources();
 
-		$this->assertInstanceOf( ListResourcesResult::class, $result );
+		$this->assertArrayHasKey( 'resources', $result );
 	}
 
 	public function test_list_resources_returns_registered_resources(): void {
@@ -38,10 +33,9 @@ final class ResourcesHandlerTest extends TestCase {
 		$handler = new ResourcesHandler( $server );
 		$result  = $handler->list_resources();
 
-		// Use DTO getter methods
-		$resources = $result->getResources();
+		$resources = $result['resources'];
 		$this->assertNotEmpty( $resources );
-		$this->assertContainsOnlyInstancesOf( ResourceDto::class, $resources );
+		$this->assertContainsOnly( 'array', $resources );
 	}
 
 	public function test_list_resources_returns_empty_array_when_no_resources(): void {
@@ -49,8 +43,7 @@ final class ResourcesHandlerTest extends TestCase {
 		$handler = new ResourcesHandler( $server );
 		$result  = $handler->list_resources();
 
-		// Use DTO getter methods
-		$resources = $result->getResources();
+		$resources = $result['resources'];
 		$this->assertIsArray( $resources );
 		$this->assertEmpty( $resources );
 	}
@@ -60,11 +53,8 @@ final class ResourcesHandlerTest extends TestCase {
 		$handler = new ResourcesHandler( $server );
 		$result  = $handler->read_resource( array( 'params' => array() ) );
 
-		// Missing uri is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32602, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 	}
 
 	public function test_read_resource_not_found_returns_error(): void {
@@ -78,11 +68,8 @@ final class ResourcesHandlerTest extends TestCase {
 			)
 		);
 
-		// Resource not found is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32002, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 	}
 
 	public function test_read_resource_with_wp_error_from_get_ability(): void {
@@ -126,11 +113,9 @@ final class ResourcesHandlerTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-		$contents = $result->getContents();
+		$contents = $result['contents'];
 		$this->assertNotEmpty( $contents );
-		$this->assertInstanceOf( TextResourceContents::class, $contents[0] );
-		$this->assertSame( 'ok', $contents[0]->getText() );
+		$this->assertSame( 'ok', $contents[0]['text'] );
 	}
 
 	public function test_read_resource_with_wp_error_from_execute(): void {
@@ -174,11 +159,8 @@ final class ResourcesHandlerTest extends TestCase {
 			)
 		);
 
-		// WP_Error from execute is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32603, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 
 		// Clean up
 		wp_unregister_ability( 'test/wp-error-resource-execute' );
@@ -225,11 +207,8 @@ final class ResourcesHandlerTest extends TestCase {
 			)
 		);
 
-		// Exception is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32603, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 
 		// Clean up
 		wp_unregister_ability( 'test/resource-execute-exception' );
@@ -253,12 +232,8 @@ final class ResourcesHandlerTest extends TestCase {
 			)
 		);
 
-		// Successful read returns ReadResourceResult DTO
-		$this->assertInstanceOf( ReadResourceResult::class, $result );
-
-		// Use DTO getter methods
-		$contents = $result->getContents();
+		$contents = $result['contents'];
 		$this->assertNotEmpty( $contents );
-		$this->assertInstanceOf( TextResourceContents::class, $contents[0] );
+		$this->assertArrayHasKey( 'text', $contents[0] );
 	}
 }

--- a/tests/phpunit/Unit/Handlers/SystemHandlerTest.php
+++ b/tests/phpunit/Unit/Handlers/SystemHandlerTest.php
@@ -6,14 +6,12 @@ namespace WP\MCP\Tests\Unit\Handlers;
 
 use WP\MCP\Handlers\System\SystemHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\Protocol\DTO\Result;
 
 final class SystemHandlerTest extends TestCase {
 
 	public function test_ping_returns_empty_array(): void {
 		$handler = new SystemHandler();
 		$result  = $handler->ping();
-		$this->assertInstanceOf( Result::class, $result );
-		$this->assertSame( array(), $result->toArray() );
+		$this->assertSame( array(), $result );
 	}
 }

--- a/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
@@ -4,31 +4,52 @@ declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Handlers;
 
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
+use WP\MCP\Domain\Tools\McpTool;
 use WP\MCP\Handlers\Tools\ToolsHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\Content\DTO\ImageContent;
-use WP\McpSchema\Common\Content\DTO\TextContent;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
-use WP\McpSchema\Common\Protocol\DTO\BlobResourceContents;
-use WP\McpSchema\Common\Protocol\DTO\EmbeddedResource;
-use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
-use WP\McpSchema\Server\Tools\DTO\CallToolResult;
 
 final class ToolsHandlerCallTest extends TestCase {
+
+	public function test_continuation_context_and_result_pass_through_unchanged(): void {
+		$received_context = null;
+		$expected         = McpExecutionResult::input_required(
+			array( 'confirm' => array( 'method' => 'elicitation/create' ) ),
+			'opaque-state'
+		);
+		$tool             = McpTool::fromArray(
+			array(
+				'name'       => 'continuing-tool',
+				'handler'    => static function ( array $arguments, McpContinuationContext $context ) use ( &$received_context, $expected ): McpExecutionResult {
+					$received_context = $context;
+
+					return $expected;
+				},
+				'permission' => '__return_true',
+			)
+		);
+		$this->assertInstanceOf( McpTool::class, $tool );
+
+		$context = new McpContinuationContext( array( 'confirm' => true ), 'previous-state' );
+		$result  = ( new ToolsHandler( $this->makeServer( array( $tool ) ) ) )->call_tool(
+			array( 'name' => 'continuing-tool' ),
+			1,
+			$context
+		);
+
+		$this->assertSame( $context, $received_context );
+		$this->assertSame( $expected, $result );
+	}
 
 	public function test_missing_name_returns_missing_parameter_error(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->call_tool( array( 'params' => array( 'arguments' => array() ) ) );
 
-		// Missing name is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getCode() );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32602, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 	}
 
 	public function test_unknown_tool_logs_and_returns_error(): void {
@@ -36,12 +57,8 @@ final class ToolsHandlerCallTest extends TestCase {
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->call_tool( array( 'params' => array( 'name' => 'nope' ) ) );
 
-		// Tool not found is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32003, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 		$this->assertNotEmpty( DummyErrorHandler::$logs );
 	}
 
@@ -54,14 +71,11 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		// Permission denied is a tool execution error - returns CallToolResult with isError
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
-		$this->assertStringContainsString( 'Permission denied', $content[0]->getText() );
+		$this->assertSame( 'text', $content[0]['type'] );
+		$this->assertStringContainsString( 'Permission denied', $content[0]['text'] );
 	}
 
 	public function test_permission_exception_logs_and_returns_error(): void {
@@ -73,13 +87,10 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		// Permission check exception is a tool execution error - returns CallToolResult with isError
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
+		$this->assertSame( 'text', $content[0]['type'] );
 		$this->assertNotEmpty( DummyErrorHandler::$logs );
 	}
 
@@ -92,14 +103,10 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		// Execute exceptions are tool execution errors - returns CallToolResult with isError
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
-		$this->assertEquals( 'text', $content[0]->getType() );
+		$this->assertSame( 'text', $content[0]['type'] );
 		$this->assertNotEmpty( DummyErrorHandler::$logs );
 	}
 
@@ -112,15 +119,11 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		// Successful image result returns CallToolResult
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$content = $result->getContent();
+		$content = $result['content'];
 		$this->assertNotEmpty( $content, 'Content array should not be empty' );
-		$this->assertInstanceOf( ImageContent::class, $content[0] );
-		$this->assertSame( 'image', $content[0]->getType() );
-		$this->assertNotEmpty( $content[0]->getData() );
-		$this->assertNotEmpty( $content[0]->getMimeType() );
+		$this->assertSame( 'image', $content[0]['type'] );
+		$this->assertNotEmpty( $content[0]['data'] );
+		$this->assertNotEmpty( $content[0]['mimeType'] );
 	}
 
 	public function test_embedded_text_resource_result_is_converted_to_embedded_resource_content_block(): void {
@@ -132,18 +135,15 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		$content = $result->getContent();
+		$content = $result['content'];
 		$this->assertNotEmpty( $content, 'Content array should not be empty' );
 
-		$this->assertInstanceOf( EmbeddedResource::class, $content[0] );
-		$this->assertSame( 'resource', $content[0]->getType() );
+		$this->assertSame( 'resource', $content[0]['type'] );
 
-		$resource = $content[0]->getResource();
-		$this->assertInstanceOf( TextResourceContents::class, $resource );
-		$this->assertSame( 'WordPress://local/tool-embedded-text', $resource->getUri() );
-		$this->assertSame( 'text/plain', $resource->getMimeType() );
-		$this->assertSame( 'hello from embedded resource', $resource->getText() );
+		$resource = $content[0]['resource'];
+		$this->assertSame( 'WordPress://local/tool-embedded-text', $resource['uri'] );
+		$this->assertSame( 'text/plain', $resource['mimeType'] );
+		$this->assertSame( 'hello from embedded resource', $resource['text'] );
 	}
 
 	public function test_embedded_blob_resource_result_is_converted_to_embedded_resource_content_block(): void {
@@ -155,27 +155,26 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		$content = $result->getContent();
+		$content = $result['content'];
 		$this->assertNotEmpty( $content, 'Content array should not be empty' );
 
-		$this->assertInstanceOf( EmbeddedResource::class, $content[0] );
-		$this->assertSame( 'resource', $content[0]->getType() );
+		$this->assertSame( 'resource', $content[0]['type'] );
 
-		$resource = $content[0]->getResource();
-		$this->assertInstanceOf( BlobResourceContents::class, $resource );
-		$this->assertSame( 'WordPress://local/tool-embedded-blob', $resource->getUri() );
-		$this->assertSame( 'application/octet-stream', $resource->getMimeType() );
-		$this->assertSame( base64_encode( 'blob-bytes' ), $resource->getBlob() ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$resource = $content[0]['resource'];
+		$this->assertSame( 'WordPress://local/tool-embedded-blob', $resource['uri'] );
+		$this->assertSame( 'application/octet-stream', $resource['mimeType'] );
+		$this->assertSame( base64_encode( 'blob-bytes' ), $resource['blob'] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
 	public function test_pre_tool_call_filter_can_modify_arguments(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 
-		$received_args = null;
-		$filter        = static function ( array $args, string $tool_name ) use ( &$received_args ): array {
+		$received_args      = null;
+		$received_tool_name = null;
+		$filter             = static function ( array $args, string $tool_name ) use ( &$received_args, &$received_tool_name ): array {
 			$received_args              = $args;
+			$received_tool_name         = $tool_name;
 			$args['injected_by_filter'] = true;
 
 			return $args;
@@ -193,6 +192,7 @@ final class ToolsHandlerCallTest extends TestCase {
 
 		$this->assertIsArray( $received_args );
 		$this->assertSame( 'value', $received_args['key'] );
+		$this->assertSame( 'test-always-allowed', $received_tool_name );
 
 		remove_filter( 'mcp_adapter_pre_tool_call', $filter );
 	}
@@ -215,12 +215,10 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		// Short-circuit returns CallToolResult with isError=true.
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertStringContainsString( 'Rate limit exceeded', $content[0]->getText() );
+		$this->assertStringContainsString( 'Rate limit exceeded', $content[0]['text'] );
 
 		remove_filter( 'mcp_adapter_pre_tool_call', $filter );
 	}
@@ -247,9 +245,7 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		// The result filter modifies the raw result before DTO assembly.
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		$structured = $result->getStructuredContent();
+		$structured = $result['structuredContent'];
 		$this->assertNotNull( $structured );
 		$this->assertTrue( $structured['filtered'] );
 
@@ -269,14 +265,12 @@ final class ToolsHandlerCallTest extends TestCase {
 			1
 		);
 
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		$this->assertFalse( (bool) $result->getIsError() );
+		$this->assertFalse( $result['isError'] );
 
-		$content = $result->getContent();
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
 
-			$text = $content[0]->getText();
+			$text = $content[0]['text'];
 			$this->assertStringContainsString( 'mcp_adapter', $text );
 
 			$decoded = json_decode( $text, true );
@@ -287,7 +281,7 @@ final class ToolsHandlerCallTest extends TestCase {
 			$this->assertSame( 'nested', $decoded['nested']['_meta']['keep'] );
 			$this->assertArrayHasKey( 'mcp_adapter', $decoded['nested']['_meta'] );
 
-			$structured = $result->getStructuredContent();
+			$structured = $result['structuredContent'];
 			$this->assertIsArray( $structured );
 			$this->assertArrayHasKey( '_meta', $structured );
 			$this->assertArrayHasKey( 'mcp_adapter', $structured['_meta'] );
@@ -307,11 +301,8 @@ final class ToolsHandlerCallTest extends TestCase {
 			1
 		);
 
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertSame( -32602, $error->getCode() );
-		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
+		$this->assertSame( -32602, $result['error']['code'] );
+		$this->assertStringContainsString( 'arguments must be an object', $result['error']['message'] );
 	}
 
 	public function test_call_tool_with_integer_arguments_returns_invalid_params_error(): void {
@@ -327,11 +318,8 @@ final class ToolsHandlerCallTest extends TestCase {
 			1
 		);
 
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertSame( -32602, $error->getCode() );
-		$this->assertStringContainsString( 'arguments must be an object', $error->getMessage() );
+		$this->assertSame( -32602, $result['error']['code'] );
+		$this->assertStringContainsString( 'arguments must be an object', $result['error']['message'] );
 	}
 
 	public function test_call_tool_with_null_arguments_succeeds(): void {
@@ -347,9 +335,7 @@ final class ToolsHandlerCallTest extends TestCase {
 			1
 		);
 
-		// null arguments should default to empty array and succeed.
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		$this->assertFalse( (bool) $result->getIsError() );
+		$this->assertFalse( $result['isError'] );
 	}
 
 	public function test_call_tool_with_missing_arguments_succeeds(): void {
@@ -364,9 +350,7 @@ final class ToolsHandlerCallTest extends TestCase {
 			1
 		);
 
-		// Missing arguments should default to empty array and succeed.
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		$this->assertFalse( (bool) $result->getIsError() );
+		$this->assertFalse( $result['isError'] );
 	}
 
 	/**
@@ -374,7 +358,7 @@ final class ToolsHandlerCallTest extends TestCase {
 	 *
 	 * @param array $shape The embedded resource result to substitute.
 	 *
-	 * @return \WP\McpSchema\Server\Tools\DTO\CallToolResult|\WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
+	 * @return array
 	 */
 	private function call_tool_returning( array $shape ) {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
@@ -403,9 +387,9 @@ final class ToolsHandlerCallTest extends TestCase {
 	public function test_embedded_resource_nested_shape_preserves_meta_on_both_levels(): void {
 		$result = $this->call_tool_returning(
 			array(
-				'type'        => 'resource',
-				'_meta'       => array( 'block' => 'level' ),
-				'resource'    => array(
+				'type'     => 'resource',
+				'_meta'    => array( 'block' => 'level' ),
+				'resource' => array(
 					'uri'      => 'ui://example/app',
 					'mimeType' => 'text/html;profile=mcp-app',
 					'text'     => '<!doctype html>',
@@ -414,18 +398,14 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( CallToolResult::class, $result );
-
-		$content = $result->getContent();
-		$this->assertInstanceOf( EmbeddedResource::class, $content[0] );
+		$content = $result['content'];
 
 		// The outer `_meta` belongs to the content block.
-		$this->assertSame( array( 'block' => 'level' ), $content[0]->get_meta() );
+		$this->assertSame( array( 'block' => 'level' ), $content[0]['_meta'] );
 
 		// The nested _meta belongs to the resource contents.
-		$resource = $content[0]->getResource();
-		$this->assertInstanceOf( TextResourceContents::class, $resource );
-		$this->assertSame( array( 'ui' => array( 'prefersBorder' => true ) ), $resource->get_meta() );
+		$resource = $content[0]['resource'];
+		$this->assertSame( array( 'ui' => array( 'prefersBorder' => true ) ), $resource['_meta'] );
 	}
 
 	public function test_embedded_resource_flat_shape_assigns_meta_to_the_resource_contents(): void {
@@ -439,16 +419,13 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( CallToolResult::class, $result );
-
-		$content = $result->getContent();
-		$this->assertInstanceOf( EmbeddedResource::class, $content[0] );
+		$content = $result['content'];
 
 		// Strip `type` and the flat shape is a ResourceContents literal, so its `_meta`
 		// describes the resource. The block carries none; the nested form is how a caller
 		// addresses the block level.
-		$this->assertNull( $content[0]->get_meta() );
-		$this->assertSame( array( 'ui' => array( 'prefersBorder' => true ) ), $content[0]->getResource()->get_meta() );
+		$this->assertArrayNotHasKey( '_meta', $content[0] );
+		$this->assertSame( array( 'ui' => array( 'prefersBorder' => true ) ), $content[0]['resource']['_meta'] );
 	}
 
 	public function test_image_result_carries_meta(): void {
@@ -461,9 +438,7 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( CallToolResult::class, $result );
-
-		$block = $result->getContent()[0]->toArray();
+		$block = $result['content'][0];
 		$this->assertSame( array( 'ui' => array( 'prefersBorder' => true ) ), $block['_meta'] );
 	}
 
@@ -480,9 +455,7 @@ final class ToolsHandlerCallTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( CallToolResult::class, $result );
-
-		$block = $result->getContent()[0]->toArray();
+		$block = $result['content'][0];
 		$this->assertArrayNotHasKey( '_meta', $block );
 		$this->assertNotEmpty( $block['data'] );
 	}

--- a/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
+++ b/tests/phpunit/Unit/Handlers/ToolsHandlerCallTest.php
@@ -43,6 +43,29 @@ final class ToolsHandlerCallTest extends TestCase {
 		$this->assertSame( $expected, $result );
 	}
 
+	public function test_completed_execution_result_uses_existing_tool_normalization(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'       => 'completed-tool',
+				'handler'    => static fn(): McpExecutionResult => McpExecutionResult::complete( array( 'value' => 'done' ) ),
+				'permission' => '__return_true',
+			)
+		);
+		$this->assertInstanceOf( McpTool::class, $tool );
+		$handler = new ToolsHandler( $this->makeServer( array( $tool ) ) );
+
+		$result = $handler->call_tool(
+			array(
+				'name'      => 'completed-tool',
+				'arguments' => array(),
+			),
+			1
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array( 'value' => 'done' ), $result['structuredContent'] );
+	}
+
 	public function test_missing_name_returns_missing_parameter_error(): void {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );

--- a/tests/phpunit/Unit/Handlers/ToolsHandlerListTest.php
+++ b/tests/phpunit/Unit/Handlers/ToolsHandlerListTest.php
@@ -7,20 +7,18 @@ namespace WP\MCP\Tests\Unit\Handlers;
 use WP\MCP\Handlers\Tools\ToolsHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Tools\DTO\ListToolsResult;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 final class ToolsHandlerListTest extends TestCase {
 
-	public function test_list_tools_returns_dto(): void {
+	public function test_list_tools_returns_array(): void {
 		// Use makeServer helper to properly set up the server with registered abilities.
 		$server = $this->makeServer( array( 'test/always-allowed' ) );
 
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->list_tools();
 
-		// Verify it returns a ListToolsResult DTO
-		$this->assertInstanceOf( ListToolsResult::class, $result );
+		$this->assertArrayHasKey( 'tools', $result );
+		$this->assertIsArray( $result['tools'] );
 	}
 
 	public function test_list_tools_applies_tools_list_filter(): void {
@@ -34,8 +32,7 @@ final class ToolsHandlerListTest extends TestCase {
 		add_filter( 'mcp_adapter_tools_list', $filter );
 
 		$result = $handler->list_tools();
-		$this->assertInstanceOf( ListToolsResult::class, $result );
-		$this->assertEmpty( $result->getTools() );
+		$this->assertSame( array( 'tools' => array() ), $result );
 
 		remove_filter( 'mcp_adapter_tools_list', $filter );
 	}
@@ -48,18 +45,15 @@ final class ToolsHandlerListTest extends TestCase {
 		$list_result = $handler->list_tools();
 		$all_result  = $handler->list_all_tools();
 
-		// Use DTO getter methods instead of toArray()
-		$list_tools = $list_result->getTools();
-		$all_tools  = $all_result->getTools();
+		$list_tools = $list_result['tools'];
+		$all_tools  = $all_result['tools'];
 
 		$this->assertNotEmpty( $list_tools );
 		$this->assertNotEmpty( $all_tools );
-		$this->assertContainsOnlyInstancesOf( ToolDto::class, $list_tools );
-		$this->assertContainsOnlyInstancesOf( ToolDto::class, $all_tools );
+		$this->assertContainsOnly( 'array', $list_tools );
+		$this->assertContainsOnly( 'array', $all_tools );
 
-		// Verify Tool DTO structure via toArray() for field checks
-		$tool       = $list_tools[0];
-		$tool_array = $tool->toArray();
+		$tool_array = $list_tools[0];
 		$this->assertArrayHasKey( 'name', $tool_array );
 		$this->assertArrayHasKey( 'description', $tool_array );
 		$this->assertArrayHasKey( 'inputSchema', $tool_array );
@@ -67,8 +61,7 @@ final class ToolsHandlerListTest extends TestCase {
 		$this->assertArrayNotHasKey( 'permission_callback', $tool_array );
 
 		// list_all_tools now returns the same as list_tools (standard MCP format)
-		$tool_all       = $all_tools[0];
-		$tool_all_array = $tool_all->toArray();
+		$tool_all_array = $all_tools[0];
 		$this->assertArrayHasKey( 'name', $tool_all_array );
 	}
 
@@ -85,8 +78,7 @@ final class ToolsHandlerListTest extends TestCase {
 		$result = $handler->list_tools();
 
 		// Should fall back to the original unfiltered list.
-		$this->assertInstanceOf( ListToolsResult::class, $result );
-		$this->assertNotEmpty( $result->getTools() );
+		$this->assertNotEmpty( $result['tools'] );
 
 		// Should have logged a warning.
 		$this->assertNotEmpty( DummyErrorHandler::$logs );

--- a/tests/phpunit/Unit/Handlers/ToolsHandlerListTest.php
+++ b/tests/phpunit/Unit/Handlers/ToolsHandlerListTest.php
@@ -7,6 +7,7 @@ namespace WP\MCP\Tests\Unit\Handlers;
 use WP\MCP\Handlers\Tools\ToolsHandler;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Tools\DTO\Tool;
 
 final class ToolsHandlerListTest extends TestCase {
 
@@ -25,8 +26,11 @@ final class ToolsHandlerListTest extends TestCase {
 		$server  = $this->makeServer( array( 'test/always-allowed' ) );
 		$handler = new ToolsHandler( $server );
 
-		// Register a filter that removes all tools.
-		$filter = static function (): array {
+		// The documented hook still receives Tool objects.
+		$filter = function ( array $tools ): array {
+			$this->assertInstanceOf( Tool::class, $tools[0] );
+			$this->assertSame( 'test-always-allowed', $tools[0]->getName() );
+
 			return array();
 		};
 		add_filter( 'mcp_adapter_tools_list', $filter );

--- a/tests/phpunit/Unit/Handlers/ToolsHandlerTest.php
+++ b/tests/phpunit/Unit/Handlers/ToolsHandlerTest.php
@@ -11,11 +11,6 @@ namespace WP\MCP\Tests\Unit\Handlers;
 
 use WP\MCP\Handlers\Tools\ToolsHandler;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\Content\DTO\TextContent;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
-use WP\McpSchema\Server\Tools\DTO\CallToolResult;
-use WP\McpSchema\Server\Tools\DTO\ListToolsResult;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 use WP_Error;
 
 /**
@@ -23,13 +18,13 @@ use WP_Error;
  */
 final class ToolsHandlerTest extends TestCase {
 
-	public function test_list_tools_returns_dto(): void {
+	public function test_list_tools_returns_array(): void {
 		wp_set_current_user( 1 );
 		$server  = $this->makeServer( array( 'test/always-allowed' ), array(), array() );
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->list_tools();
 
-		$this->assertInstanceOf( ListToolsResult::class, $result );
+		$this->assertArrayHasKey( 'tools', $result );
 	}
 
 	public function test_list_tools_returns_registered_tools(): void {
@@ -38,10 +33,9 @@ final class ToolsHandlerTest extends TestCase {
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->list_tools();
 
-		// Use DTO getter methods instead of toArray()
-		$tools = $result->getTools();
+		$tools = $result['tools'];
 		$this->assertNotEmpty( $tools );
-		$this->assertContainsOnlyInstancesOf( ToolDto::class, $tools );
+		$this->assertContainsOnly( 'array', $tools );
 	}
 
 	public function test_list_tools_returns_empty_array_when_no_tools(): void {
@@ -49,23 +43,20 @@ final class ToolsHandlerTest extends TestCase {
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->list_tools();
 
-		// Use DTO getter methods instead of toArray()
-		$tools = $result->getTools();
+		$tools = $result['tools'];
 		$this->assertIsArray( $tools );
 		$this->assertEmpty( $tools );
 	}
 
-	public function test_list_all_tools_returns_dto(): void {
+	public function test_list_all_tools_returns_array(): void {
 		wp_set_current_user( 1 );
 		$server  = $this->makeServer( array( 'test/always-allowed' ), array(), array() );
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->list_all_tools();
 
-		$this->assertInstanceOf( ListToolsResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$tools = $result->getTools();
+		$tools = $result['tools'];
 		$this->assertNotEmpty( $tools );
-		$this->assertContainsOnlyInstancesOf( ToolDto::class, $tools );
+		$this->assertContainsOnly( 'array', $tools );
 	}
 
 	public function test_call_tool_missing_name_returns_error(): void {
@@ -73,12 +64,8 @@ final class ToolsHandlerTest extends TestCase {
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->call_tool( array( 'params' => array() ) );
 
-		// Missing name is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32602, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 	}
 
 	public function test_call_tool_not_found_returns_error(): void {
@@ -92,12 +79,8 @@ final class ToolsHandlerTest extends TestCase {
 			)
 		);
 
-		// Tool not found is a protocol error - returns JSONRPCErrorResponse
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$error = $result->getError();
-		$this->assertNotNull( $error );
-		$this->assertNotEmpty( $error->getMessage() );
+		$this->assertSame( -32003, $result['error']['code'] );
+		$this->assertNotEmpty( $result['error']['message'] );
 	}
 
 	public function test_call_tool_with_wp_error_from_execute(): void {
@@ -136,13 +119,10 @@ final class ToolsHandlerTest extends TestCase {
 			)
 		);
 
-		// WP_Error from execute is a tool execution error - returns CallToolResult with isError
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
+		$this->assertSame( 'text', $content[0]['type'] );
 
 		// Clean up
 		wp_unregister_ability( 'test/wp-error-execute' );
@@ -184,13 +164,10 @@ final class ToolsHandlerTest extends TestCase {
 			)
 		);
 
-		// Permission exception is a tool execution error - returns CallToolResult with isError
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
+		$this->assertSame( 'text', $content[0]['type'] );
 
 		// Clean up
 		wp_unregister_ability( 'test/permission-exception-in-call' );
@@ -216,14 +193,10 @@ final class ToolsHandlerTest extends TestCase {
 			)
 		);
 
-		// Successful execution returns CallToolResult
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		// Success means isError is not true (either null or false)
-		$this->assertNotTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertFalse( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
+		$this->assertSame( 'text', $content[0]['type'] );
 	}
 
 	public function test_call_tool_execution_exception_returns_error(): void {
@@ -241,13 +214,10 @@ final class ToolsHandlerTest extends TestCase {
 			)
 		);
 
-		// Execution exception is a tool execution error - returns CallToolResult with isError
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
+		$this->assertSame( 'text', $content[0]['type'] );
 	}
 
 	public function test_call_tool_permission_exception_returns_error(): void {
@@ -267,12 +237,10 @@ final class ToolsHandlerTest extends TestCase {
 
 		// Per MCP spec: "Any errors that originate from the tool SHOULD be reported inside
 		// the result object, with isError set to true"
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
+		$this->assertSame( 'text', $content[0]['type'] );
 	}
 
 	public function test_call_tool_permission_denied_returns_error(): void {
@@ -292,13 +260,11 @@ final class ToolsHandlerTest extends TestCase {
 
 		// Per MCP spec: "Any errors that originate from the tool SHOULD be reported inside
 		// the result object, with isError set to true"
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
-		$this->assertStringContainsString( 'Permission denied', $content[0]->getText() );
+		$this->assertSame( 'text', $content[0]['type'] );
+		$this->assertStringContainsString( 'Permission denied', $content[0]['text'] );
 	}
 
 	public function test_call_tool_uses_metadata_flags_without_exposing_them(): void {
@@ -329,18 +295,17 @@ final class ToolsHandlerTest extends TestCase {
 		$server  = $this->makeServer( array( 'test/flat-transform-call' ), array(), array() );
 		$handler = new ToolsHandler( $server );
 
-		// Use DTO getter methods instead of toArray()
-		$tools      = $handler->list_tools()->getTools();
+		$tools      = $handler->list_tools()['tools'];
 		$tool_entry = null;
 		foreach ( $tools as $tool ) {
-			if ( 'test-flat-transform-call' === $tool->toArray()['name'] ) {
+			if ( 'test-flat-transform-call' === $tool['name'] ) {
 				$tool_entry = $tool;
 				break;
 			}
 		}
 
 		$this->assertNotNull( $tool_entry );
-		$this->assertInstanceOf( ToolDto::class, $tool_entry );
+		$this->assertIsArray( $tool_entry );
 
 		$result = $handler->call_tool(
 			array(
@@ -351,10 +316,8 @@ final class ToolsHandlerTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
 		$this->assertSame( 'hello-world', $captured_input, 'Ability should receive unwrapped argument from metadata flag.' );
-		$structured_content = $result->getStructuredContent();
+		$structured_content = $result['structuredContent'];
 		$this->assertNotNull( $structured_content );
 		$this->assertArrayNotHasKey( '_meta', $structured_content );
 		$this->assertSame( array( 'result' => 'hello-world' ), $structured_content );
@@ -370,19 +333,15 @@ final class ToolsHandlerTest extends TestCase {
 		$handler = new ToolsHandler( $server );
 		$result  = $handler->list_tools();
 
-		// Use DTO getter methods instead of toArray()
-		$tools = $result->getTools();
+		$tools = $result['tools'];
 		$this->assertNotEmpty( $tools );
-		$this->assertContainsOnlyInstancesOf( ToolDto::class, $tools );
+		$this->assertContainsOnly( 'array', $tools );
 
-		$tool = $tools[0];
-		// Tool DTO provides typed access - verify required properties exist via toArray()
-		// since Tool DTO doesn't have getName() getter (name is in BaseMetadata parent)
-		$tool_array = $tool->toArray();
+		$tool_array = $tools[0];
 		$this->assertArrayHasKey( 'name', $tool_array );
 		$this->assertArrayHasKey( 'description', $tool_array );
 		$this->assertArrayHasKey( 'inputSchema', $tool_array );
-		// Ensure callback is not in the response (DTOs don't expose internal callbacks)
+		// Ensure callbacks are not exposed in protocol data.
 		$this->assertArrayNotHasKey( 'callback', $tool_array );
 		$this->assertArrayNotHasKey( 'permission_callback', $tool_array );
 	}
@@ -425,12 +384,10 @@ final class ToolsHandlerTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( CallToolResult::class, $result );
-		// Use DTO getter methods instead of toArray()
-		$this->assertTrue( $result->getIsError() );
-		$content = $result->getContent();
-		$this->assertInstanceOf( TextContent::class, $content[0] );
-		$this->assertEquals( 'Test string error', $content[0]->getText() );
+		$this->assertTrue( $result['isError'] );
+		$content = $result['content'];
+		$this->assertSame( 'text', $content[0]['type'] );
+		$this->assertSame( 'Test string error', $content[0]['text'] );
 
 		wp_unregister_ability( 'test/string-error' );
 	}
@@ -470,20 +427,15 @@ final class ToolsHandlerTest extends TestCase {
 			)
 		);
 
-		// Successful execution returns CallToolResult
-		$this->assertInstanceOf( CallToolResult::class, $result );
-
-		// Use DTO getter methods instead of toArray()
-		// Should not have an error (isError is not true - either null or false)
-		$this->assertNotTrue( $result->getIsError() );
+		$this->assertFalse( $result['isError'] );
 
 		// Should have content
-		$content = $result->getContent();
+		$content = $result['content'];
 		$this->assertNotEmpty( $content );
-		$this->assertInstanceOf( TextContent::class, $content[0] );
+		$this->assertSame( 'text', $content[0]['type'] );
 
 		// Should have structured content with the scalar wrapped
-		$structured_content = $result->getStructuredContent();
+		$structured_content = $result['structuredContent'];
 		$this->assertNotNull( $structured_content );
 		$this->assertArrayHasKey( 'result', $structured_content );
 		$this->assertSame( 'hello-world', $structured_content['result'] );

--- a/tests/phpunit/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php
+++ b/tests/phpunit/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php
@@ -6,686 +6,372 @@ namespace WP\MCP\Tests\Unit\Infrastructure\ErrorHandling;
 
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Common\JsonRpc\DTO\Error;
-use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse;
 
 final class McpErrorFactoryTest extends TestCase {
 
-	/**
-	 * Test that create_error_response returns a JSONRPCErrorResponse DTO.
-	 */
-	public function test_create_error_response_returns_dto(): void {
+	public function test_create_error_response_returns_complete_array_envelope(): void {
 		$response = McpErrorFactory::create_error_response( 1, -32603, 'Test error' );
 
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( '2.0', $response->getJsonrpc() );
-		$this->assertSame( 1, $response->getId() );
-		$this->assertInstanceOf( Error::class, $response->getError() );
-		$this->assertSame( -32603, $response->getError()->getCode() );
-		$this->assertSame( 'Test error', $response->getError()->getMessage() );
+		$this->assertSame(
+			array(
+				'jsonrpc' => '2.0',
+				'error'   => array(
+					'code'    => -32603,
+					'message' => 'Test error',
+				),
+				'id'      => 1,
+			),
+			$response
+		);
 	}
 
-	/**
-	 * Test that create_error_response toArray produces valid structure.
-	 */
-	public function test_create_error_response_to_array_creates_valid_structure(): void {
-		$response = McpErrorFactory::create_error_response( 1, -32603, 'Test error' );
-		$array    = $response->toArray();
-
-		$this->assertArrayHasKey( 'jsonrpc', $array );
-		$this->assertSame( '2.0', $array['jsonrpc'] );
-		$this->assertArrayHasKey( 'id', $array );
-		$this->assertSame( 1, $array['id'] );
-		$this->assertArrayHasKey( 'error', $array );
-		$this->assertArrayHasKey( 'code', $array['error'] );
-		$this->assertArrayHasKey( 'message', $array['error'] );
-		$this->assertSame( -32603, $array['error']['code'] );
-		$this->assertSame( 'Test error', $array['error']['message'] );
-	}
-
-	/**
-	 * Test that create_error_response includes data when provided.
-	 */
-	public function test_create_error_response_includes_data_when_provided(): void {
+	public function test_create_error_response_includes_non_null_data(): void {
 		$data     = array( 'key' => 'value' );
 		$response = McpErrorFactory::create_error_response( 1, -32603, 'Test error', $data );
 
-		$this->assertSame( $data, $response->getError()->getData() );
-
-		$array = $response->toArray();
-		$this->assertArrayHasKey( 'data', $array['error'] );
-		$this->assertSame( $data, $array['error']['data'] );
+		$this->assertSame( $data, $response['error']['data'] );
 	}
 
-	/**
-	 * Test that create_error_response excludes data when null.
-	 */
-	public function test_create_error_response_excludes_data_when_null(): void {
+	public function test_create_error_response_omits_null_data(): void {
 		$response = McpErrorFactory::create_error_response( 1, -32603, 'Test error', null );
 
-		$this->assertNull( $response->getError()->getData() );
-
-		$array = $response->toArray();
-		$this->assertArrayNotHasKey( 'data', $array['error'] );
+		$this->assertArrayNotHasKey( 'data', $response['error'] );
 	}
 
-	/**
-	 * Test that create_error_response accepts string IDs.
-	 */
 	public function test_create_error_response_accepts_string_id(): void {
 		$response = McpErrorFactory::create_error_response( 'request-123', -32603, 'Test error' );
 
-		$this->assertSame( 'request-123', $response->getId() );
+		$this->assertSame( 'request-123', $response['id'] );
 	}
 
-	/**
-	 * Test that create_error_response accepts null IDs.
-	 */
-	public function test_create_error_response_accepts_null_id(): void {
+	public function test_create_error_response_includes_null_id(): void {
 		$response = McpErrorFactory::create_error_response( null, -32603, 'Test error' );
 
-		$this->assertNull( $response->getId() );
-
-		$array = $response->toArray();
-		$this->assertArrayNotHasKey( 'id', $array );
+		$this->assertArrayHasKey( 'id', $response );
+		$this->assertNull( $response['id'] );
 	}
 
 	/**
-	 * Test parse_error returns a DTO with correct error code.
+	 * @dataProvider provide_error_responses
+	 *
+	 * @param callable(): array $factory Factory callback.
+	 * @param int               $expected_code Expected error code.
+	 * @param string            $expected_message Expected message fragment.
 	 */
-	public function test_parse_error_returns_dto(): void {
-		$response = McpErrorFactory::parse_error( 1, 'Invalid JSON' );
+	public function test_error_response_factories_return_stable_arrays( callable $factory, int $expected_code, string $expected_message ): void {
+		$response = $factory();
 
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::PARSE_ERROR, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Parse error', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'Invalid JSON', $response->getError()->getMessage() );
+		$this->assertSame( '2.0', $response['jsonrpc'] );
+		$this->assertSame( 1, $response['id'] );
+		$this->assertSame( $expected_code, $response['error']['code'] );
+		$this->assertStringContainsString( $expected_message, $response['error']['message'] );
 	}
 
 	/**
-	 * Test parse_error without details.
+	 * @return array<string, array{callable(): array, int, string}>
 	 */
-	public function test_parse_error_without_details(): void {
-		$response = McpErrorFactory::parse_error( 1 );
+	public function provide_error_responses(): array {
+		return array(
+			'parse error'        => array(
+				static fn(): array => McpErrorFactory::parse_error( 1, 'Invalid JSON' ),
+				McpErrorFactory::PARSE_ERROR,
+				'Invalid JSON',
+			),
+			'invalid request'    => array(
+				static fn(): array => McpErrorFactory::invalid_request( 1, 'Missing method' ),
+				McpErrorFactory::INVALID_REQUEST,
+				'Missing method',
+			),
+			'method not found'   => array(
+				static fn(): array => McpErrorFactory::method_not_found( 1, 'test/method' ),
+				McpErrorFactory::METHOD_NOT_FOUND,
+				'test/method',
+			),
+			'invalid params'     => array(
+				static fn(): array => McpErrorFactory::invalid_params( 1, 'Parameter validation failed' ),
+				McpErrorFactory::INVALID_PARAMS,
+				'Parameter validation failed',
+			),
+			'internal error'     => array(
+				static fn(): array => McpErrorFactory::internal_error( 1, 'Database connection failed' ),
+				McpErrorFactory::INTERNAL_ERROR,
+				'Database connection failed',
+			),
+			'mcp disabled'       => array(
+				static fn(): array => McpErrorFactory::mcp_disabled( 1 ),
+				McpErrorFactory::SERVER_ERROR,
+				'MCP functionality is currently disabled',
+			),
+			'validation error'   => array(
+				static fn(): array => McpErrorFactory::validation_error( 1, 'Tool name is required' ),
+				McpErrorFactory::INVALID_PARAMS,
+				'Tool name is required',
+			),
+			'missing parameter'  => array(
+				static fn(): array => McpErrorFactory::missing_parameter( 1, 'tool_name' ),
+				McpErrorFactory::INVALID_PARAMS,
+				'tool_name',
+			),
+			'resource not found' => array(
+				static fn(): array => McpErrorFactory::resource_not_found( 1, 'mcp://resource/test' ),
+				McpErrorFactory::RESOURCE_NOT_FOUND,
+				'mcp://resource/test',
+			),
+			'tool not found'     => array(
+				static fn(): array => McpErrorFactory::tool_not_found( 1, 'test-tool' ),
+				McpErrorFactory::TOOL_NOT_FOUND,
+				'test-tool',
+			),
+			'ability not found'  => array(
+				static fn(): array => McpErrorFactory::ability_not_found( 1, 'test-ability' ),
+				McpErrorFactory::TOOL_NOT_FOUND,
+				'test-ability',
+			),
+			'prompt not found'   => array(
+				static fn(): array => McpErrorFactory::prompt_not_found( 1, 'test-prompt' ),
+				McpErrorFactory::PROMPT_NOT_FOUND,
+				'test-prompt',
+			),
+			'session not found'  => array(
+				static fn(): array => McpErrorFactory::session_not_found( 1, 'Expired' ),
+				McpErrorFactory::SESSION_NOT_FOUND,
+				'Expired',
+			),
+			'permission denied'  => array(
+				static fn(): array => McpErrorFactory::permission_denied( 1, 'User lacks required capability' ),
+				McpErrorFactory::PERMISSION_DENIED,
+				'User lacks required capability',
+			),
+			'unauthorized'       => array(
+				static fn(): array => McpErrorFactory::unauthorized( 1, 'Authentication required' ),
+				McpErrorFactory::UNAUTHORIZED,
+				'Authentication required',
+			),
+		);
+	}
 
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::PARSE_ERROR, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Parse error', $response->getError()->getMessage() );
+	public function test_optional_detail_factories_preserve_default_messages(): void {
+		$this->assertSame( 'Parse error', McpErrorFactory::parse_error( 1 )['error']['message'] );
+		$this->assertSame( 'Invalid Request', McpErrorFactory::invalid_request( 1 )['error']['message'] );
+		$this->assertSame( 'Invalid params', McpErrorFactory::invalid_params( 1 )['error']['message'] );
+		$this->assertSame( 'Internal error', McpErrorFactory::internal_error( 1 )['error']['message'] );
+		$this->assertSame( 'Session not found', McpErrorFactory::session_not_found( 1 )['error']['message'] );
+		$this->assertSame( 'Permission denied', McpErrorFactory::permission_denied( 1 )['error']['message'] );
+		$this->assertSame( 'Unauthorized', McpErrorFactory::unauthorized( 1 )['error']['message'] );
+	}
+
+	public function test_header_mismatch_returns_exact_modern_error(): void {
+		$response = McpErrorFactory::header_mismatch( 1, 'MCP-Protocol-Version', '2026-07-28', '2025-11-25' );
+
+		$this->assertSame( McpErrorFactory::HEADER_MISMATCH, $response['error']['code'] );
+		$this->assertSame(
+			"Header mismatch: MCP-Protocol-Version header value '2026-07-28' does not match body value '2025-11-25'",
+			$response['error']['message']
+		);
+		$this->assertSame(
+			array(
+				'header'   => 'MCP-Protocol-Version',
+				'expected' => '2026-07-28',
+				'actual'   => '2025-11-25',
+			),
+			$response['error']['data']
+		);
+	}
+
+	public function test_missing_required_client_capability_returns_exact_modern_error(): void {
+		$required = array( 'elicitation' => new \stdClass() );
+		$response = McpErrorFactory::missing_required_client_capability( 1, $required );
+
+		$this->assertSame( McpErrorFactory::MISSING_REQUIRED_CLIENT_CAPABILITY, $response['error']['code'] );
+		$this->assertSame( $required, $response['error']['data']['requiredCapabilities'] );
+	}
+
+	public function test_unsupported_protocol_version_returns_exact_modern_error(): void {
+		$response = McpErrorFactory::unsupported_protocol_version(
+			1,
+			'1900-01-01',
+			array( '2026-07-28', '2025-11-25' )
+		);
+
+		$this->assertSame( McpErrorFactory::UNSUPPORTED_PROTOCOL_VERSION, $response['error']['code'] );
+		$this->assertSame( 'Unsupported protocol version', $response['error']['message'] );
+		$this->assertSame(
+			array(
+				'supported' => array( '2026-07-28', '2025-11-25' ),
+				'requested' => '1900-01-01',
+			),
+			$response['error']['data']
+		);
 	}
 
 	/**
-	 * Test invalid_request returns a DTO with correct error code.
+	 * @dataProvider provide_http_status_mappings
 	 */
-	public function test_invalid_request_returns_dto(): void {
-		$response = McpErrorFactory::invalid_request( 1, 'Missing method' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Invalid Request', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'Missing method', $response->getError()->getMessage() );
+	public function test_mcp_error_to_http_status( int $error_code, int $expected_status ): void {
+		$this->assertSame( $expected_status, McpErrorFactory::mcp_error_to_http_status( $error_code ) );
 	}
 
 	/**
-	 * Test method_not_found returns a DTO with correct error code.
+	 * @return array<string, array{int, int}>
 	 */
-	public function test_method_not_found_returns_dto(): void {
-		$response = McpErrorFactory::method_not_found( 1, 'test/method' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::METHOD_NOT_FOUND, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'test/method', $response->getError()->getMessage() );
+	public function provide_http_status_mappings(): array {
+		return array(
+			'parse error'         => array( McpErrorFactory::PARSE_ERROR, 400 ),
+			'invalid request'     => array( McpErrorFactory::INVALID_REQUEST, 400 ),
+			'header mismatch'     => array( McpErrorFactory::HEADER_MISMATCH, 400 ),
+			'missing capability'  => array( McpErrorFactory::MISSING_REQUIRED_CLIENT_CAPABILITY, 400 ),
+			'unsupported version' => array( McpErrorFactory::UNSUPPORTED_PROTOCOL_VERSION, 400 ),
+			'unauthorized'        => array( McpErrorFactory::UNAUTHORIZED, 401 ),
+			'permission denied'   => array( McpErrorFactory::PERMISSION_DENIED, 403 ),
+			'resource not found'  => array( McpErrorFactory::RESOURCE_NOT_FOUND, 404 ),
+			'tool not found'      => array( McpErrorFactory::TOOL_NOT_FOUND, 404 ),
+			'prompt not found'    => array( McpErrorFactory::PROMPT_NOT_FOUND, 404 ),
+			'session not found'   => array( McpErrorFactory::SESSION_NOT_FOUND, 404 ),
+			'method not found'    => array( McpErrorFactory::METHOD_NOT_FOUND, 404 ),
+			'internal error'      => array( McpErrorFactory::INTERNAL_ERROR, 500 ),
+			'server error'        => array( McpErrorFactory::SERVER_ERROR, 500 ),
+			'timeout'             => array( McpErrorFactory::TIMEOUT_ERROR, 504 ),
+			'invalid params'      => array( McpErrorFactory::INVALID_PARAMS, 200 ),
+			'unknown'             => array( -99999, 200 ),
+		);
 	}
 
-	/**
-	 * Test invalid_params returns a DTO with correct error code.
-	 */
-	public function test_invalid_params_returns_dto(): void {
-		$response = McpErrorFactory::invalid_params( 1, 'Parameter validation failed' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Invalid params', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'Parameter validation failed', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test internal_error returns a DTO with correct error code.
-	 */
-	public function test_internal_error_returns_dto(): void {
-		$response = McpErrorFactory::internal_error( 1, 'Database connection failed' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Internal error', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'Database connection failed', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test mcp_disabled returns a DTO with correct error code.
-	 */
-	public function test_mcp_disabled_returns_dto(): void {
-		$response = McpErrorFactory::mcp_disabled( 1 );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::SERVER_ERROR, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'MCP functionality is currently disabled', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test validation_error returns a DTO with correct error code.
-	 */
-	public function test_validation_error_returns_dto(): void {
-		$response = McpErrorFactory::validation_error( 1, 'Tool name is required' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Validation error', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'Tool name is required', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test missing_parameter returns a DTO with correct error code.
-	 */
-	public function test_missing_parameter_returns_dto(): void {
-		$response = McpErrorFactory::missing_parameter( 1, 'tool_name' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Missing required parameter', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'tool_name', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test resource_not_found returns a DTO with correct error code.
-	 */
-	public function test_resource_not_found_returns_dto(): void {
-		$response = McpErrorFactory::resource_not_found( 1, 'mcp://resource/test' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::RESOURCE_NOT_FOUND, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Resource not found', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'mcp://resource/test', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test tool_not_found returns a DTO with correct error code.
-	 */
-	public function test_tool_not_found_returns_dto(): void {
-		$response = McpErrorFactory::tool_not_found( 1, 'test-tool' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Tool not found', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'test-tool', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test ability_not_found returns a DTO with correct error code.
-	 */
-	public function test_ability_not_found_returns_dto(): void {
-		$response = McpErrorFactory::ability_not_found( 1, 'test-ability' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::TOOL_NOT_FOUND, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Ability not found', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'test-ability', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test prompt_not_found returns a DTO with correct error code.
-	 */
-	public function test_prompt_not_found_returns_dto(): void {
-		$response = McpErrorFactory::prompt_not_found( 1, 'test-prompt' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::PROMPT_NOT_FOUND, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Prompt not found', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'test-prompt', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test permission_denied returns a DTO with correct error code.
-	 */
-	public function test_permission_denied_returns_dto(): void {
-		$response = McpErrorFactory::permission_denied( 1, 'User lacks required capability' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::PERMISSION_DENIED, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Permission denied', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'User lacks required capability', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test permission_denied without details.
-	 */
-	public function test_permission_denied_without_details(): void {
-		$response = McpErrorFactory::permission_denied( 1 );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::PERMISSION_DENIED, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Permission denied', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test unauthorized returns a DTO with correct error code.
-	 */
-	public function test_unauthorized_returns_dto(): void {
-		$response = McpErrorFactory::unauthorized( 1, 'Authentication required' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::UNAUTHORIZED, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Unauthorized', $response->getError()->getMessage() );
-		$this->assertStringContainsString( 'Authentication required', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test unauthorized without details.
-	 */
-	public function test_unauthorized_without_details(): void {
-		$response = McpErrorFactory::unauthorized( 1 );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $response );
-		$this->assertSame( McpErrorFactory::UNAUTHORIZED, $response->getError()->getCode() );
-		$this->assertStringContainsString( 'Unauthorized', $response->getError()->getMessage() );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with parse error.
-	 */
-	public function test_mcp_error_to_http_status_parse_error(): void {
-		$this->assertSame( 400, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::PARSE_ERROR ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with invalid request.
-	 */
-	public function test_mcp_error_to_http_status_invalid_request(): void {
-		$this->assertSame( 400, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::INVALID_REQUEST ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with unauthorized.
-	 */
-	public function test_mcp_error_to_http_status_unauthorized(): void {
-		$this->assertSame( 401, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::UNAUTHORIZED ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with permission denied.
-	 */
-	public function test_mcp_error_to_http_status_permission_denied(): void {
-		$this->assertSame( 403, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::PERMISSION_DENIED ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with resource not found.
-	 */
-	public function test_mcp_error_to_http_status_resource_not_found(): void {
-		$this->assertSame( 404, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::RESOURCE_NOT_FOUND ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with tool not found.
-	 */
-	public function test_mcp_error_to_http_status_tool_not_found(): void {
-		$this->assertSame( 404, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::TOOL_NOT_FOUND ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with prompt not found.
-	 */
-	public function test_mcp_error_to_http_status_prompt_not_found(): void {
-		$this->assertSame( 404, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::PROMPT_NOT_FOUND ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with method not found.
-	 */
-	public function test_mcp_error_to_http_status_method_not_found(): void {
-		$this->assertSame( 404, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::METHOD_NOT_FOUND ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with internal error.
-	 */
-	public function test_mcp_error_to_http_status_internal_error(): void {
-		$this->assertSame( 500, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::INTERNAL_ERROR ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with server error.
-	 */
-	public function test_mcp_error_to_http_status_server_error(): void {
-		$this->assertSame( 500, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::SERVER_ERROR ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with timeout error.
-	 */
-	public function test_mcp_error_to_http_status_timeout_error(): void {
-		$this->assertSame( 504, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::TIMEOUT_ERROR ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with invalid params returns 200.
-	 */
-	public function test_mcp_error_to_http_status_invalid_params_returns_200(): void {
-		$this->assertSame( 200, McpErrorFactory::mcp_error_to_http_status( McpErrorFactory::INVALID_PARAMS ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with unknown code returns 200.
-	 */
-	public function test_mcp_error_to_http_status_unknown_code_returns_200(): void {
-		$this->assertSame( 200, McpErrorFactory::mcp_error_to_http_status( -99999 ) );
-	}
-
-	/**
-	 * Test mcp_error_to_http_status with string code.
-	 */
-	public function test_mcp_error_to_http_status_string_code(): void {
-		// Test with string code (should default to 200)
+	public function test_mcp_error_to_http_status_defaults_non_numeric_codes_to_200(): void {
 		$this->assertSame( 200, McpErrorFactory::mcp_error_to_http_status( 'invalid' ) );
 	}
 
-	/**
-	 * Test get_http_status_for_error with a DTO.
-	 */
-	public function test_get_http_status_for_error_with_dto(): void {
-		$error_response = McpErrorFactory::parse_error( 1 );
-		$status         = McpErrorFactory::get_http_status_for_error( $error_response );
+	public function test_get_http_status_for_error_reads_array_envelope(): void {
+		$this->assertSame( 400, McpErrorFactory::get_http_status_for_error( McpErrorFactory::parse_error( 1 ) ) );
+	}
 
-		$this->assertSame( 400, $status );
+	public function test_get_http_status_for_error_rejects_invalid_envelope(): void {
+		$this->assertSame( 500, McpErrorFactory::get_http_status_for_error( array( 'jsonrpc' => '2.0' ) ) );
+		$this->assertSame(
+			500,
+			McpErrorFactory::get_http_status_for_error(
+				array(
+					'jsonrpc' => '2.0',
+					'error'   => array( 'message' => 'Missing code' ),
+				)
+			)
+		);
 	}
 
 	/**
-	 * Test get_http_status_for_error with an array (legacy support).
+	 * @dataProvider provide_valid_jsonrpc_messages
+	 *
+	 * @param array<string, mixed> $message JSON-RPC message.
 	 */
-	public function test_get_http_status_for_error_with_array(): void {
-		$error_response = array(
-			'jsonrpc' => '2.0',
-			'id'      => 1,
-			'error'   => array(
-				'code'    => McpErrorFactory::PARSE_ERROR,
-				'message' => 'Parse error',
+	public function test_validate_jsonrpc_message_accepts_valid_messages( array $message ): void {
+		$this->assertTrue( McpErrorFactory::validate_jsonrpc_message( $message ) );
+	}
+
+	/**
+	 * @return array<string, array{array<string, mixed>}>
+	 */
+	public function provide_valid_jsonrpc_messages(): array {
+		return array(
+			'request'        => array(
+				array(
+					'jsonrpc' => '2.0',
+					'method'  => 'test/method',
+					'id'      => 1,
+				),
+			),
+			'notification'   => array(
+				array(
+					'jsonrpc' => '2.0',
+					'method'  => 'test/method',
+				),
+			),
+			'result'         => array(
+				array(
+					'jsonrpc' => '2.0',
+					'id'      => 1,
+					'result'  => array( 'success' => true ),
+				),
+			),
+			'error response' => array(
+				array(
+					'jsonrpc' => '2.0',
+					'id'      => 1,
+					'error'   => array(
+						'code'    => -32603,
+						'message' => 'Internal error',
+					),
+				),
 			),
 		);
-
-		$status = McpErrorFactory::get_http_status_for_error( $error_response );
-		$this->assertSame( 400, $status );
 	}
 
 	/**
-	 * Test get_http_status_for_error with missing code returns 500.
+	 * @dataProvider provide_invalid_jsonrpc_messages
+	 *
+	 * @param mixed  $message Invalid JSON-RPC message.
+	 * @param string $message_fragment Expected validation message fragment.
 	 */
-	public function test_get_http_status_for_error_with_missing_code_returns_500(): void {
-		$error_response = array(
-			'jsonrpc' => '2.0',
-			'id'      => 1,
-			'error'   => array(
-				'message' => 'Test error',
-				// Missing 'code' key
+	public function test_validate_jsonrpc_message_returns_array_error( $message, string $message_fragment ): void {
+		$result = McpErrorFactory::validate_jsonrpc_message( $message );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '2.0', $result['jsonrpc'] );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
+		$this->assertStringContainsString( $message_fragment, $result['error']['message'] );
+	}
+
+	/**
+	 * @return array<string, array{mixed, string}>
+	 */
+	public function provide_invalid_jsonrpc_messages(): array {
+		return array(
+			'non-array'       => array( 'not an array', 'JSON object' ),
+			'missing version' => array(
+				array(
+					'method' => 'test/method',
+					'id'     => 1,
+				),
+				'jsonrpc version',
+			),
+			'wrong version'   => array(
+				array(
+					'jsonrpc' => '1.0',
+					'method'  => 'test/method',
+					'id'      => 1,
+				),
+				'jsonrpc version',
+			),
+			'missing payload' => array(
+				array(
+					'jsonrpc' => '2.0',
+					'id'      => 1,
+				),
+				'method or result/error field',
+			),
+			'missing id'      => array(
+				array(
+					'jsonrpc' => '2.0',
+					'result'  => array( 'success' => true ),
+				),
+				'id field',
 			),
 		);
-
-		$status = McpErrorFactory::get_http_status_for_error( $error_response );
-		$this->assertSame( 500, $status );
 	}
 
-	/**
-	 * Test get_http_status_for_error with missing error key returns 500.
-	 */
-	public function test_get_http_status_for_error_with_missing_error_key_returns_500(): void {
-		$error_response = array(
-			'jsonrpc' => '2.0',
-			'id'      => 1,
-			// Missing 'error' key
-		);
-
-		$status = McpErrorFactory::get_http_status_for_error( $error_response );
-		$this->assertSame( 500, $status );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message with valid request.
-	 */
-	public function test_validate_jsonrpc_message_valid_request(): void {
-		$message = array(
-			'jsonrpc' => '2.0',
-			'method'  => 'test/method',
-			'id'      => 1,
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message with valid notification.
-	 */
-	public function test_validate_jsonrpc_message_valid_notification(): void {
-		$message = array(
-			'jsonrpc' => '2.0',
-			'method'  => 'test/method',
-			// No 'id' for notifications
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message with valid response.
-	 */
-	public function test_validate_jsonrpc_message_valid_response(): void {
-		$message = array(
-			'jsonrpc' => '2.0',
-			'id'      => 1,
-			'result'  => array( 'success' => true ),
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message with valid error response.
-	 */
-	public function test_validate_jsonrpc_message_valid_error_response(): void {
-		$message = array(
-			'jsonrpc' => '2.0',
-			'id'      => 1,
-			'error'   => array(
+	public function test_create_error_returns_nested_error_object(): void {
+		$this->assertSame(
+			array(
 				'code'    => -32603,
-				'message' => 'Internal error',
+				'message' => 'Test error',
 			),
+			McpErrorFactory::create_error( -32603, 'Test error' )
 		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-		$this->assertTrue( $result );
 	}
 
-	/**
-	 * Test validate_jsonrpc_message returns DTO for non-array.
-	 */
-	public function test_validate_jsonrpc_message_not_array_returns_dto(): void {
-		$result = McpErrorFactory::validate_jsonrpc_message( 'not an array' );
+	public function test_create_error_includes_non_null_data(): void {
+		$data = array( 'key' => 'value' );
 
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
-		$this->assertStringContainsString( 'JSON object', $result->getError()->getMessage() );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message returns DTO for missing jsonrpc version.
-	 */
-	public function test_validate_jsonrpc_message_missing_jsonrpc_version_returns_dto(): void {
-		$message = array(
-			'method' => 'test/method',
-			'id'     => 1,
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
-		$this->assertStringContainsString( 'jsonrpc version', $result->getError()->getMessage() );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message returns DTO for wrong jsonrpc version.
-	 */
-	public function test_validate_jsonrpc_message_wrong_jsonrpc_version_returns_dto(): void {
-		$message = array(
-			'jsonrpc' => '1.0',
-			'method'  => 'test/method',
-			'id'      => 1,
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message returns DTO for missing method and result/error.
-	 */
-	public function test_validate_jsonrpc_message_missing_method_and_result_error_returns_dto(): void {
-		$message = array(
-			'jsonrpc' => '2.0',
-			'id'      => 1,
-			// No method, result, or error
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
-		$this->assertStringContainsString( 'method or result/error field', $result->getError()->getMessage() );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message returns DTO for response missing id.
-	 */
-	public function test_validate_jsonrpc_message_response_missing_id_returns_dto(): void {
-		$message = array(
-			'jsonrpc' => '2.0',
-			'result'  => array( 'success' => true ),
-			// Missing 'id' for response
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result->getError()->getCode() );
-		$this->assertStringContainsString( 'id field', $result->getError()->getMessage() );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message returns null ID for non-array input.
-	 *
-	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
-	 */
-	public function test_validate_jsonrpc_message_not_array_returns_null_id(): void {
-		$result = McpErrorFactory::validate_jsonrpc_message( 'not an array' );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertNull( $result->getId() );
-
-		$array = $result->toArray();
-		$this->assertArrayNotHasKey( 'id', $array );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message returns null ID for missing jsonrpc version.
-	 *
-	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
-	 */
-	public function test_validate_jsonrpc_message_missing_version_returns_null_id(): void {
-		$message = array(
-			'method' => 'test/method',
-			'id'     => 1,
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertNull( $result->getId() );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message returns null ID for wrong jsonrpc version.
-	 *
-	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
-	 */
-	public function test_validate_jsonrpc_message_wrong_version_returns_null_id(): void {
-		$message = array(
-			'jsonrpc' => '1.0',
-			'method'  => 'test/method',
-			'id'      => 1,
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertNull( $result->getId() );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message returns null ID for missing method/result/error.
-	 *
-	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
-	 */
-	public function test_validate_jsonrpc_message_missing_method_returns_null_id(): void {
-		$message = array(
-			'jsonrpc' => '2.0',
-			'id'      => 1,
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertNull( $result->getId() );
-	}
-
-	/**
-	 * Test validate_jsonrpc_message returns null ID for response missing id.
-	 *
-	 * JSON-RPC 2.0 spec: When request ID cannot be determined, use null.
-	 */
-	public function test_validate_jsonrpc_message_response_missing_id_returns_null_id(): void {
-		$message = array(
-			'jsonrpc' => '2.0',
-			'result'  => array( 'success' => true ),
-		);
-
-		$result = McpErrorFactory::validate_jsonrpc_message( $message );
-
-		$this->assertInstanceOf( JSONRPCErrorResponse::class, $result );
-		$this->assertNull( $result->getId() );
-	}
-
-	/**
-	 * Test create_error helper method returns Error DTO.
-	 */
-	public function test_create_error_returns_dto(): void {
-		$error = McpErrorFactory::create_error( -32603, 'Test error' );
-
-		$this->assertInstanceOf( Error::class, $error );
-		$this->assertSame( -32603, $error->getCode() );
-		$this->assertSame( 'Test error', $error->getMessage() );
-		$this->assertNull( $error->getData() );
-	}
-
-	/**
-	 * Test create_error with data.
-	 */
-	public function test_create_error_with_data(): void {
-		$data  = array( 'key' => 'value' );
-		$error = McpErrorFactory::create_error( -32603, 'Test error', $data );
-
-		$this->assertInstanceOf( Error::class, $error );
-		$this->assertSame( $data, $error->getData() );
+		$this->assertSame( $data, McpErrorFactory::create_error( -32603, 'Test error', $data )['data'] );
 	}
 }

--- a/tests/phpunit/Unit/Prompts/McpPromptBuilderTest.php
+++ b/tests/phpunit/Unit/Prompts/McpPromptBuilderTest.php
@@ -5,7 +5,9 @@ declare( strict_types=1 );
 namespace WP\MCP\Tests\Unit\Prompts;
 
 use WP\MCP\Domain\Prompts\McpPromptBuilder;
+use WP\MCP\Tests\Fixtures\LegacyPromptBuilder;
 use WP\MCP\Tests\TestCase;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
 
 
 // Test prompt class
@@ -169,16 +171,25 @@ class TestPromptWithAddArgument extends McpPromptBuilder {
 
 final class McpPromptBuilderTest extends TestCase {
 
+	public function test_baseline_prompt_builder_interface_remains_registerable(): void {
+		$builder = new LegacyPromptBuilder();
+		$this->assertInstanceOf( Prompt::class, $builder->build() );
+
+		$server = $this->makeServer( array(), array(), array( $builder ) );
+		$this->assertArrayHasKey( 'legacy-builder-prompt', $server->get_prompts() );
+	}
+
 	public function test_builder_creates_prompt(): void {
 		$builder = new TestPrompt();
 		$prompt  = $builder->build();
+		$data    = $prompt->toArray();
 
-		$this->assertIsArray( $prompt );
-		$this->assertSame( 'test-prompt', $prompt['name'] );
-		$this->assertSame( 'Test Prompt', $prompt['title'] );
-		$this->assertSame( 'A test prompt for unit testing', $prompt['description'] );
+		$this->assertInstanceOf( Prompt::class, $prompt );
+		$this->assertSame( 'test-prompt', $data['name'] );
+		$this->assertSame( 'Test Prompt', $data['title'] );
+		$this->assertSame( 'A test prompt for unit testing', $data['description'] );
 
-		$arguments = $prompt['arguments'];
+		$arguments = $data['arguments'];
 		$this->assertCount( 2, $arguments );
 		$this->assertSame( 'input', $arguments[0]['name'] );
 		$this->assertTrue( $arguments[0]['required'] );
@@ -244,9 +255,9 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPromptWithIcons();
 		$prompt  = $builder->build();
 
-		$this->assertIsArray( $prompt );
+		$this->assertInstanceOf( Prompt::class, $prompt );
 
-		$arr = $prompt;
+		$arr = $prompt->toArray();
 
 		// Verify icons array is present.
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -269,7 +280,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPromptWithMixedIcons();
 		$prompt  = $builder->build();
 
-		$arr = $prompt;
+		$arr = $prompt->toArray();
 
 		// Should have only 2 valid icons (one without src was filtered out).
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -284,7 +295,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPrompt();
 		$prompt  = $builder->build();
 
-		$arr = $prompt;
+		$arr = $prompt->toArray();
 
 		// Verify icons key is not present when builder has no icons.
 		$this->assertArrayNotHasKey( 'icons', $arr );
@@ -317,7 +328,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPromptWithMeta();
 		$prompt  = $builder->build();
 
-		$arr = $prompt;
+		$arr = $prompt->toArray();
 
 		// Verify _meta is present.
 		$this->assertArrayHasKey( '_meta', $arr );
@@ -337,7 +348,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPrompt();
 		$prompt  = $builder->build();
 
-		$arr = $prompt;
+		$arr = $prompt->toArray();
 
 		$this->assertArrayNotHasKey( '_meta', $arr );
 	}
@@ -369,7 +380,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPromptWithIconsAndMeta();
 		$prompt  = $builder->build();
 
-		$arr = $prompt;
+		$arr = $prompt->toArray();
 
 		// Verify icons are present.
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -427,9 +438,9 @@ final class McpPromptBuilderTest extends TestCase {
 		$prompt3 = $builder->build();
 
 		// All should have exactly 3 arguments (not accumulating).
-		$this->assertCount( 3, $prompt1['arguments'] );
-		$this->assertCount( 3, $prompt2['arguments'] );
-		$this->assertCount( 3, $prompt3['arguments'] );
+		$this->assertCount( 3, $prompt1->toArray()['arguments'] );
+		$this->assertCount( 3, $prompt2->toArray()['arguments'] );
+		$this->assertCount( 3, $prompt3->toArray()['arguments'] );
 	}
 
 	public function test_getters_do_not_accumulate_arguments(): void {
@@ -445,7 +456,7 @@ final class McpPromptBuilderTest extends TestCase {
 
 		// Build should still have exactly 3 arguments.
 		$prompt = $builder->build();
-		$this->assertCount( 3, $prompt['arguments'] );
+		$this->assertCount( 3, $prompt->toArray()['arguments'] );
 	}
 
 	public function test_mixed_getter_and_build_calls_do_not_accumulate(): void {
@@ -460,10 +471,11 @@ final class McpPromptBuilderTest extends TestCase {
 
 		// Final build should still have exactly 3 arguments.
 		$prompt = $builder->build();
-		$this->assertCount( 3, $prompt['arguments'] );
+		$data   = $prompt->toArray();
+		$this->assertCount( 3, $data['arguments'] );
 
 		// Verify argument names are correct (no duplicates).
-		$args      = $prompt['arguments'];
+		$args      = $data['arguments'];
 		$arg_names = array_map( static fn( $arg ) => $arg['name'], $args );
 		$this->assertSame( array( 'code', 'language', 'focus' ), $arg_names );
 	}

--- a/tests/phpunit/Unit/Prompts/McpPromptBuilderTest.php
+++ b/tests/phpunit/Unit/Prompts/McpPromptBuilderTest.php
@@ -6,7 +6,7 @@ namespace WP\MCP\Tests\Unit\Prompts;
 
 use WP\MCP\Domain\Prompts\McpPromptBuilder;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
+
 
 // Test prompt class
 class TestPrompt extends McpPromptBuilder {
@@ -173,17 +173,17 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPrompt();
 		$prompt  = $builder->build();
 
-		$this->assertInstanceOf( PromptDto::class, $prompt );
-		$this->assertSame( 'test-prompt', $prompt->getName() );
-		$this->assertSame( 'Test Prompt', $prompt->getTitle() );
-		$this->assertSame( 'A test prompt for unit testing', $prompt->getDescription() );
+		$this->assertIsArray( $prompt );
+		$this->assertSame( 'test-prompt', $prompt['name'] );
+		$this->assertSame( 'Test Prompt', $prompt['title'] );
+		$this->assertSame( 'A test prompt for unit testing', $prompt['description'] );
 
-		$arguments = $prompt->getArguments();
+		$arguments = $prompt['arguments'];
 		$this->assertCount( 2, $arguments );
-		$this->assertSame( 'input', $arguments[0]->getName() );
-		$this->assertTrue( $arguments[0]->getRequired() );
-		$this->assertSame( 'optional', $arguments[1]->getName() );
-		$this->assertNull( $arguments[1]->getRequired() );
+		$this->assertSame( 'input', $arguments[0]['name'] );
+		$this->assertTrue( $arguments[0]['required'] );
+		$this->assertSame( 'optional', $arguments[1]['name'] );
+		$this->assertArrayNotHasKey( 'required', $arguments[1] );
 	}
 
 	public function test_prompt_can_be_registered_with_server(): void {
@@ -195,7 +195,7 @@ final class McpPromptBuilderTest extends TestCase {
 
 		$prompt = $server->get_prompt( 'test-prompt' );
 		$this->assertNotNull( $prompt );
-		$this->assertSame( 'test-prompt', $prompt->getName() );
+		$this->assertSame( 'test-prompt', $prompt['name'] );
 	}
 
 	public function test_prompt_execution_bypasses_abilities(): void {
@@ -244,9 +244,9 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPromptWithIcons();
 		$prompt  = $builder->build();
 
-		$this->assertInstanceOf( PromptDto::class, $prompt );
+		$this->assertIsArray( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Verify icons array is present.
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -269,7 +269,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPromptWithMixedIcons();
 		$prompt  = $builder->build();
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Should have only 2 valid icons (one without src was filtered out).
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -284,7 +284,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPrompt();
 		$prompt  = $builder->build();
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Verify icons key is not present when builder has no icons.
 		$this->assertArrayNotHasKey( 'icons', $arr );
@@ -317,7 +317,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPromptWithMeta();
 		$prompt  = $builder->build();
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Verify _meta is present.
 		$this->assertArrayHasKey( '_meta', $arr );
@@ -337,7 +337,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPrompt();
 		$prompt  = $builder->build();
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		$this->assertArrayNotHasKey( '_meta', $arr );
 	}
@@ -369,7 +369,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$builder = new TestPromptWithIconsAndMeta();
 		$prompt  = $builder->build();
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Verify icons are present.
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -394,7 +394,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$prompt = $server->get_prompt( 'test-prompt-with-icons' );
 		$this->assertNotNull( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 		$this->assertArrayHasKey( 'icons', $arr );
 		$this->assertCount( 2, $arr['icons'] );
 	}
@@ -409,7 +409,7 @@ final class McpPromptBuilderTest extends TestCase {
 		$prompt = $server->get_prompt( 'test-prompt-with-meta' );
 		$this->assertNotNull( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 		$this->assertArrayHasKey( '_meta', $arr );
 		$this->assertArrayHasKey( 'custom_vendor', $arr['_meta'] );
 	}
@@ -427,9 +427,9 @@ final class McpPromptBuilderTest extends TestCase {
 		$prompt3 = $builder->build();
 
 		// All should have exactly 3 arguments (not accumulating).
-		$this->assertCount( 3, $prompt1->getArguments() );
-		$this->assertCount( 3, $prompt2->getArguments() );
-		$this->assertCount( 3, $prompt3->getArguments() );
+		$this->assertCount( 3, $prompt1['arguments'] );
+		$this->assertCount( 3, $prompt2['arguments'] );
+		$this->assertCount( 3, $prompt3['arguments'] );
 	}
 
 	public function test_getters_do_not_accumulate_arguments(): void {
@@ -445,7 +445,7 @@ final class McpPromptBuilderTest extends TestCase {
 
 		// Build should still have exactly 3 arguments.
 		$prompt = $builder->build();
-		$this->assertCount( 3, $prompt->getArguments() );
+		$this->assertCount( 3, $prompt['arguments'] );
 	}
 
 	public function test_mixed_getter_and_build_calls_do_not_accumulate(): void {
@@ -460,11 +460,11 @@ final class McpPromptBuilderTest extends TestCase {
 
 		// Final build should still have exactly 3 arguments.
 		$prompt = $builder->build();
-		$this->assertCount( 3, $prompt->getArguments() );
+		$this->assertCount( 3, $prompt['arguments'] );
 
 		// Verify argument names are correct (no duplicates).
-		$args      = $prompt->getArguments();
-		$arg_names = array_map( static fn( $arg ) => $arg->getName(), $args );
+		$args      = $prompt['arguments'];
+		$arg_names = array_map( static fn( $arg ) => $arg['name'], $args );
 		$this->assertSame( array( 'code', 'language', 'focus' ), $arg_names );
 	}
 

--- a/tests/phpunit/Unit/Prompts/McpPromptTest.php
+++ b/tests/phpunit/Unit/Prompts/McpPromptTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Prompts;
 
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Prompts\McpPrompt;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 use WP_Error;
 
 /**
@@ -45,19 +46,18 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_protocol_dto();
+		$data = $prompt->get_protocol_data();
 
-		$this->assertInstanceOf( PromptDto::class, $dto );
-		$this->assertSame( 'test-array', $dto->getName() );
-		$this->assertSame( 'Test Array Prompt', $dto->getTitle() );
-		$this->assertSame( 'A prompt created from array config', $dto->getDescription() );
+		$this->assertSame( 'test-array', $data['name'] );
+		$this->assertSame( 'Test Array Prompt', $data['title'] );
+		$this->assertSame( 'A prompt created from array config', $data['description'] );
 
-		$arguments = $dto->getArguments();
+		$arguments = $data['arguments'];
 		$this->assertCount( 2, $arguments );
-		$this->assertSame( 'code', $arguments[0]->getName() );
-		$this->assertTrue( $arguments[0]->getRequired() );
-		$this->assertSame( 'language', $arguments[1]->getName() );
-		$this->assertNull( $arguments[1]->getRequired() );
+		$this->assertSame( 'code', $arguments[0]['name'] );
+		$this->assertTrue( $arguments[0]['required'] );
+		$this->assertSame( 'language', $arguments[1]['name'] );
+		$this->assertArrayNotHasKey( 'required', $arguments[1] );
 	}
 
 	public function test_fromArray_handler_is_executed(): void {
@@ -77,6 +77,23 @@ final class McpPromptTest extends TestCase {
 
 		$this->assertSame( 21, $result['received']['value'] );
 		$this->assertSame( 42, $result['computed'] );
+	}
+
+	public function test_execute_passes_continuation_to_opt_in_handler_and_preserves_result(): void {
+		$context = new McpContinuationContext( array(), 'prompt-state' );
+		$prompt  = McpPrompt::fromArray(
+			array(
+				'name'    => 'continuation-prompt',
+				'handler' => static function ( array $arguments, ?McpContinuationContext $continuation ): McpExecutionResult {
+					return McpExecutionResult::input_required( array(), $continuation ? $continuation->get_request_state() : null );
+				},
+			)
+		);
+
+		$result = $prompt->execute( array(), $context );
+
+		$this->assertInstanceOf( McpExecutionResult::class, $result );
+		$this->assertSame( 'prompt-state', $result->get_request_state() );
 	}
 
 	public function test_fromArray_permission_callback(): void {
@@ -136,8 +153,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_protocol_dto();
-		$arr = $dto->toArray();
+		$arr = $prompt->get_protocol_data();
 
 		$this->assertArrayHasKey( 'icons', $arr );
 		$this->assertCount( 1, $arr['icons'] );
@@ -157,8 +173,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_protocol_dto();
-		$arr = $dto->toArray();
+		$arr = $prompt->get_protocol_data();
 
 		$this->assertArrayHasKey( '_meta', $arr );
 		$this->assertSame( 'custom_value', $arr['_meta']['custom_key'] );
@@ -205,8 +220,7 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_protocol_dto();
-		$arr = $dto->toArray();
+		$arr = $prompt->get_protocol_data();
 
 		$this->assertArrayHasKey( 'icons', $arr );
 		$this->assertArrayHasKey( '_meta', $arr );
@@ -266,14 +280,12 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_protocol_dto();
-		$this->assertSame( 'getter-test', $dto->getName() );
-		$this->assertSame( 'Getter Title', $dto->getTitle() );
-		$this->assertSame( 'Getter Description', $dto->getDescription() );
-		$this->assertCount( 1, $dto->getArguments() );
-		$this->assertSame( 'arg1', $dto->getArguments()[0]->getName() );
-
-		$arr = $dto->toArray();
+		$arr = $prompt->get_protocol_data();
+		$this->assertSame( 'getter-test', $arr['name'] );
+		$this->assertSame( 'Getter Title', $arr['title'] );
+		$this->assertSame( 'Getter Description', $arr['description'] );
+		$this->assertCount( 1, $arr['arguments'] );
+		$this->assertSame( 'arg1', $arr['arguments'][0]['name'] );
 		$this->assertArrayHasKey( 'icons', $arr );
 		$this->assertCount( 1, $arr['icons'] );
 		$this->assertArrayHasKey( '_meta', $arr );
@@ -288,13 +300,13 @@ final class McpPromptTest extends TestCase {
 			)
 		);
 
-		$dto = $prompt->get_protocol_dto();
-		$this->assertSame( 'minimal-test', $dto->getName() );
-		$this->assertNull( $dto->getTitle() );
-		$this->assertNull( $dto->getDescription() );
-		$this->assertNull( $dto->getArguments() );
-		$this->assertNull( $dto->getIcons() );
-		$this->assertNull( $dto->get_meta() );
+		$data = $prompt->get_protocol_data();
+		$this->assertSame( 'minimal-test', $data['name'] );
+		$this->assertArrayNotHasKey( 'title', $data );
+		$this->assertArrayNotHasKey( 'description', $data );
+		$this->assertArrayNotHasKey( 'arguments', $data );
+		$this->assertArrayNotHasKey( 'icons', $data );
+		$this->assertArrayNotHasKey( '_meta', $data );
 	}
 
 	// =========================================================================

--- a/tests/phpunit/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
+++ b/tests/phpunit/Unit/Prompts/RegisterAbilityAsMcpPromptTest.php
@@ -6,7 +6,6 @@ namespace WP\MCP\Tests\Unit\Prompts;
 
 use WP\MCP\Domain\Prompts\RegisterAbilityAsMcpPrompt;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Prompts\DTO\Prompt as PromptDto;
 
 final class RegisterAbilityAsMcpPromptTest extends TestCase {
 
@@ -14,11 +13,11 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$ability = wp_get_ability( 'test/prompt' );
 		$this->assertNotNull( $ability, 'Ability test/prompt should be registered' );
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
-		$this->assertInstanceOf( PromptDto::class, $prompt );
-		$arr = $prompt->toArray();
+		$this->assertIsArray( $prompt );
+		$arr = $prompt;
 		$this->assertSame( 'test-prompt', $arr['name'] );
 		$this->assertArrayHasKey( 'arguments', $arr );
-		$this->assertNull( $prompt->get_meta() );
+		$this->assertArrayNotHasKey( '_meta', $prompt );
 	}
 
 	public function test_annotations_are_mapped_to_mcp_format(): void {
@@ -28,9 +27,9 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
-		// Note: Schema Prompt DTO does not support annotations; these are intentionally not exposed.
+		// Note: Prompt protocol data does not support annotations; these are intentionally not exposed.
 		$this->assertArrayNotHasKey( 'annotations', $arr );
 	}
 
@@ -41,9 +40,9 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
-		// Note: Schema Prompt DTO does not support annotations; these are intentionally not exposed.
+		// Note: Prompt protocol data does not support annotations; these are intentionally not exposed.
 		$this->assertArrayNotHasKey( 'annotations', $arr );
 	}
 
@@ -54,7 +53,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Verify annotations field is not present when empty.
 		$this->assertArrayNotHasKey( 'annotations', $arr );
@@ -71,10 +70,10 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
+		$this->assertIsArray( $built['prompt'] );
 		$prompt = $built['prompt'];
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Should have exactly one argument named 'input'.
 		$this->assertArrayHasKey( 'arguments', $arr );
@@ -95,10 +94,10 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
+		$this->assertIsArray( $built['prompt'] );
 		$prompt = $built['prompt'];
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Should have exactly one argument named 'input'.
 		$this->assertArrayHasKey( 'arguments', $arr );
@@ -121,7 +120,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		$this->assertArrayHasKey( 'arguments', $arr );
 		$this->assertCount( 2, $arr['arguments'] );
@@ -164,7 +163,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		$this->assertArrayHasKey( 'arguments', $arr );
 		$this->assertCount( 3, $arr['arguments'] );
@@ -211,10 +210,10 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
+		$this->assertIsArray( $built['prompt'] );
 		$prompt = $built['prompt'];
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Empty object schema should result in no arguments key.
 		$this->assertArrayNotHasKey( 'arguments', $arr );
@@ -230,7 +229,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// No schema should result in no arguments key.
 		$this->assertArrayNotHasKey( 'arguments', $arr );
@@ -243,10 +242,10 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
+		$this->assertIsArray( $built['prompt'] );
 		$prompt = $built['prompt'];
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Object schema should have arguments.
 		$this->assertArrayHasKey( 'arguments', $arr );
@@ -295,10 +294,10 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
+		$this->assertIsArray( $built['prompt'] );
 		$prompt = $built['prompt'];
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Should have 2 arguments from explicit definition.
 		$this->assertArrayHasKey( 'arguments', $arr );
@@ -329,10 +328,10 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
+		$this->assertIsArray( $built['prompt'] );
 		$prompt = $built['prompt'];
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Should have exactly 1 argument from explicit override, NOT from input_schema.
 		$this->assertArrayHasKey( 'arguments', $arr );
@@ -364,10 +363,10 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
+		$this->assertIsArray( $built['prompt'] );
 		$prompt = $built['prompt'];
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Should fall back to input_schema since mcp.arguments is empty.
 		$this->assertArrayHasKey( 'arguments', $arr );
@@ -412,10 +411,10 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
+		$this->assertIsArray( $built['prompt'] );
 		$prompt = $built['prompt'];
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Should have 2 arguments.
 		$this->assertArrayHasKey( 'arguments', $arr );
@@ -446,11 +445,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$built = RegisterAbilityAsMcpPrompt::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
-		$this->assertInstanceOf( PromptDto::class, $built['prompt'] );
-		$prompt = $built['prompt'];
-
-		$arr = $prompt->toArray();
-
+		$this->assertIsArray( $built['prompt'] );
 		// Verify arguments_source is 'schema' for auto-converted arguments.
 		$this->assertSame( 'schema', $built['adapter_meta']['arguments_source'] );
 	}
@@ -477,7 +472,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Verify icons array is present.
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -503,7 +498,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Should have only 2 valid icons (the one missing src was filtered out).
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -521,7 +516,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Verify icons key is not present when ability has no icons.
 		$this->assertArrayNotHasKey( 'icons', $arr );
@@ -538,7 +533,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Verify _meta is present with user-defined keys.
 		$this->assertArrayHasKey( '_meta', $arr );
@@ -561,7 +556,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		$this->assertArrayNotHasKey( '_meta', $arr );
 	}
@@ -577,7 +572,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 
 		// Verify icons are present.
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -608,7 +603,7 @@ final class RegisterAbilityAsMcpPromptTest extends TestCase {
 		$prompt = RegisterAbilityAsMcpPrompt::make( $ability );
 		$this->assertNotWPError( $prompt );
 
-		$arr = $prompt->toArray();
+		$arr = $prompt;
 		$this->assertSame( 'custom-prompt-name', $arr['name'] );
 
 		remove_filter( 'mcp_adapter_prompt_name', $filter_callback );

--- a/tests/phpunit/Unit/Resources/McpResourceTest.php
+++ b/tests/phpunit/Unit/Resources/McpResourceTest.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Resources;
 
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Resources\McpResource;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 use WP_Error;
 
 final class McpResourceTest extends TestCase {
 
 
-	public function test_from_ability_builds_clean_resource_dto_and_adapter_meta(): void {
+	public function test_from_ability_builds_clean_resource_data_and_adapter_meta(): void {
 		$ability = wp_get_ability( 'test/resource-new-meta' );
 		$this->assertNotNull( $ability, 'Ability test/resource-new-meta should be registered' );
 
@@ -20,10 +21,8 @@ final class McpResourceTest extends TestCase {
 		$this->assertNotWPError( $mcp_resource );
 		$this->assertInstanceOf( McpResource::class, $mcp_resource );
 
-		$dto = $mcp_resource->get_protocol_dto();
-		$this->assertInstanceOf( ResourceDto::class, $dto );
-
-		$arr = $dto->toArray();
+		$arr = $mcp_resource->get_protocol_data();
+		$this->assertIsArray( $arr );
 		$this->assertArrayHasKey( '_meta', $arr );
 		$this->assertArrayHasKey( 'custom_field', $arr['_meta'] );
 		$this->assertSame( 'custom_value', $arr['_meta']['custom_field'] );
@@ -78,8 +77,7 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$dto = $mcp_resource->get_protocol_dto();
-		$arr = $dto->toArray();
+		$arr = $mcp_resource->get_protocol_data();
 
 		$this->assertArrayHasKey( '_meta', $arr );
 		$this->assertArrayHasKey( 'foo', $arr['_meta'] );
@@ -99,12 +97,11 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$dto = $resource->get_protocol_dto();
+		$data = $resource->get_protocol_data();
 
-		$this->assertInstanceOf( ResourceDto::class, $dto );
-		$this->assertSame( 'WordPress://local/minimal', $dto->getUri() );
+		$this->assertSame( 'WordPress://local/minimal', $data['uri'] );
 		// Name defaults to URI when not provided
-		$this->assertSame( 'WordPress://local/minimal', $dto->getName() );
+		$this->assertSame( 'WordPress://local/minimal', $data['name'] );
 	}
 
 	public function test_fromArray_with_all_options(): void {
@@ -126,15 +123,14 @@ final class McpResourceTest extends TestCase {
 			)
 		);
 
-		$dto  = $resource->get_protocol_dto();
-		$data = $dto->toArray();
+		$data = $resource->get_protocol_data();
 
-		$this->assertSame( 'WordPress://local/full', $dto->getUri() );
-		$this->assertSame( 'full-resource', $dto->getName() );
-		$this->assertSame( 'Full Resource', $dto->getTitle() );
-		$this->assertSame( 'A comprehensive test resource', $dto->getDescription() );
-		$this->assertSame( 'text/plain', $dto->getMimeType() );
-		$this->assertSame( 1024, $dto->getSize() );
+		$this->assertSame( 'WordPress://local/full', $data['uri'] );
+		$this->assertSame( 'full-resource', $data['name'] );
+		$this->assertSame( 'Full Resource', $data['title'] );
+		$this->assertSame( 'A comprehensive test resource', $data['description'] );
+		$this->assertSame( 'text/plain', $data['mimeType'] );
+		$this->assertSame( 1024, $data['size'] );
 		$this->assertArrayHasKey( 'annotations', $data );
 		$this->assertArrayHasKey( '_meta', $data );
 		$this->assertSame( '1.0', $data['_meta']['version'] );
@@ -185,6 +181,23 @@ final class McpResourceTest extends TestCase {
 		$result = $resource->execute( array( 'name' => 'Claude' ) );
 
 		$this->assertSame( 'Hello, Claude', $result );
+	}
+
+	public function test_execute_passes_continuation_to_opt_in_handler_and_preserves_result(): void {
+		$context  = new McpContinuationContext( array(), 'resource-state' );
+		$resource = McpResource::fromArray(
+			array(
+				'uri'     => 'WordPress://local/continuation',
+				'handler' => static function ( array $arguments, ?McpContinuationContext $continuation ): McpExecutionResult {
+					return McpExecutionResult::input_required( array(), $continuation ? $continuation->get_request_state() : null );
+				},
+			)
+		);
+
+		$result = $resource->execute( array(), $context );
+
+		$this->assertInstanceOf( McpExecutionResult::class, $result );
+		$this->assertSame( 'resource-state', $result->get_request_state() );
 	}
 
 	public function test_fromArray_checks_permission(): void {
@@ -255,22 +268,24 @@ final class McpResourceTest extends TestCase {
 		$this->assertSame( 'Permission check exploded', $result->get_error_message() );
 	}
 
-	public function test_fromArray_returns_wp_error_when_annotations_throw(): void {
-		// Pass invalid annotations data that causes Annotations::fromArray() to throw.
-		// The 'priority' field expects a float, not a string.
+	public function test_fromArray_deep_validation_rejects_invalid_annotations(): void {
+		add_filter( 'mcp_adapter_validation_enabled', '__return_true' );
+
 		$result = McpResource::fromArray(
 			array(
 				'uri'         => 'WordPress://local/invalid-annotations',
 				'handler'     => static fn() => 'content',
 				'annotations' => array(
-					'priority' => 'not-a-float', // This will cause Annotations::fromArray() to throw.
+					'priority' => 'not-a-float',
 				),
 			)
 		);
 
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'mcp_resource_dto_creation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Expected float', $result->get_error_message() );
+		$this->assertSame( 'mcp_resource_validation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'priority must be a number', $result->get_error_message() );
+
+		remove_filter( 'mcp_adapter_validation_enabled', '__return_true' );
 	}
 
 	// =========================================================================

--- a/tests/phpunit/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
+++ b/tests/phpunit/Unit/Resources/RegisterAbilityAsMcpResourceTest.php
@@ -6,7 +6,6 @@ namespace WP\MCP\Tests\Unit\Resources;
 
 use WP\MCP\Domain\Resources\RegisterAbilityAsMcpResource;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Resources\DTO\Resource as ResourceDto;
 
 final class RegisterAbilityAsMcpResourceTest extends TestCase {
 
@@ -14,10 +13,10 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$ability = wp_get_ability( 'test/resource' );
 		$this->assertNotNull( $ability, 'Ability test/resource should be registered' );
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
-		$this->assertInstanceOf( ResourceDto::class, $resource );
-		$arr = $resource->toArray();
+		$this->assertIsArray( $resource );
+		$arr = $resource;
 		$this->assertSame( 'WordPress://local/resource-1', $arr['uri'] );
-		$this->assertNull( $resource->get_meta() );
+		$this->assertArrayNotHasKey( '_meta', $resource );
 	}
 
 	public function test_annotations_are_mapped_to_mcp_format(): void {
@@ -54,7 +53,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		// Verify MCP-format annotations.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -105,7 +104,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		// Verify only provided annotations are present.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -125,7 +124,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		// Verify annotations field is not present when empty.
 		$this->assertArrayNotHasKey( 'annotations', $arr );
@@ -156,7 +155,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 		$this->assertSame( 'WordPress://local/resource-whitespace', $arr['uri'] );
 
 		// Cleanup.
@@ -170,7 +169,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		// Verify core fields.
 		$this->assertSame( 'test/resource-new-meta', $arr['name'] );
@@ -219,7 +218,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		// The descriptor carries whatever the author declared.
 		$this->assertArrayHasKey( 'mimeType', $arr );
@@ -233,7 +232,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		$this->assertArrayHasKey( 'size', $arr );
 		$this->assertSame( 2048, $arr['size'] );
@@ -246,7 +245,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		$this->assertArrayHasKey( 'icons', $arr );
 		$this->assertCount( 1, $arr['icons'] );
@@ -268,7 +267,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 		$this->assertSame( 'filtered-test/resource', $arr['name'] );
 
 		remove_filter( 'mcp_adapter_resource_name', $filter_callback, 10 );
@@ -287,7 +286,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 		$this->assertSame( 'WordPress://filtered/resource-1', $arr['uri'] );
 
 		remove_filter( 'mcp_adapter_resource_uri', $filter_callback, 10 );
@@ -347,7 +346,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		// Resource should still be created successfully (graceful degradation).
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		// Annotations should NOT be present (all dropped due to validation errors).
 		$this->assertArrayNotHasKey( 'annotations', $arr );
@@ -391,7 +390,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		// Resource should still be created successfully.
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		// ALL annotations should be dropped even though priority was valid.
 		// This is because we drop all if ANY are invalid.
@@ -408,7 +407,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		// Valid annotations should be preserved.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -439,7 +438,7 @@ final class RegisterAbilityAsMcpResourceTest extends TestCase {
 		$resource = RegisterAbilityAsMcpResource::make( $ability );
 		$this->assertNotWPError( $resource );
 
-		$arr = $resource->toArray();
+		$arr = $resource;
 
 		// mimeType should be present with valid format.
 		$this->assertArrayHasKey( 'mimeType', $arr );

--- a/tests/phpunit/Unit/Servers/DefaultServerFactoryTest.php
+++ b/tests/phpunit/Unit/Servers/DefaultServerFactoryTest.php
@@ -76,8 +76,8 @@ final class DefaultServerFactoryTest extends TestCase {
 		// The test/resource ability has mcp.public=true and mcp.type='resource'
 		$resources      = $server->get_resources();
 		$resource_names = array_map(
-			static function ( $resource ) {
-				return $resource->getName();
+			static function ( array $resource_data ): string {
+				return (string) $resource_data['name'];
 			},
 			$resources
 		);
@@ -104,8 +104,8 @@ final class DefaultServerFactoryTest extends TestCase {
 		// The test/prompt ability has mcp.public=true and mcp.type='prompt'
 		$prompts      = $server->get_prompts();
 		$prompt_names = array_map(
-			static function ( $prompt ) {
-				return $prompt->getName();
+			static function ( array $prompt ): string {
+				return (string) $prompt['name'];
 			},
 			$prompts
 		);
@@ -158,8 +158,8 @@ final class DefaultServerFactoryTest extends TestCase {
 
 		$tools      = $server->get_tools();
 		$tool_names = array_map(
-			static function ( $tool ) {
-				return $tool->getName();
+			static function ( array $tool ): string {
+				return (string) $tool['name'];
 			},
 			$tools
 		);

--- a/tests/phpunit/Unit/Tools/McpToolTest.php
+++ b/tests/phpunit/Unit/Tools/McpToolTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace WP\MCP\Tests\Unit\Tools;
 
+use WP\MCP\Domain\Continuation\McpContinuationContext;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Domain\Tools\McpTool;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 use WP_Error;
 
 final class McpToolTest extends TestCase {
@@ -46,10 +47,8 @@ final class McpToolTest extends TestCase {
 		$mcp_tool = McpTool::fromAbility( $ability );
 		$this->assertNotWPError( $mcp_tool );
 
-		$dto = $mcp_tool->get_protocol_dto();
-		$this->assertInstanceOf( ToolDto::class, $dto );
-
-		$data = $dto->toArray();
+		$data = $mcp_tool->get_protocol_data();
+		$this->assertIsArray( $data );
 
 		// User-provided _meta is preserved.
 		$this->assertArrayHasKey( '_meta', $data );
@@ -178,15 +177,14 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto = $tool->get_protocol_dto();
+		$data = $tool->get_protocol_data();
 
-		$this->assertInstanceOf( ToolDto::class, $dto );
-		$this->assertSame( 'minimal-tool', $dto->getName() );
-		$this->assertNull( $dto->getTitle() );
-		$this->assertNull( $dto->getDescription() );
+		$this->assertSame( 'minimal-tool', $data['name'] );
+		$this->assertArrayNotHasKey( 'title', $data );
+		$this->assertArrayNotHasKey( 'description', $data );
 
 		// Input schema defaults to object type
-		$input_schema = $dto->getInputSchema()->toArray();
+		$input_schema = $data['inputSchema'];
 		$this->assertSame( 'object', $input_schema['type'] );
 	}
 
@@ -221,12 +219,11 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_protocol_dto();
-		$data = $dto->toArray();
+		$data = $tool->get_protocol_data();
 
-		$this->assertSame( 'full-featured-tool', $dto->getName() );
-		$this->assertSame( 'Full Featured Tool', $dto->getTitle() );
-		$this->assertSame( 'A comprehensive test tool', $dto->getDescription() );
+		$this->assertSame( 'full-featured-tool', $data['name'] );
+		$this->assertSame( 'Full Featured Tool', $data['title'] );
+		$this->assertSame( 'A comprehensive test tool', $data['description'] );
 
 		// Check input schema
 		$this->assertArrayHasKey( 'inputSchema', $data );
@@ -259,8 +256,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_protocol_dto();
-		$data = $dto->toArray();
+		$data = $tool->get_protocol_data();
 
 		$this->assertArrayHasKey( 'annotations', $data );
 		$this->assertTrue( $data['annotations']['readOnlyHint'] );
@@ -280,8 +276,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_protocol_dto();
-		$data = $dto->toArray();
+		$data = $tool->get_protocol_data();
 
 		$this->assertArrayHasKey( 'annotations', $data );
 		$this->assertTrue( $data['annotations']['destructiveHint'] );
@@ -303,8 +298,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_protocol_dto();
-		$data = $dto->toArray();
+		$data = $tool->get_protocol_data();
 
 		$this->assertSame( 'Custom Annotation Title', $data['annotations']['title'] );
 		$this->assertFalse( $data['annotations']['readOnlyHint'] );
@@ -408,12 +402,11 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_protocol_dto();
-		$data = $dto->toArray();
+		$data = $tool->get_protocol_data();
 
-		$this->assertSame( 'array-tool', $dto->getName() );
-		$this->assertSame( 'Array Tool', $dto->getTitle() );
-		$this->assertSame( 'Created from array', $dto->getDescription() );
+		$this->assertSame( 'array-tool', $data['name'] );
+		$this->assertSame( 'Array Tool', $data['title'] );
+		$this->assertSame( 'Created from array', $data['description'] );
 		$this->assertTrue( $data['annotations']['readOnlyHint'] );
 
 		// Execute
@@ -452,8 +445,7 @@ final class McpToolTest extends TestCase {
 			)
 		);
 
-		$dto  = $tool->get_protocol_dto();
-		$data = $dto->toArray();
+		$data = $tool->get_protocol_data();
 
 		$this->assertArrayHasKey( '_meta', $data );
 		$this->assertSame( '1.0.0', $data['_meta']['version'] );
@@ -498,22 +490,24 @@ final class McpToolTest extends TestCase {
 		$this->assertSame( 'Permission check exploded', $result->get_error_message() );
 	}
 
-	public function test_fromArray_returns_wp_error_when_annotations_throw(): void {
-		// Pass invalid annotations data that causes ToolAnnotations::fromArray() to throw.
-		// The 'readOnlyHint' field expects a bool, not a string.
+	public function test_fromArray_deep_validation_rejects_invalid_annotations(): void {
+		add_filter( 'mcp_adapter_validation_enabled', '__return_true' );
+
 		$result = McpTool::fromArray(
 			array(
 				'name'        => 'invalid-annotations-tool',
 				'handler'     => static fn( $args ) => array( 'ok' => true ),
 				'annotations' => array(
-					'readOnlyHint' => 'not-a-boolean', // This will cause ToolAnnotations::fromArray() to throw.
+					'readOnlyHint' => 'not-a-boolean',
 				),
 			)
 		);
 
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'mcp_tool_dto_creation_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Expected bool', $result->get_error_message() );
+		$this->assertSame( 'mcp_tool_validation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'must be a boolean', $result->get_error_message() );
+
+		remove_filter( 'mcp_adapter_validation_enabled', '__return_true' );
 	}
 
 	// =========================================================================
@@ -553,6 +547,40 @@ final class McpToolTest extends TestCase {
 				'items'  => array( 1, 2, 3 ),
 			),
 			$result
+		);
+	}
+
+	public function test_execute_passes_continuation_only_to_opt_in_handler_and_preserves_result(): void {
+		$context = new McpContinuationContext( array( 'answer' => 'yes' ), 'state-1' );
+		$tool    = McpTool::fromArray(
+			array(
+				'name'    => 'continuation-tool',
+				'handler' => static function ( array $arguments, ?McpContinuationContext $continuation ): McpExecutionResult {
+					return McpExecutionResult::input_required(
+						array( 'next' => array( 'method' => 'elicitation/create' ) ),
+						$continuation ? $continuation->get_request_state() : null
+					);
+				},
+			)
+		);
+
+		$result = $tool->execute( array(), $context );
+
+		$this->assertInstanceOf( McpExecutionResult::class, $result );
+		$this->assertSame( 'state-1', $result->get_request_state() );
+	}
+
+	public function test_execute_keeps_one_argument_handler_compatible_when_continuation_is_present(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'    => 'one-argument-tool',
+				'handler' => static fn( array $arguments ): array => $arguments,
+			)
+		);
+
+		$this->assertSame(
+			array( 'value' => 'ok' ),
+			$tool->execute( array( 'value' => 'ok' ), new McpContinuationContext() )
 		);
 	}
 

--- a/tests/phpunit/Unit/Tools/RegisterAbilityAsMcpToolTest.php
+++ b/tests/phpunit/Unit/Tools/RegisterAbilityAsMcpToolTest.php
@@ -6,19 +6,18 @@ namespace WP\MCP\Tests\Unit\Tools;
 
 use WP\MCP\Domain\Tools\RegisterAbilityAsMcpTool;
 use WP\MCP\Tests\TestCase;
-use WP\McpSchema\Server\Tools\DTO\Tool as ToolDto;
 
 final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 	/**
-	 * @param \WP_Ability $ability The ability to build into a Tool DTO.
+	 * @param \WP_Ability $ability The ability to build into tool protocol data.
 	 */
-	private function build_tool_from_ability( \WP_Ability $ability ): ToolDto {
+	private function build_tool_from_ability( \WP_Ability $ability ): array {
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
 		$this->assertIsArray( $built );
 		$this->assertArrayHasKey( 'tool', $built );
-		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
+		$this->assertIsArray( $built['tool'] );
 
 		return $built['tool'];
 	}
@@ -27,7 +26,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$ability = wp_get_ability( 'test/always-allowed' );
 		$this->assertNotNull( $ability, 'Ability test/always-allowed should be registered' );
 		$tool = $this->build_tool_from_ability( $ability );
-		$arr  = $tool->toArray();
+		$arr  = $tool;
 		$this->assertSame( 'test-always-allowed', $arr['name'] );
 		$this->assertArrayHasKey( 'inputSchema', $arr );
 	}
@@ -38,7 +37,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify MCP-format annotations.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -63,7 +62,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify only non-null annotations are present.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -79,7 +78,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify instructions field is not in the output.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -96,7 +95,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify MCP-native fields are preserved.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -116,7 +115,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify annotations field is not present.
 		$this->assertArrayNotHasKey( 'annotations', $arr );
@@ -128,7 +127,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify annotations field is not present when all values are null.
 		$this->assertArrayNotHasKey( 'annotations', $arr );
@@ -140,7 +139,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify annotations exist.
 		$this->assertArrayHasKey( 'annotations', $arr );
@@ -167,7 +166,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 			$tool = $this->build_tool_from_ability( $ability );
 
-			$arr = $tool->toArray();
+			$arr = $tool;
 
 		if ( ! isset( $arr['annotations'] ) ) {
 			// If no annotations, test passes.
@@ -224,7 +223,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotNull( $ability, 'Ability test/flat-transformed-tool should be registered' );
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
-		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
+		$this->assertIsArray( $built['tool'] );
 
 		$adapter_meta = $built['adapter_meta'];
 		$this->assertSame( 'test/flat-transformed-tool', $adapter_meta['ability'] );
@@ -269,9 +268,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( ToolDto::class, $tool );
+		$this->assertIsArray( $tool );
 
-			$data = $tool->toArray();
+			$data = $tool;
 			$this->assertArrayHasKey( '_meta', $data );
 			$this->assertSame( 'public_meta_value', $data['_meta']['public_meta_key'] );
 			$this->assertSame( 'public_meta_other_value', $data['_meta']['public_meta_other'] );
@@ -311,7 +310,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 			$tool = $this->build_tool_from_ability( $ability );
 
-			$arr = $tool->toArray();
+			$arr = $tool;
 			$this->assertSame( 'custom-filtered-name', $arr['name'] );
 
 		remove_filter( 'mcp_adapter_tool_name', $filter_callback );
@@ -377,7 +376,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 			$tool = $this->build_tool_from_ability( $ability );
 
-			$arr = $tool->toArray();
+			$arr = $tool;
 			$this->assertSame( 'test-slash-ability', $arr['name'] );
 
 		wp_unregister_ability( 'test/slash-ability' );
@@ -411,7 +410,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
-		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
+		$this->assertIsArray( $built['tool'] );
 
 		// Verify input transformation metadata is present.
 		$adapter_meta = $built['adapter_meta'];
@@ -452,7 +451,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
-		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
+		$this->assertIsArray( $built['tool'] );
 
 		$adapter_meta = $built['adapter_meta'];
 		$this->assertSame( 'test/output-only-transformed', $adapter_meta['ability'] );
@@ -506,7 +505,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$built = RegisterAbilityAsMcpTool::build( $ability );
 		$this->assertNotWPError( $built );
-		$this->assertInstanceOf( ToolDto::class, $built['tool'] );
+		$this->assertIsArray( $built['tool'] );
 
 		$adapter_meta = $built['adapter_meta'];
 
@@ -531,7 +530,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify icons field exists and has correct structure.
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -557,7 +556,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify icons field exists with only valid icons.
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -580,9 +579,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( ToolDto::class, $tool );
+		$this->assertIsArray( $tool );
 
-		$meta = $tool->get_meta();
+		$meta = $tool['_meta'];
 		$this->assertIsArray( $meta );
 
 		// Verify custom vendor keys are present.
@@ -604,9 +603,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( ToolDto::class, $tool );
+		$this->assertIsArray( $tool );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify icons field exists.
 		$this->assertArrayHasKey( 'icons', $arr );
@@ -615,7 +614,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertSame( array( '48x48' ), $arr['icons'][0]['sizes'] );
 
 		// Verify custom _meta exists (internal adapter metadata is not exposed here).
-		$meta = $tool->get_meta();
+		$meta = $tool['_meta'];
 		$this->assertArrayHasKey( 'vendor_info', $meta );
 		$this->assertSame( 'test-value', $meta['vendor_info']['custom_data'] );
 		$this->assertSame( 'test/with-icons-and-meta', $built['adapter_meta']['ability'] );
@@ -628,7 +627,7 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 
 		$tool = $this->build_tool_from_ability( $ability );
 
-		$arr = $tool->toArray();
+		$arr = $tool;
 
 		// Verify icons field is not present.
 		$this->assertArrayNotHasKey( 'icons', $arr );
@@ -643,9 +642,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( ToolDto::class, $tool );
+		$this->assertIsArray( $tool );
 
-		$data = $tool->toArray();
+		$data = $tool;
 		$this->assertArrayNotHasKey( '_meta', $data );
 		$this->assertSame( 'test/always-allowed', $built['adapter_meta']['ability'] );
 	}
@@ -686,9 +685,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( ToolDto::class, $tool );
+		$this->assertIsArray( $tool );
 
-		$data = $tool->toArray();
+		$data = $tool;
 		$this->assertArrayHasKey( '_meta', $data );
 		$this->assertArrayHasKey( 'mcp_adapter', $data['_meta'] );
 		$this->assertSame(
@@ -736,9 +735,9 @@ final class RegisterAbilityAsMcpToolTest extends TestCase {
 		$this->assertNotWPError( $built );
 
 		$tool = $built['tool'];
-		$this->assertInstanceOf( ToolDto::class, $tool );
+		$this->assertIsArray( $tool );
 
-		$data = $tool->toArray();
+		$data = $tool;
 		$this->assertArrayNotHasKey( '_meta', $data );
 		$this->assertSame( 'test/empty-meta', $built['adapter_meta']['ability'] );
 

--- a/tests/phpunit/Unit/Transport/Infrastructure/DtoSerializationRegressionTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/DtoSerializationRegressionTest.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Regression tests for DTO serialization at the transport boundary.
+ * Regression tests for schema-backed serialization at the transport boundary.
  *
- * These tests ensure schema DTOs round-trip to arrays and JSON without producing placeholder `{}` objects
- * for nested DTOs.
+ * These tests ensure validated schema records round-trip to JSON without
+ * producing placeholder `{}` objects for nested records.
  *
  * @package McpAdapter
  */
@@ -15,10 +15,7 @@ namespace WP\MCP\Tests\Unit\Transport\Infrastructure;
 use WP\MCP\Domain\Utils\ContentBlockHelper;
 use WP\MCP\Tests\TestCase;
 use WP\MCP\Transport\Infrastructure\JsonRpcResponseBuilder;
-use WP\McpSchema\Common\Protocol\DTO\BlobResourceContents;
-use WP\McpSchema\Common\Protocol\DTO\TextResourceContents;
-use WP\McpSchema\Server\Resources\DTO\ReadResourceResult;
-use WP\McpSchema\Server\Tools\DTO\CallToolResult;
+use WP\McpSchema\Schemas;
 
 final class DtoSerializationRegressionTest extends TestCase {
 
@@ -33,14 +30,14 @@ final class DtoSerializationRegressionTest extends TestCase {
 			)
 		);
 
-		$dto = CallToolResult::fromArray(
+		$record = Schemas::v20251125()->callToolResult()->fromArray(
 			array(
 				'content' => array( $block ),
 				'isError' => false,
 			)
 		);
 
-		$result = $dto->toArray();
+		$result = $record->toWireArray();
 
 		$response = JsonRpcResponseBuilder::create_success_response( 1, $result );
 		$json     = wp_json_encode( $response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
@@ -67,29 +64,25 @@ final class DtoSerializationRegressionTest extends TestCase {
 	}
 
 	public function test_read_resource_result_serializes_contents_items_as_arrays_without_placeholder_objects(): void {
-		$text = TextResourceContents::fromArray(
-			array(
-				'uri'      => 'WordPress://local/resource-1',
-				'text'     => 'content',
-				'mimeType' => 'text/plain',
-				'_meta'    => array(
-					'keep' => 'value',
-				),
-			)
+		$text = array(
+			'uri'      => 'WordPress://local/resource-1',
+			'text'     => 'content',
+			'mimeType' => 'text/plain',
+			'_meta'    => array(
+				'keep' => 'value',
+			),
 		);
 
-		$blob = BlobResourceContents::fromArray(
-			array(
-				'uri'      => 'WordPress://local/resource-2',
-				'blob'     => 'YmFzZTY0', // "base64" - not important for this test.
-				'mimeType' => 'application/octet-stream',
-				'_meta'    => array(
-					'keep' => 'blob-meta',
-				),
-			)
+		$blob = array(
+			'uri'      => 'WordPress://local/resource-2',
+			'blob'     => 'YmFzZTY0', // "base64" - not important for this test.
+			'mimeType' => 'application/octet-stream',
+			'_meta'    => array(
+				'keep' => 'blob-meta',
+			),
 		);
 
-		$dto = ReadResourceResult::fromArray(
+		$record = Schemas::v20251125()->readResourceResult()->fromArray(
 			array(
 				'contents' => array( $text, $blob ),
 				'_meta'    => array(
@@ -98,7 +91,7 @@ final class DtoSerializationRegressionTest extends TestCase {
 			)
 		);
 
-		$result = $dto->toArray();
+		$result = $record->toWireArray();
 
 		$response = JsonRpcResponseBuilder::create_success_response( 1, $result );
 		$json     = wp_json_encode( $response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
@@ -114,14 +107,14 @@ final class DtoSerializationRegressionTest extends TestCase {
 		$this->assertIsArray( $decoded['result']['contents'] );
 		$this->assertCount( 2, $decoded['result']['contents'] );
 
-			$this->assertSame( 'WordPress://local/resource-1', $decoded['result']['contents'][0]['uri'] );
-			$this->assertSame( 'content', $decoded['result']['contents'][0]['text'] );
-			$this->assertSame( 'text/plain', $decoded['result']['contents'][0]['mimeType'] );
-			$this->assertSame( 'value', $decoded['result']['contents'][0]['_meta']['keep'] );
+		$this->assertSame( 'WordPress://local/resource-1', $decoded['result']['contents'][0]['uri'] );
+		$this->assertSame( 'content', $decoded['result']['contents'][0]['text'] );
+		$this->assertSame( 'text/plain', $decoded['result']['contents'][0]['mimeType'] );
+		$this->assertSame( 'value', $decoded['result']['contents'][0]['_meta']['keep'] );
 
-			$this->assertSame( 'WordPress://local/resource-2', $decoded['result']['contents'][1]['uri'] );
-			$this->assertSame( 'YmFzZTY0', $decoded['result']['contents'][1]['blob'] );
-			$this->assertSame( 'application/octet-stream', $decoded['result']['contents'][1]['mimeType'] );
-			$this->assertSame( 'blob-meta', $decoded['result']['contents'][1]['_meta']['keep'] );
+		$this->assertSame( 'WordPress://local/resource-2', $decoded['result']['contents'][1]['uri'] );
+		$this->assertSame( 'YmFzZTY0', $decoded['result']['contents'][1]['blob'] );
+		$this->assertSame( 'application/octet-stream', $decoded['result']['contents'][1]['mimeType'] );
+		$this->assertSame( 'blob-meta', $decoded['result']['contents'][1]['_meta']['keep'] );
 	}
 }

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
@@ -91,6 +91,15 @@ final class HttpRequestHandlerTest extends TestCase {
 		$this->assertEquals( McpErrorFactory::PARSE_ERROR, $data['error']['code'] );
 	}
 
+	public function test_handle_request_post_empty_batch_is_invalid_request(): void {
+		$request  = $this->createPostRequest( array() );
+		$context  = new HttpRequestContext( $request );
+		$response = $this->handler->handle_request( $context );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $response->get_data()['error']['code'] );
+	}
+
 	public function test_handle_request_post_initialize(): void {
 		$request = $this->createPostRequest(
 			array(
@@ -511,7 +520,7 @@ final class HttpRequestHandlerTest extends TestCase {
 		$response = $this->handler->handle_request( new HttpRequestContext( $request ) );
 		$data     = $response->get_data();
 
-		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 400, $response->get_status() );
 		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $data['error']['code'] );
 		$this->assertSame( 75, $data['id'] );
 	}
@@ -584,6 +593,89 @@ final class HttpRequestHandlerTest extends TestCase {
 		$this->assertArrayNotHasKey( 'error', $data );
 	}
 
+	public function test_raw_legacy_initialize_rejects_capabilities_list(): void {
+		$response = $this->handleRawRequest(
+			'{"jsonrpc":"2.0","id":80,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":[],"clientInfo":{"name":"raw-client","version":"1.0.0"}}}'
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $data['error']['code'] );
+	}
+
+	public function test_raw_modern_request_accepts_client_capabilities_object(): void {
+		$response = $this->handleRawRequest(
+			'{"jsonrpc":"2.0","id":81,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}',
+			'2026-07-28'
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'result', $data );
+	}
+
+	public function test_raw_modern_request_rejects_client_capabilities_list(): void {
+		$response = $this->handleRawRequest(
+			'{"jsonrpc":"2.0","id":82,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":[]}}}',
+			'2026-07-28'
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $data['error']['code'] );
+	}
+
+	public function test_raw_modern_tool_arguments_list_is_not_coerced_to_object(): void {
+		$response = $this->handleRawRequest(
+			'{"jsonrpc":"2.0","id":83,"method":"tools/call","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"name":"test-always-allowed","arguments":[]}}',
+			'2026-07-28'
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $data['error']['code'] );
+	}
+
+	public function test_raw_modern_prompt_arguments_list_is_not_coerced_to_object(): void {
+		$response = $this->handleRawRequest(
+			'{"jsonrpc":"2.0","id":84,"method":"prompts/get","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"name":"test/prompt","arguments":[]}}',
+			'2026-07-28'
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $data['error']['code'] );
+	}
+
+	public function test_raw_modern_continuation_response_list_is_not_coerced_to_map(): void {
+		$response = $this->handleRawRequest(
+			'{"jsonrpc":"2.0","id":85,"method":"tools/call","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"name":"test-always-allowed","arguments":{},"inputResponses":[],"requestState":"opaque"}}',
+			'2026-07-28'
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $data['error']['code'] );
+	}
+
+	public function test_modern_http_response_preserves_numeric_key_objects(): void {
+		$filter = static fn() => array(
+			'numeric' => (object) array( 0 => 'zero' ),
+		);
+		add_filter( 'mcp_adapter_tool_call_result', $filter );
+
+		try {
+			$response = $this->handleRawRequest(
+				'{"jsonrpc":"2.0","id":86,"method":"tools/call","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"name":"test-always-allowed","arguments":{}}}',
+				'2026-07-28'
+			);
+			$data     = $response->get_data();
+			$result   = (array) $data['result'];
+
+			$this->assertSame( 200, $response->get_status() );
+			$this->assertInstanceOf( \stdClass::class, $result['structuredContent']['numeric'] );
+			$this->assertStringContainsString( '"numeric":{"0":"zero"}', wp_json_encode( $data ) );
+		} finally {
+			remove_filter( 'mcp_adapter_tool_call_result', $filter );
+		}
+	}
+
 	// Helper methods
 
 	/**
@@ -643,9 +735,53 @@ final class HttpRequestHandlerTest extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/test-mcp' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_header( 'Accept', 'application/json, text/event-stream' );
-		$request->set_body( wp_json_encode( $body ) );
+		$request->set_body( wp_json_encode( $this->normalizeTestWireObjects( $body ) ) );
 
 		return $request;
+	}
+
+	private function handleRawRequest( string $json, ?string $protocol_version = null ): WP_REST_Response {
+		$request = new WP_REST_Request( 'POST', '/test-mcp' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_header( 'Accept', 'application/json, text/event-stream' );
+		if ( null !== $protocol_version ) {
+			$request->set_header( 'Mcp-Protocol-Version', $protocol_version );
+		}
+		$request->set_body( $json );
+
+		return $this->handler->handle_request( new HttpRequestContext( $request ) );
+	}
+
+	/**
+	 * Express empty object fields accurately in fixtures assembled as PHP arrays.
+	 *
+	 * Raw identity regressions set the JSON body directly and bypass this helper.
+	 *
+	 * @param mixed       $value Fixture value.
+	 * @param string|null $key Parent key.
+	 * @return mixed
+	 */
+	private function normalizeTestWireObjects( $value, ?string $key = null ) {
+		$object_keys = array(
+			'_meta',
+			'arguments',
+			'capabilities',
+			'io.modelcontextprotocol/clientCapabilities',
+			'params',
+		);
+		if ( array() === $value && null !== $key && in_array( $key, $object_keys, true ) ) {
+			return new \stdClass();
+		}
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$result = array();
+		foreach ( $value as $item_key => $item ) {
+			$result[ $item_key ] = $this->normalizeTestWireObjects( $item, (string) $item_key );
+		}
+
+		return $result;
 	}
 
 	private function createTransportContext( McpServer $server ): McpTransportContext {

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpRequestHandlerTest.php
@@ -99,6 +99,7 @@ final class HttpRequestHandlerTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -128,6 +129,7 @@ final class HttpRequestHandlerTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -180,6 +182,7 @@ final class HttpRequestHandlerTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -230,6 +233,7 @@ final class HttpRequestHandlerTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -315,6 +319,7 @@ final class HttpRequestHandlerTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -355,7 +360,7 @@ final class HttpRequestHandlerTest extends TestCase {
 		$this->assertStringContainsString( 'Method not allowed', $data['error']['message'] );
 	}
 
-	public function test_handle_request_post_withNoProtocolVersionHeader_acceptsRequest(): void {
+	public function test_handle_request_post_with_no_protocol_version_header_rejects_legacy_request(): void {
 		// Create session first.
 		$session_id = $this->initializeAndGetSessionId();
 
@@ -374,11 +379,11 @@ final class HttpRequestHandlerTest extends TestCase {
 		$response = $this->handler->handle_request( $context );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 400, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertArrayHasKey( 'result', $data );
-		$this->assertArrayNotHasKey( 'error', $data );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $data['error']['code'] );
+		$this->assertStringContainsString( 'Missing MCP-Protocol-Version header', $data['error']['message'] );
 	}
 
 	public function test_handle_request_post_withSupportedProtocolVersionHeader_acceptsRequest(): void {
@@ -407,34 +412,146 @@ final class HttpRequestHandlerTest extends TestCase {
 		$this->assertArrayNotHasKey( 'error', $data );
 	}
 
-	public function test_handle_request_post_withUnsupportedProtocolVersionHeader_returnsError(): void {
-		// Create session first.
-		$session_id = $this->initializeAndGetSessionId();
-
+	public function test_handle_request_post_with_unsupported_protocol_version_returns_exact_error(): void {
+		$params = $this->modern_params();
+		$params['_meta']['io.modelcontextprotocol/protocolVersion'] = '9999-99-99';
 		$request = $this->createPostRequest(
 			array(
 				'jsonrpc' => '2.0',
 				'id'      => 2,
 				'method'  => 'tools/list',
-				'params'  => array(),
+				'params'  => $params,
 			)
 		);
-		$request->set_header( 'Mcp-Session-Id', $session_id );
 		$request->set_header( 'Mcp-Protocol-Version', '9999-99-99' );
 
 		$context  = new HttpRequestContext( $request );
 		$response = $this->handler->handle_request( $context );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		// INVALID_REQUEST (-32600) maps to HTTP 400 via McpErrorFactory::mcp_error_to_http_status().
 		$this->assertEquals( 400, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertArrayHasKey( 'error', $data );
 		$this->assertEquals( 2, $data['id'] );
-		$this->assertEquals( McpErrorFactory::INVALID_REQUEST, $data['error']['code'] );
+		$this->assertEquals( McpErrorFactory::UNSUPPORTED_PROTOCOL_VERSION, $data['error']['code'] );
 		$this->assertStringContainsString( 'Unsupported protocol version', $data['error']['message'] );
-		$this->assertStringContainsString( '9999-99-99', $data['error']['message'] );
+		$this->assertSame( '9999-99-99', $data['error']['data']['requested'] );
+	}
+
+	public function test_modern_discovery_is_stateless_when_header_and_body_match(): void {
+		$request = $this->createPostRequest(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 70,
+				'method'  => 'server/discover',
+				'params'  => $this->modern_params( true ),
+			)
+		);
+		$request->set_header( 'Mcp-Protocol-Version', '2026-07-28' );
+		$context  = new HttpRequestContext( $request );
+		$response = $this->handler->handle_request( $context );
+		$data     = $response->get_data();
+		$result   = (array) $data['result'];
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 70, $data['id'] );
+		$this->assertSame( 'complete', $result['resultType'] );
+		$this->assertSame( array( '2026-07-28', '2025-11-25' ), $result['supportedVersions'] );
+		$this->assertSame( 0, $result['ttlMs'] );
+		$this->assertSame( 'private', $result['cacheScope'] );
+	}
+
+	public function test_modern_request_rejects_missing_protocol_header(): void {
+		$request  = $this->createPostRequest(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 71,
+				'method'  => 'tools/list',
+				'params'  => $this->modern_params(),
+			)
+		);
+		$response = $this->handler->handle_request( new HttpRequestContext( $request ) );
+		$data     = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( McpErrorFactory::HEADER_MISMATCH, $data['error']['code'] );
+		$this->assertSame( 71, $data['id'] );
+	}
+
+	public function test_modern_request_rejects_header_body_version_mismatch(): void {
+		$request = $this->createPostRequest(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 72,
+				'method'  => 'tools/list',
+				'params'  => $this->modern_params(),
+			)
+		);
+		$request->set_header( 'Mcp-Protocol-Version', '2025-11-25' );
+		$response = $this->handler->handle_request( new HttpRequestContext( $request ) );
+		$data     = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( McpErrorFactory::HEADER_MISMATCH, $data['error']['code'] );
+		$this->assertSame( '2026-07-28', $data['error']['data']['expected'] );
+		$this->assertSame( '2025-11-25', $data['error']['data']['actual'] );
+	}
+
+	public function test_modern_request_rejects_missing_body_metadata_even_with_header(): void {
+		$request = $this->createPostRequest(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 75,
+				'method'  => 'tools/list',
+				'params'  => array(),
+			)
+		);
+		$request->set_header( 'Mcp-Protocol-Version', '2026-07-28' );
+		$response = $this->handler->handle_request( new HttpRequestContext( $request ) );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $data['error']['code'] );
+		$this->assertSame( 75, $data['id'] );
+	}
+
+	public function test_modern_request_does_not_require_legacy_session(): void {
+		$request = $this->createPostRequest(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 73,
+				'method'  => 'tools/list',
+				'params'  => $this->modern_params(),
+			)
+		);
+		$request->set_header( 'Mcp-Protocol-Version', '2026-07-28' );
+		$response = $this->handler->handle_request( new HttpRequestContext( $request ) );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'result', $data );
+		$this->assertArrayNotHasKey( 'error', $data );
+	}
+
+	public function test_legacy_request_rejects_header_that_differs_from_session_revision(): void {
+		$session_id = $this->initializeAndGetSessionId();
+		$request    = $this->createPostRequest(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 74,
+				'method'  => 'tools/list',
+				'params'  => array(),
+			)
+		);
+		$request->set_header( 'Mcp-Session-Id', $session_id );
+		$request->set_header( 'Mcp-Protocol-Version', '2026-07-28' );
+		$response = $this->handler->handle_request( new HttpRequestContext( $request ) );
+		$data     = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $data['error']['code'] );
+		$this->assertStringContainsString( 'does not match', $data['error']['message'] );
 	}
 
 	public function test_handle_request_post_initialize_skipsProtocolVersionHeaderValidation(): void {
@@ -445,6 +562,7 @@ final class HttpRequestHandlerTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -481,6 +599,7 @@ final class HttpRequestHandlerTest extends TestCase {
 				'method'  => 'initialize',
 				'params'  => array(
 					'protocolVersion' => '2025-11-25',
+					'capabilities'    => array(),
 					'clientInfo'      => array(
 						'name'    => 'test-client',
 						'version' => '1.0.0',
@@ -504,11 +623,27 @@ final class HttpRequestHandlerTest extends TestCase {
 		return (string) array_key_last( $sessions );
 	}
 
+	/** @return array<string, mixed> */
+	private function modern_params( bool $include_client_info = false ): array {
+		$metadata = array(
+			'io.modelcontextprotocol/protocolVersion'    => '2026-07-28',
+			'io.modelcontextprotocol/clientCapabilities' => array(),
+		);
+		if ( $include_client_info ) {
+			$metadata['io.modelcontextprotocol/clientInfo'] = array(
+				'name'    => 'modern-http-client',
+				'version' => '1.0.0',
+			);
+		}
+
+		return array( '_meta' => $metadata );
+	}
+
 	private function createPostRequest( array $body ): WP_REST_Request {
 		$request = new WP_REST_Request( 'POST', '/test-mcp' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_header( 'Accept', 'application/json, text/event-stream' );
-		$request->set_body( json_encode( $body ) );
+		$request->set_body( wp_json_encode( $body ) );
 
 		return $request;
 	}

--- a/tests/phpunit/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/HttpSessionValidatorTest.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WP\MCP\Tests\Unit\Transport\Infrastructure;
 
+use WP\MCP\Core\McpVersionNegotiator;
 use WP\MCP\Infrastructure\ErrorHandling\McpErrorFactory;
 use WP\MCP\Tests\TestCase;
 use WP\MCP\Transport\Infrastructure\HttpRequestContext;
@@ -64,6 +65,52 @@ final class HttpSessionValidatorTest extends TestCase {
 		$this->assertArrayHasKey( 'error', $result );
 		$this->assertEquals( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
 		$this->assertStringContainsString( 'Missing Mcp-Session-Id header', $result['error']['message'] );
+	}
+
+	public function test_get_protocol_version_from_valid_session(): void {
+		wp_set_current_user( $this->test_user_id );
+		$session_id = SessionManager::create_session(
+			$this->test_user_id,
+			array( 'protocolVersion' => McpVersionNegotiator::LEGACY_PROTOCOL_VERSION )
+		);
+		$this->assertIsString( $session_id );
+
+		$request = new WP_REST_Request( 'POST', '/test' );
+		$request->set_header( 'Mcp-Session-Id', $session_id );
+
+		$this->assertSame(
+			McpVersionNegotiator::LEGACY_PROTOCOL_VERSION,
+			HttpSessionValidator::get_protocol_version( new HttpRequestContext( $request ) )
+		);
+	}
+
+	public function test_get_protocol_version_returns_session_validation_error(): void {
+		wp_set_current_user( $this->test_user_id );
+
+		$result = HttpSessionValidator::get_protocol_version(
+			new HttpRequestContext( new WP_REST_Request( 'POST', '/test' ) )
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
+		$this->assertNull( $result['id'] );
+	}
+
+	public function test_get_protocol_version_rejects_unsupported_session_version(): void {
+		wp_set_current_user( $this->test_user_id );
+		$session_id = SessionManager::create_session(
+			$this->test_user_id,
+			array( 'protocolVersion' => '1900-01-01' )
+		);
+		$this->assertIsString( $session_id );
+
+		$request = new WP_REST_Request( 'POST', '/test' );
+		$request->set_header( 'Mcp-Session-Id', $session_id );
+		$result = HttpSessionValidator::get_protocol_version( new HttpRequestContext( $request ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( McpErrorFactory::INVALID_REQUEST, $result['error']['code'] );
+		$this->assertStringContainsString( 'supported protocol version', $result['error']['message'] );
 	}
 
 	public function test_create_session_with_valid_user(): void {
@@ -195,7 +242,8 @@ final class HttpSessionValidatorTest extends TestCase {
 		$result = HttpSessionValidator::validate_session_header( $context );
 
 		$this->assertIsArray( $result );
-		$this->assertArrayNotHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 	}
 
 	/**
@@ -215,7 +263,8 @@ final class HttpSessionValidatorTest extends TestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'error', $result );
-		$this->assertArrayNotHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 	}
 
 	/**
@@ -235,7 +284,8 @@ final class HttpSessionValidatorTest extends TestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'error', $result );
-		$this->assertArrayNotHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 	}
 
 	/**
@@ -250,7 +300,8 @@ final class HttpSessionValidatorTest extends TestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'error', $result );
-		$this->assertArrayNotHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 	}
 
 	/**
@@ -268,7 +319,8 @@ final class HttpSessionValidatorTest extends TestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'error', $result );
-		$this->assertArrayNotHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 	}
 
 	/**
@@ -287,6 +339,7 @@ final class HttpSessionValidatorTest extends TestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'error', $result );
-		$this->assertArrayNotHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertNull( $result['id'] );
 	}
 }

--- a/tests/phpunit/Unit/Transport/Infrastructure/JsonRpcRequestDecoderTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/JsonRpcRequestDecoderTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests for lossless JSON-RPC request decoding.
+ *
+ * @package WP\MCP\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WP\MCP\Tests\Unit\Transport\Infrastructure;
+
+use WP\MCP\Tests\TestCase;
+use WP\MCP\Transport\Infrastructure\JsonRpcRequestDecoder;
+
+final class JsonRpcRequestDecoderTest extends TestCase {
+
+	public function test_preserves_nested_empty_object_and_list_identity(): void {
+		$valid   = false;
+		$decoded = JsonRpcRequestDecoder::decode(
+			'{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"object":{},"list":[]}}',
+			$valid
+		);
+
+		$this->assertTrue( $valid );
+		$this->assertIsArray( $decoded );
+		$this->assertInstanceOf( \stdClass::class, $decoded['params'] );
+		$this->assertInstanceOf( \stdClass::class, $decoded['params']->object );
+		$this->assertSame( array(), $decoded['params']->list );
+	}
+
+	public function test_preserves_batch_message_boundaries(): void {
+		$valid   = false;
+		$decoded = JsonRpcRequestDecoder::decode(
+			'[{"jsonrpc":"2.0","id":1,"method":"ping"},{"jsonrpc":"2.0","id":2,"method":"ping"}]',
+			$valid
+		);
+
+		$this->assertTrue( $valid );
+		$this->assertIsArray( $decoded );
+		$this->assertCount( 2, $decoded );
+		$this->assertIsArray( $decoded[0] );
+		$this->assertSame( 2, $decoded[1]['id'] );
+	}
+
+	public function test_reports_invalid_json_without_inventing_a_value(): void {
+		$valid   = true;
+		$decoded = JsonRpcRequestDecoder::decode( '{', $valid );
+
+		$this->assertFalse( $valid );
+		$this->assertNull( $decoded );
+	}
+}

--- a/tests/phpunit/Unit/Transport/Infrastructure/JsonRpcResponseBuilderTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/JsonRpcResponseBuilderTest.php
@@ -29,6 +29,16 @@ class JsonRpcResponseBuilderTest extends TestCase {
 	}
 
 	/**
+	 * Test that an object-shaped result retains its identity.
+	 */
+	public function test_create_success_response_preserves_object_identity(): void {
+		$result   = (object) array( 'status' => 'ok' );
+		$response = JsonRpcResponseBuilder::create_success_response( 123, $result );
+
+		$this->assertSame( $result, $response['result'] );
+	}
+
+	/**
 	 * Test creating an error response.
 	 */
 	public function test_create_error_response(): void {
@@ -41,7 +51,7 @@ class JsonRpcResponseBuilderTest extends TestCase {
 
 		$this->assertEquals( '2.0', $response['jsonrpc'] );
 		$this->assertEquals( 456, $response['id'] );
-		$this->assertEquals( $error, $response['error'] );
+		$this->assertSame( $error, $response['error'] );
 	}
 
 	/**

--- a/tests/phpunit/Unit/Transport/Infrastructure/JsonRpcResponseBuilderTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/JsonRpcResponseBuilderTest.php
@@ -70,6 +70,7 @@ class JsonRpcResponseBuilderTest extends TestCase {
 			),
 		);
 		$this->assertTrue( JsonRpcResponseBuilder::is_batch_request( $batch_body ) );
+		$this->assertFalse( JsonRpcResponseBuilder::is_batch_request( array() ) );
 
 		// Test single request
 		$single_body = array(

--- a/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -10,6 +10,8 @@ declare( strict_types=1 );
 namespace WP\MCP\Tests\Unit\Transport\Infrastructure;
 
 use WP\MCP\Core\McpServer;
+use WP\MCP\Core\McpVersionNegotiator;
+use WP\MCP\Domain\Continuation\McpExecutionResult;
 use WP\MCP\Handlers\Initialize\InitializeHandler;
 use WP\MCP\Handlers\Prompts\PromptsHandler;
 use WP\MCP\Handlers\Resources\ResourcesHandler;
@@ -23,7 +25,6 @@ use WP\MCP\Transport\Infrastructure\HttpRequestContext;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
 use WP\MCP\Transport\Infrastructure\RequestRouter;
 use WP\MCP\Transport\Infrastructure\SessionManager;
-use WP\McpSchema\Common\McpConstants;
 use WP_REST_Request;
 
 /**
@@ -78,6 +79,7 @@ final class RequestRouterTest extends TestCase {
 			'initialize',
 			array(
 				'protocolVersion' => '2025-11-25',
+				'capabilities'    => array(),
 				'clientInfo'      => array(
 					'name'    => 'test-client',
 					'version' => '1.0.0',
@@ -89,7 +91,7 @@ final class RequestRouterTest extends TestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'protocolVersion', $result );
-		$this->assertEquals( McpConstants::LATEST_PROTOCOL_VERSION, $result['protocolVersion'] );
+		$this->assertSame( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION, $result['protocolVersion'] );
 		$this->assertArrayHasKey( 'serverInfo', $result );
 
 		// Verify observability events (unified event name with status tag)
@@ -118,6 +120,7 @@ final class RequestRouterTest extends TestCase {
 			'initialize',
 			array(
 				'protocolVersion' => '2025-11-25',
+				'capabilities'    => array(),
 				'clientInfo'      => array(
 					'name'    => 'test-client',
 					'version' => '1.0.0',
@@ -160,7 +163,14 @@ final class RequestRouterTest extends TestCase {
 		$http_context = new HttpRequestContext( $request );
 		$result       = $this->router->route_request(
 			'initialize',
-			array( 'protocolVersion' => '2025-11-25' ),
+			array(
+				'protocolVersion' => '2025-11-25',
+				'capabilities'    => array(),
+				'clientInfo'      => array(
+					'name'    => 'test-client',
+					'version' => '1.0.0',
+				),
+			),
 			1,
 			'test-transport',
 			$http_context
@@ -359,6 +369,7 @@ final class RequestRouterTest extends TestCase {
 			'initialize',
 			array(
 				'protocolVersion' => '2025-11-25',
+				'capabilities'    => array(),
 				'clientInfo'      => array(
 					'name'    => 'test-client',
 					'version' => '1.0.0',
@@ -402,6 +413,7 @@ final class RequestRouterTest extends TestCase {
 			'initialize',
 			array(
 				'protocolVersion' => '2025-11-25',
+				'capabilities'    => array(),
 				'clientInfo'      => array(
 					'name'    => 'test-client',
 					'version' => '1.0.0',
@@ -638,6 +650,7 @@ final class RequestRouterTest extends TestCase {
 			'initialize',
 			array(
 				'protocolVersion' => '2025-11-25',
+				'capabilities'    => array(),
 				'clientInfo'      => array(
 					'name'    => 'test-client',
 					'version' => '1.0.0',
@@ -851,8 +864,7 @@ final class RequestRouterTest extends TestCase {
 		);
 
 		$this->assertIsArray( $result );
-		// Ping with null ID should still work
-		$this->assertEmpty( $result );
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $result['error']['code'] );
 	}
 
 	public function test_route_request_with_string_request_id(): void {
@@ -916,6 +928,194 @@ final class RequestRouterTest extends TestCase {
 		$this->assertIsArray( $result );
 		// Whitespace-only URI should be treated as empty
 		$this->assertArrayHasKey( 'error', $result );
+	}
+
+	public function test_initialize_falls_back_to_the_exact_legacy_revision(): void {
+		$result = $this->router->route_request(
+			'initialize',
+			array(
+				'protocolVersion' => '2024-11-05',
+				'capabilities'    => array(),
+				'clientInfo'      => array(
+					'name'    => 'fallback-client',
+					'version' => '1.0.0',
+				),
+			),
+			41,
+			'test-transport'
+		);
+
+		$this->assertSame( McpVersionNegotiator::LEGACY_PROTOCOL_VERSION, $result['protocolVersion'] );
+		$this->assertArrayNotHasKey( 'resultType', $result );
+		$this->assertArrayNotHasKey( 'ttlMs', $result );
+		$this->assertArrayNotHasKey( 'cacheScope', $result );
+	}
+
+	public function test_modern_discovery_is_explicit_and_schema_encoded(): void {
+		$result = $this->router->route_request(
+			'server/discover',
+			$this->modern_params( true ),
+			42,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( 'complete', $result['resultType'] );
+		$this->assertSame( McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS, $result['supportedVersions'] );
+		$this->assertSame( array( 'prompts', 'resources', 'tools' ), array_keys( $result['capabilities'] ) );
+		$this->assertSame( 0, $result['ttlMs'] );
+		$this->assertSame( 'private', $result['cacheScope'] );
+		$this->assertSame(
+			array(
+				'name'    => 'Test MCP Server',
+				'version' => '1.0.0',
+			),
+			$result['_meta']['io.modelcontextprotocol/serverInfo']
+		);
+	}
+
+	public function test_modern_request_requires_protocol_metadata(): void {
+		$result = $this->router->route_request(
+			'tools/list',
+			array(),
+			43,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $result['error']['code'] );
+		$this->assertStringContainsString( 'Invalid params', $result['error']['message'] );
+	}
+
+	public function test_unsupported_revision_is_rejected_before_handler_dispatch(): void {
+		$tools_handler = $this->createMock( ToolsHandler::class );
+		$tools_handler->expects( $this->never() )->method( 'list_tools' );
+		$this->context->tools_handler = $tools_handler;
+
+		$params = $this->modern_params();
+		$params['_meta']['io.modelcontextprotocol/protocolVersion'] = '2099-01-01';
+		$result = $this->router->route_request( 'tools/list', $params, 44, 'test-transport' );
+
+		$this->assertSame( McpErrorFactory::UNSUPPORTED_PROTOCOL_VERSION, $result['error']['code'] );
+		$this->assertSame( '2099-01-01', $result['error']['data']['requested'] );
+		$this->assertSame( McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS, $result['error']['data']['supported'] );
+	}
+
+	public function test_modern_ping_is_method_not_found(): void {
+		$result = $this->router->route_request(
+			'ping',
+			$this->modern_params(),
+			45,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( McpErrorFactory::METHOD_NOT_FOUND, $result['error']['code'] );
+	}
+
+	public function test_modern_list_result_has_only_the_applicable_cache_fields(): void {
+		$result = $this->router->route_request(
+			'tools/list',
+			$this->modern_params(),
+			46,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( 'complete', $result['resultType'] );
+		$this->assertSame( 0, $result['ttlMs'] );
+		$this->assertSame( 'private', $result['cacheScope'] );
+		$this->assertArrayHasKey( 'tools', $result );
+		$this->assertSame(
+			array(
+				'name'    => 'Test MCP Server',
+				'version' => '1.0.0',
+			),
+			$result['_meta']['io.modelcontextprotocol/serverInfo']
+		);
+	}
+
+	public function test_modern_call_result_omits_inapplicable_cache_fields(): void {
+		$params              = $this->modern_params();
+		$params['name']      = 'test-always-allowed';
+		$params['arguments'] = array( 'test' => 'value' );
+
+		$result = $this->router->route_request(
+			'tools/call',
+			$params,
+			47,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( 'complete', $result['resultType'] );
+		$this->assertArrayHasKey( 'content', $result );
+		$this->assertArrayNotHasKey( 'ttlMs', $result );
+		$this->assertArrayNotHasKey( 'cacheScope', $result );
+	}
+
+	public function test_request_schema_rejects_missing_required_tool_name(): void {
+		$result = $this->router->route_request(
+			'tools/call',
+			$this->modern_params(),
+			48,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( McpErrorFactory::INVALID_PARAMS, $result['error']['code'] );
+		$this->assertStringContainsString( 'name', $result['error']['message'] );
+	}
+
+	public function test_modern_input_required_result_is_encoded_without_callback_execution(): void {
+		$tools_handler = $this->createMock( ToolsHandler::class );
+		$tools_handler->expects( $this->once() )
+			->method( 'call_tool' )
+			->willReturn( McpExecutionResult::input_required( array(), 'opaque-state' ) );
+		$this->context->tools_handler = $tools_handler;
+
+		$params              = $this->modern_params();
+		$params['name']      = 'test-always-allowed';
+		$params['arguments'] = array();
+		$result              = $this->router->route_request(
+			'tools/call',
+			$params,
+			49,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( 'input_required', $result['resultType'] );
+		$this->assertSame( 'opaque-state', $result['requestState'] );
+		$this->assertArrayNotHasKey( 'ttlMs', $result );
+		$this->assertArrayNotHasKey( 'cacheScope', $result );
+	}
+
+	/**
+	 * Build the mandatory request metadata for the stateless protocol.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function modern_params( bool $include_client_info = false ): array {
+		$metadata = array(
+			'io.modelcontextprotocol/protocolVersion'    => McpVersionNegotiator::MODERN_PROTOCOL_VERSION,
+			'io.modelcontextprotocol/clientCapabilities' => array(),
+		);
+		if ( $include_client_info ) {
+			$metadata['io.modelcontextprotocol/clientInfo'] = array(
+				'name'    => 'modern-test-client',
+				'version' => '1.0.0',
+			);
+		}
+
+		return array( '_meta' => $metadata );
 	}
 
 	private function createTransportContext( McpServer $server ): McpTransportContext {

--- a/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
+++ b/tests/phpunit/Unit/Transport/Infrastructure/RequestRouterTest.php
@@ -11,7 +11,9 @@ namespace WP\MCP\Tests\Unit\Transport\Infrastructure;
 
 use WP\MCP\Core\McpServer;
 use WP\MCP\Core\McpVersionNegotiator;
+use WP\MCP\Domain\Continuation\McpContinuationContext;
 use WP\MCP\Domain\Continuation\McpExecutionResult;
+use WP\MCP\Domain\Tools\McpTool;
 use WP\MCP\Handlers\Initialize\InitializeHandler;
 use WP\MCP\Handlers\Prompts\PromptsHandler;
 use WP\MCP\Handlers\Resources\ResourcesHandler;
@@ -25,6 +27,9 @@ use WP\MCP\Transport\Infrastructure\HttpRequestContext;
 use WP\MCP\Transport\Infrastructure\McpTransportContext;
 use WP\MCP\Transport\Infrastructure\RequestRouter;
 use WP\MCP\Transport\Infrastructure\SessionManager;
+use WP\McpSchema\Server\Prompts\DTO\Prompt;
+use WP\McpSchema\Server\Resources\DTO\Resource;
+use WP\McpSchema\Server\Tools\DTO\Tool;
 use WP_REST_Request;
 
 /**
@@ -1059,6 +1064,160 @@ final class RequestRouterTest extends TestCase {
 		$this->assertArrayNotHasKey( 'cacheScope', $result );
 	}
 
+	/**
+	 * @dataProvider modernStructuredContentProvider
+	 * @param mixed $structured_content Arbitrary modern JSON value.
+	 */
+	public function test_modern_structured_content_round_trips_without_key_based_coercion( $structured_content ): void {
+		$tools_handler = $this->createMock( ToolsHandler::class );
+		$tools_handler->method( 'call_tool' )->willReturn(
+			array(
+				'content'           => array(),
+				'structuredContent' => $structured_content,
+			)
+		);
+		$this->context->tools_handler = $tools_handler;
+		$params                       = $this->modern_params();
+		$params['name']               = 'test-always-allowed';
+		$params['arguments']          = array();
+
+		$result = $this->router->route_request(
+			'tools/call',
+			$params,
+			48,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( 'complete', $result['resultType'] );
+		$this->assertArrayHasKey( 'structuredContent', $result );
+		$this->assertSame( $structured_content, $result['structuredContent'] );
+	}
+
+	public function test_modern_structured_content_preserves_numeric_key_objects(): void {
+		$numeric_object = json_decode( '{"0":"zero"}' );
+		$this->assertInstanceOf( \stdClass::class, $numeric_object );
+
+		$tools_handler = $this->createMock( ToolsHandler::class );
+		$tools_handler->method( 'call_tool' )->willReturn(
+			array(
+				'content'           => array(),
+				'structuredContent' => $numeric_object,
+			)
+		);
+		$this->context->tools_handler = $tools_handler;
+		$params                       = $this->modern_params();
+		$params['name']               = 'test-always-allowed';
+		$params['arguments']          = array();
+
+		$result = $this->router->route_request(
+			'tools/call',
+			$params,
+			48,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertInstanceOf( \stdClass::class, $result['structuredContent'] );
+		$this->assertSame( '{"0":"zero"}', wp_json_encode( $result['structuredContent'] ) );
+	}
+
+	public function test_facade_list_hooks_preserve_known_empty_objects(): void {
+		$tool_filter     = static fn(): array => array(
+			Tool::fromArray(
+				array(
+					'name'        => 'filtered-tool',
+					'inputSchema' => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+				)
+			),
+		);
+		$resource_filter = static fn(): array => array(
+			Resource::fromArray(
+				array(
+					'uri'         => 'file:///filtered',
+					'name'        => 'filtered-resource',
+					'annotations' => array(),
+				)
+			),
+		);
+		$prompt_filter   = static fn(): array => array(
+			Prompt::fromArray(
+				array(
+					'name'  => 'filtered-prompt',
+					'_meta' => array(),
+				)
+			),
+		);
+		add_filter( 'mcp_adapter_tools_list', $tool_filter );
+		add_filter( 'mcp_adapter_resources_list', $resource_filter );
+		add_filter( 'mcp_adapter_prompts_list', $prompt_filter );
+
+		try {
+			$tools     = $this->router->route_request( 'tools/list', $this->modern_params(), 60, 'test', null, McpVersionNegotiator::MODERN_PROTOCOL_VERSION );
+			$resources = $this->router->route_request( 'resources/list', $this->modern_params(), 61, 'test', null, McpVersionNegotiator::MODERN_PROTOCOL_VERSION );
+			$prompts   = $this->router->route_request( 'prompts/list', $this->modern_params(), 62, 'test', null, McpVersionNegotiator::MODERN_PROTOCOL_VERSION );
+
+			$this->assertArrayNotHasKey( 'error', $tools, (string) wp_json_encode( $tools ) );
+			$this->assertInstanceOf( \stdClass::class, $tools['tools'][0]['inputSchema']['properties'] );
+			$this->assertArrayNotHasKey( 'error', $resources, (string) wp_json_encode( $resources ) );
+			$this->assertInstanceOf( \stdClass::class, $resources['resources'][0]['annotations'] );
+			$this->assertArrayNotHasKey( 'error', $prompts, (string) wp_json_encode( $prompts ) );
+			$this->assertInstanceOf( \stdClass::class, $prompts['prompts'][0]['_meta'] );
+		} finally {
+			remove_filter( 'mcp_adapter_tools_list', $tool_filter );
+			remove_filter( 'mcp_adapter_resources_list', $resource_filter );
+			remove_filter( 'mcp_adapter_prompts_list', $prompt_filter );
+		}
+	}
+
+	/** @return array<string,array{0:mixed}> */
+	public static function modernStructuredContentProvider(): array {
+		return array(
+			'reserved-looking nested keys' => array(
+				array(
+					'arguments'      => array(),
+					'_meta'          => array(),
+					'inputResponses' => array(),
+				),
+			),
+			'list'                         => array( array( 'one', 'two' ) ),
+			'scalar'                       => array( 'value' ),
+			'boolean'                      => array( true ),
+			'explicit null'                => array( null ),
+			'business discriminator key'   => array( array( 'resultType' => 'input_required' ) ),
+		);
+	}
+
+	public function test_legacy_structured_content_rejects_non_object_values(): void {
+		$tools_handler = $this->createMock( ToolsHandler::class );
+		$tools_handler->method( 'call_tool' )->willReturn(
+			array(
+				'content'           => array(),
+				'structuredContent' => 'not-an-object',
+			)
+		);
+		$this->context->tools_handler = $tools_handler;
+
+		$result = $this->router->route_request(
+			'tools/call',
+			array(
+				'name'      => 'test-always-allowed',
+				'arguments' => array(),
+			),
+			49,
+			'test-transport',
+			null,
+			McpVersionNegotiator::LEGACY_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( McpErrorFactory::INTERNAL_ERROR, $result['error']['code'] );
+	}
+
 	public function test_request_schema_rejects_missing_required_tool_name(): void {
 		$result = $this->router->route_request(
 			'tools/call',
@@ -1096,6 +1255,156 @@ final class RequestRouterTest extends TestCase {
 		$this->assertSame( 'opaque-state', $result['requestState'] );
 		$this->assertArrayNotHasKey( 'ttlMs', $result );
 		$this->assertArrayNotHasKey( 'cacheScope', $result );
+	}
+
+	public function test_modern_input_required_accepts_zero_property_elicitation_schema(): void {
+		$tools_handler = $this->createMock( ToolsHandler::class );
+		$tools_handler->method( 'call_tool' )->willReturn(
+			McpExecutionResult::input_required(
+				array(
+					'empty-form' => array(
+						'method' => 'elicitation/create',
+						'params' => array(
+							'message'         => 'Continue',
+							'requestedSchema' => array(
+								'type'       => 'object',
+								'properties' => array(),
+							),
+						),
+					),
+				)
+			)
+		);
+		$this->context->tools_handler = $tools_handler;
+
+		$params = $this->modern_params();
+		$params['_meta']['io.modelcontextprotocol/clientCapabilities'] = array(
+			'elicitation' => array( 'form' => array() ),
+		);
+		$params['name']      = 'test-always-allowed';
+		$params['arguments'] = array();
+		$result              = $this->router->route_request( 'tools/call', $params, 63, 'test', null, McpVersionNegotiator::MODERN_PROTOCOL_VERSION );
+
+		$this->assertArrayNotHasKey( 'error', $result, (string) wp_json_encode( $result ) );
+		$this->assertSame( 'input_required', $result['resultType'] );
+		$this->assertInstanceOf( \stdClass::class, $result['inputRequests']['empty-form']['params']['requestedSchema']['properties'] );
+	}
+
+	public function test_modern_input_request_requires_declared_client_capability(): void {
+		$tools_handler = $this->createMock( ToolsHandler::class );
+		$tools_handler->method( 'call_tool' )->willReturn(
+			McpExecutionResult::input_required(
+				array(
+					'confirm' => array(
+						'method' => 'elicitation/create',
+						'params' => array(
+							'mode'            => 'form',
+							'message'         => 'Confirm',
+							'requestedSchema' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'confirmed' => array( 'type' => 'boolean' ),
+								),
+							),
+						),
+					),
+				)
+			)
+		);
+		$this->context->tools_handler = $tools_handler;
+
+		$params              = $this->modern_params();
+		$params['name']      = 'test-always-allowed';
+		$params['arguments'] = array();
+		$result              = $this->router->route_request(
+			'tools/call',
+			$params,
+			50,
+			'test-transport',
+			null,
+			McpVersionNegotiator::MODERN_PROTOCOL_VERSION
+		);
+
+		$this->assertSame( McpErrorFactory::MISSING_REQUIRED_CLIENT_CAPABILITY, $result['error']['code'] );
+		$this->assertArrayHasKey( 'elicitation', $result['error']['data']['requiredCapabilities'] );
+	}
+
+	public function test_modern_tool_continuation_round_trip_is_stateless(): void {
+		$tool = McpTool::fromArray(
+			array(
+				'name'       => 'round-trip-tool',
+				'permission' => '__return_true',
+				'handler'    => static function ( array $arguments, McpContinuationContext $continuation ): McpExecutionResult {
+					if ( ! $continuation->is_resumed() ) {
+						return McpExecutionResult::input_required(
+							array(
+								'confirm' => array(
+									'method' => 'elicitation/create',
+									'params' => array(
+										'mode'            => 'form',
+										'message'         => 'Confirm',
+										'requestedSchema' => array(
+											'type'       => 'object',
+											'properties' => array(
+												'confirmed' => array( 'type' => 'boolean' ),
+											),
+										),
+									),
+								),
+							),
+							'round-trip-state'
+						);
+					}
+
+					return McpExecutionResult::complete(
+						array(
+							'state'     => $continuation->get_request_state(),
+							'responses' => $continuation->get_input_responses(),
+						)
+					);
+				},
+			)
+		);
+		$this->assertInstanceOf( McpTool::class, $tool );
+		$server = new McpServer(
+			'continuation-server',
+			'mcp/v1',
+			'/continuation',
+			'Continuation Server',
+			'Stateless continuation test',
+			'1.0.0',
+			array(),
+			DummyErrorHandler::class,
+			DummyObservabilityHandler::class,
+			array( $tool )
+		);
+		$router = new RequestRouter( $this->createTransportContext( $server ) );
+		$params = $this->modern_params();
+		$params['_meta']['io.modelcontextprotocol/clientCapabilities'] = array(
+			'elicitation' => array( 'form' => array() ),
+		);
+		$params['name']      = 'round-trip-tool';
+		$params['arguments'] = array();
+
+		$first = $router->route_request( 'tools/call', $params, 51, 'test', null, McpVersionNegotiator::MODERN_PROTOCOL_VERSION );
+		$this->assertArrayNotHasKey( 'error', $first, (string) wp_json_encode( $first ) );
+		$this->assertSame( 'input_required', $first['resultType'] );
+		$this->assertSame( 'round-trip-state', $first['requestState'] );
+		$this->assertArrayHasKey( 'confirm', $first['inputRequests'] );
+
+		$params['requestState']   = $first['requestState'];
+		$params['inputResponses'] = array(
+			'confirm' => array(
+				'action'  => 'accept',
+				'content' => array( 'confirmed' => true ),
+			),
+		);
+		$second                   = $router->route_request( 'tools/call', $params, 52, 'test', null, McpVersionNegotiator::MODERN_PROTOCOL_VERSION );
+
+		$this->assertArrayNotHasKey( 'error', $second, (string) wp_json_encode( $second ) );
+		$this->assertSame( 'complete', $second['resultType'] );
+		$this->assertSame( 'round-trip-state', $second['structuredContent']['state'] );
+		$this->assertTrue( $second['structuredContent']['responses']['confirm']['content']['confirmed'] );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Adds exact descriptor-backed support for MCP `2025-11-25` and `2026-07-28` across initialization/discovery, tools, resources, resource templates, prompts, errors, HTTP, STDIO, and stateless multi-round continuation.

This is a draft experiment paired with WordPress/php-mcp-schema#14. It is not a release proposal.

## Why?

The Adapter previously coupled execution internals to one concrete DTO tree and revision-specific serialization behavior. Supporting two exact MCP revisions requires request-scoped revision identity, schema-owned wire validation, and lossless JSON object/list handling without duplicating schema codecs inside the Adapter.

## How?

- Selects an exact descriptor catalog for every request through `McpProtocolContext` and `RequestRouter`.
- Preserves the session-based `2025-11-25` initialize lifecycle, including fallback negotiation and required follow-up headers.
- Implements stateless `2026-07-28` `server/discover`, per-request metadata, header agreement, `-32020`, `-32021`, and `-32022` errors.
- Schema-validates every advertised tools, resources, templates, and prompts request, result, and complete JSON-RPC envelope.
- Emits exact modern `resultType` and cache fields; modern `ping` correctly remains method-not-found because the official schema has no `PingRequest`.
- Adds stateless input-required/resume support for `tools/call`, `resources/read`, and `prompts/get` through additive continuation context and result objects.
- Keeps component storage and execution revision-neutral while retaining established prompt-builder and hook payload contracts through five narrow descriptor-backed compatibility facades.
- Decodes HTTP and STDIO JSON losslessly so `{}` and `[]`, numeric-key objects, unknown fields, and opaque structured content retain exact wire identity.

### Use of AI Tools

AI assistance: Yes  
Tool(s): OpenAI Codex  
Model(s): GPT-5  
Used for: Repository analysis, implementation, tests, documentation, and local verification. The resulting changes and test evidence were reviewed against the recorded protocol and compatibility decisions before publication.

## Testing Instructions

- `npm run test:php` — passed: 1,077 tests, 3,897 assertions, 1 skipped
- `npm run lint:php` — passed across 66 analyzed paths
- `npm run lint:php:stan` — passed across 66 analyzed paths with no errors
- `composer validate --strict` — passed
- `git diff --check` — passed
- Official `@modelcontextprotocol/sdk` integration suite — 35/35 passed
- Official Inspector legacy-compatible flow — tools/resources/templates/prompts discovery, tool call, resource not-found, and prompt invalid-params passed
- Independent modern HTTP flow — discovery, all advertised list/call methods, required cache fields, modern method gating, unsupported version, and header mismatch passed

## Changelog Entry

> Developer - Add exact descriptor-backed MCP 2025-11-25 and 2026-07-28 protocol support.
