### PR TITLE
docs: change recommendation to be installed as a canonical plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,21 @@ For a full breakdown of the component structure, see the [Architecture Overview]
 
 ## Installation
 
-### As a WordPress Plugin (Recommended)
+MCP Adapter is distributed as a WordPress plugin. Install and activate it like any other plugin. The release ships with everything it needs, so there is no autoloader to wire up and no build step to run.
 
-MCP Adapter is designed to be installed as a WordPress plugin. To install you should download the latest stable release from the [GitHub Releases page](https://github.com/WordPress/mcp-adapter/releases/latest) and install it like any other WordPress plugin.
+Requires WordPress 6.9 or newer; the Abilities API is part of core, so there is no separate plugin to install.
 
-#### With WP-CLI
+### Manually
+
+Download the latest stable `mcp-adapter.zip` from the [GitHub Releases page](https://github.com/WordPress/mcp-adapter/releases/latest), then upload it from **Plugins → Add Plugin → Upload Plugin** and activate it.
+
+### With WP-CLI
 
 ```bash
 wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip --activate
 ```
 
-#### With WP-Env
+### With WP-Env
 
 ```jsonc
 // .wp-env.json
@@ -76,28 +80,20 @@ wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/downl
 }
 ```
 
-### As a Composer Library (for plugin developers)
+### As a dependency of your plugin
 
-Plugin developers may wish to install MCP Adapter as a Composer dependency to integrate MCP functionality into their own plugins.
-
-```bash
-composer require wordpress/mcp-adapter
-```
-
-#### Using Jetpack Autoloader (Highly Recommended)
-
-When multiple plugins use the MCP Adapter, it's highly recommended to use the [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) to prevent version conflicts. The Jetpack Autoloader ensures that only the latest version of shared packages is loaded, eliminating conflicts when different plugins use different versions of the same dependency.
-
-```bash
-composer require automattic/jetpack-autoloader
-```
-
-Then load it in your main plugin file instead of the standard Composer autoloader:
+The `WP\MCP` classes are provided by the MCP Adapter plugin, so declare it as a plugin dependency using the `Requires Plugins` field in your [plugin header](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/):
 
 ```php
 <?php
-require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
+/**
+ * Plugin Name:      My Plugin
+ * Description:      Adds MCP tools for my feature.
+ * Requires Plugins: mcp-adapter
+ */
 ```
+
+WordPress then ensures MCP Adapter is installed and active before your plugin loads. If you also need to enforce a minimum version, check the `WP_MCP_VERSION` constant at runtime alongside the availability check shown below.
 
 ### Using MCP Adapter in Your Plugin
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For a full breakdown of the component structure, see the [Architecture Overview]
 
 - **PHP**: >= 7.4
 - **WordPress**: >= 6.9 (includes the [Abilities API](https://developer.wordpress.org/news/2025/11/introducing-the-wordpress-abilities-api/) in core — no separate plugin)
-- **[php-mcp-schema](https://github.com/WordPress/php-mcp-schema)** (`^0.1.0`): Typed DTOs for MCP protocol types — installed automatically via Composer
+- **[php-mcp-schema](https://github.com/WordPress/php-mcp-schema)** (`^0.1.0`): Typed DTOs for MCP protocol types
 
 ## Installation
 
@@ -92,8 +92,6 @@ The `WP\MCP` classes are provided by the MCP Adapter plugin, so declare it as a 
  * Requires Plugins: mcp-adapter
  */
 ```
-
-WordPress then ensures MCP Adapter is installed and active before your plugin loads. If you also need to enforce a minimum version, check the `WP_MCP_VERSION` constant at runtime alongside the availability check shown below.
 
 ### Using MCP Adapter in Your Plugin
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Documentation for the WordPress MCP Adapter - transform WordPress abilities into
 ## Getting started
 
 - **[Quick Start Guide](getting-started/README.md)** - Get running in minutes with working examples
-- **[Installation Guide](getting-started/installation.md)** - Installation methods (Composer recommended)
+- **[Installation Guide](getting-started/installation.md)** - Installing and activating the plugin
 - **[Basic Examples](getting-started/basic-examples.md)** - Complete examples for tools, resources, and prompts
 
 ## Implementation guides

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -10,25 +10,18 @@ The MCP Adapter transforms WordPress abilities into AI-accessible interfaces, al
 
 - **PHP 7.4 or higher**
 - **WordPress 6.9 or higher** (Abilities API is built into core — no separate plugin)
-- **Composer** (optional — for plugin developers bundling the adapter as a dependency)
 
 ## Quick Start
 
 ### Step 1: Install MCP Adapter
 
-**Recommended: WordPress plugin**
+MCP Adapter is a WordPress plugin. Install and activate it:
 
 ```bash
 wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip --activate
 ```
 
-Or download the latest release from [GitHub](https://github.com/WordPress/mcp-adapter/releases/latest) and install it like any other plugin.
-
-**For plugin developers: Composer package**
-
-```bash
-composer require wordpress/mcp-adapter
-```
+Or download the latest release from [GitHub](https://github.com/WordPress/mcp-adapter/releases/latest) and install it like any other plugin. See the [Installation Guide](installation.md) for more options.
 
 ### Step 2: Register a Simple Ability
 
@@ -74,36 +67,7 @@ add_action( 'wp_abilities_api_init', function() {
 });
 ```
 
-### Step 3: Initialize MCP Adapter
-
-**If using Composer with Jetpack Autoloader (Recommended):**
-```php
-<?php
-// Load Jetpack autoloader (handles version conflicts)
-require_once __DIR__ . '/vendor/autoload_packages.php';
-
-use WP\MCP\Core\McpAdapter;
-
-// Initialize the adapter
-McpAdapter::instance();
-```
-
-**If using standard Composer autoloader:**
-```php
-<?php
-// Load standard Composer autoloader
-require_once __DIR__ . '/vendor/autoload.php';
-
-use WP\MCP\Core\McpAdapter;
-
-// Initialize the adapter
-McpAdapter::instance();
-```
-
-**If using WordPress Plugin:**
-The adapter initializes automatically when the plugin is activated.
-
-### Step 4: Create Your MCP Server (Optional)
+### Step 3: Create Your MCP Server (Optional)
 
 The adapter creates a default server automatically, but you can create custom servers:
 
@@ -124,7 +88,7 @@ add_action( 'mcp_adapter_init', function( $adapter ) {
 });
 ```
 
-### Step 5: Test Your Setup
+### Step 4: Test Your Setup
 
 Test your MCP server:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,7 +14,7 @@ The plugin automatically initializes and creates a default MCP server at `/wp-js
 
 ## Depending on MCP Adapter from your own plugin
 
-The `WP\MCP` classes are provided by the MCP Adapter plugin. Declare it as a plugin dependency using the `Requires Plugins` field in your [plugin header](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/). WordPress then ensures MCP Adapter is installed and active before your plugin loads. Still guard your code at runtime, so a deactivated dependency degrades gracefully:
+The `WP\MCP` classes are provided by the MCP Adapter plugin. Declare it as a plugin dependency using the `Requires Plugins` field in your [plugin header](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/).
 
 ```php
 <?php

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,10 +1,8 @@
 # Installation Guide
 
-This guide covers different installation methods for the MCP Adapter.
+MCP Adapter is distributed as a WordPress plugin. Install and activate it like any other plugin. Requires WordPress 6.9 or newer.
 
-## Installation Methods
-
-### Method 1: WordPress Plugin (Recommended)
+## Installing the plugin
 
 Download the latest release from [GitHub](https://github.com/WordPress/mcp-adapter/releases/latest) and install it like any other WordPress plugin, or use WP-CLI:
 
@@ -14,53 +12,17 @@ wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/downl
 
 The plugin automatically initializes and creates a default MCP server at `/wp-json/mcp/mcp-adapter-default-server`.
 
-Requires WordPress 6.9 or newer. The Abilities API ships with core — you do not need a separate abilities-api plugin.
+## Depending on MCP Adapter from your own plugin
 
-### Method 2: Composer Package (for plugin developers)
-
-If you are building a plugin that depends on MCP Adapter, install it as a Composer package:
-
-```bash
-composer require wordpress/mcp-adapter
-```
-
-#### Using Jetpack Autoloader (Highly Recommended)
-
-When multiple plugins use the MCP Adapter, use the [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) to prevent version conflicts:
-
-```bash
-composer require automattic/jetpack-autoloader
-```
-
-Then load it in your plugin:
-
-```php
-<?php
-// Load the Jetpack autoloader instead of vendor/autoload.php
-require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
-
-use WP\MCP\Core\McpAdapter;
-
-// Initialize the adapter
-McpAdapter::instance();
-```
-
-#### Benefits
-- Version conflict resolution
-- Plugin compatibility 
-- WordPress optimized
-- Automatic dependency management
-
-#### Using MCP Adapter in Your Plugin
-
-Once the MCP Adapter plugin is active, you can use it in your own plugins:
+The `WP\MCP` classes are provided by the MCP Adapter plugin. Declare it as a plugin dependency using the `Requires Plugins` field in your [plugin header](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/). WordPress then ensures MCP Adapter is installed and active before your plugin loads. Still guard your code at runtime, so a deactivated dependency degrades gracefully:
 
 ```php
 <?php
 /**
- * Plugin Name: My MCP Plugin
- * Description: Demonstrates MCP Adapter integration
- * Version: 1.0.0
+ * Plugin Name:      My MCP Plugin
+ * Description:      Demonstrates MCP Adapter integration
+ * Version:          1.0.0
+ * Requires Plugins: mcp-adapter
  */
 
 // Prevent direct access
@@ -197,7 +159,11 @@ add_action( 'wp_loaded', function() {
 **MCP Adapter plugin not found**
 - Verify the plugin is installed in `wp-content/plugins/mcp-adapter/`
 - Check the plugin is activated in WordPress admin
+
+**"The Composer autoloader was not found"**
+- Only affects source checkouts; the release zip ships with its `vendor/` directory
 - Run `composer install` in the plugin directory
+- Check `vendor/autoload_packages.php` exists
 
 **"WordPress Abilities API not available"**
 - Requires WordPress 6.9 or higher. The Abilities API is part of core — there is no separate plugin to install.
@@ -206,10 +172,6 @@ add_action( 'wp_loaded', function() {
 - Check WordPress REST API is enabled
 - Verify permalink structure is not "Plain"
 - Test basic REST API: `curl "https://yoursite.com/wp-json/"`
-
-**Composer autoloader missing**
-- Run `composer install` in the plugin directory
-- Check `vendor/autoload.php` exists
 
 ### Debug Mode
 
@@ -238,7 +200,7 @@ Once installation is complete:
 - **WordPress**: >= 6.9
 
 ### Optional
-- **Composer**: For dependency management
 - **WP-CLI**: For command-line MCP server testing
+- **Composer**: Only needed to build from a source checkout; release builds ship with their dependencies
 
 The MCP Adapter automatically handles initialization and creates a default server when activated.

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -4,12 +4,6 @@ Common issues and quick solutions for the MCP Adapter.
 
 ## Quick Fixes
 
-### MCP Adapter Not Found
-```bash
-# Check plugin is installed and active
-wp plugin status mcp-adapter
-```
-
 ### REST API 404 Errors
 ```bash
 # Check WordPress REST API works

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -6,11 +6,8 @@ Common issues and quick solutions for the MCP Adapter.
 
 ### MCP Adapter Not Found
 ```bash
-# Check plugin is active
+# Check plugin is installed and active
 wp plugin status mcp-adapter
-
-# If using Composer, verify Jetpack autoloader
-ls vendor/autoload_packages.php
 ```
 
 ### REST API 404 Errors
@@ -81,49 +78,30 @@ wp plugin activate mcp-adapter
 wp plugin status mcp-adapter
 ```
 
-### Composer Dependencies Missing
+### Composer Autoloader Missing
+
+If you see *"The Composer autoloader was not found"*, the plugin's dependencies have not been installed. The release zip ships with its `vendor/` directory, so this only happens when the plugin was installed from a source checkout.
+
 ```bash
-# Install dependencies including Jetpack Autoloader
+# Install dependencies in the plugin directory
 cd wp-content/plugins/mcp-adapter
-composer require automattic/jetpack-autoloader
 composer install
 
-# Check Jetpack autoloader exists
+# Check the autoloader exists (Jetpack Autoloader, not autoload.php)
 ls vendor/autoload_packages.php
 ```
 
-### Why Use Jetpack Autoloader?
+Alternatively, install a release build instead of a source checkout:
 
-**Problem**: Multiple plugins using different versions of MCP Adapter can cause conflicts:
+```bash
+wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip --activate --force
 ```
-Plugin A uses MCP Adapter v1.0 → loads first
-Plugin B uses MCP Adapter v1.2 → can't load, causes errors
-```
-
-**Solution**: Jetpack Autoloader automatically loads the **latest version**:
-```
-Plugin A uses MCP Adapter v1.0 + Jetpack Autoloader
-Plugin B uses MCP Adapter v1.2 + Jetpack Autoloader
-→ Both plugins use v1.2 (latest), no conflicts
-```
-
-**Benefits**:
-- ✅ **Prevents version conflicts** between plugins
-- ✅ **Automatic latest version** loading
-- ✅ **WordPress optimized** for plugin environments
-- ✅ **Zero configuration** needed
 
 ### Class Not Found
-```php
-// For Composer projects, check Jetpack autoloader
-if ( ! class_exists( 'WP\MCP\Core\McpAdapter' ) ) {
-    // Load Jetpack autoloader
-    if ( is_file( __DIR__ . '/vendor/autoload_packages.php' ) ) {
-        require_once __DIR__ . '/vendor/autoload_packages.php';
-    }
-}
 
-// For plugin usage, check plugin is active
+`WP\MCP\*` classes are provided by the MCP Adapter plugin. If they are missing, the plugin is not active. Check for it rather than trying to load an autoloader yourself:
+
+```php
 if ( ! class_exists( 'WP\MCP\Core\McpAdapter' ) ) {
     add_action( 'admin_notices', function() {
         echo '<div class="notice notice-error"><p>MCP Adapter plugin must be active.</p></div>';
@@ -131,6 +109,8 @@ if ( ! class_exists( 'WP\MCP\Core\McpAdapter' ) ) {
     return;
 }
 ```
+
+Add `Requires Plugins: mcp-adapter` to your plugin header so WordPress loads MCP Adapter before your plugin.
 
 ### Abilities API Missing
 ```php

--- a/readme.txt
+++ b/readme.txt
@@ -27,11 +27,13 @@ The MCP Adapter bridges WordPress's Abilities API with the [Model Context Protoc
 
 == Installation ==
 
-Install MCP Adapter as a WordPress plugin from the [latest GitHub release](https://github.com/WordPress/mcp-adapter/releases/latest), or see the [README](https://github.com/WordPress/mcp-adapter#installation) for WP-CLI and wp-env options.
-
-Plugin developers can also add it as a Composer dependency: `composer require wordpress/mcp-adapter`
+1. Upload the plugin files to the `/wp-content/plugins/mcp-adapter` directory, or install the plugin through the WordPress plugins screen directly.
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. The adapter initializes automatically and creates a default MCP server at `/wp-json/mcp/mcp-adapter-default-server`.
 
 Requires WordPress 6.9 or newer (the Abilities API is included in core).
+
+Plugin developers should depend on MCP Adapter by adding `Requires Plugins: mcp-adapter` to their plugin header. See the [README](https://github.com/WordPress/mcp-adapter#installation) for WP-CLI and wp-env options.
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,8 @@ The MCP Adapter bridges WordPress's Abilities API with the [Model Context Protoc
 
 == Installation ==
 
+Download the latest plugin ZIP from the [GitHub releases page](https://github.com/WordPress/mcp-adapter/releases) before following the steps below.
+
 1. Upload the plugin files to the `/wp-content/plugins/mcp-adapter` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. The adapter initializes automatically and creates a default MCP server at `/wp-json/mcp/mcp-adapter-default-server`.


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/mcp-adapter/blob/trunk/CONTRIBUTING.md -->

## What?

See https://github.com/WordPress/mcp-adapter/issues/178

Removes Composer and Jetpack Autoloader from the user-facing installation documentation, so installing and activating the WordPress plugin is the only documented way to get MCP Adapter.

> [!NOTE]
> Some docs here assume this PR will be part of the .org release

## Why?

Issue #178 tracks the path to the WordPress.org plugin directory, and one of its open items is "Cleanup and update install docs to prioritize usage via plugin". The docs had not caught up with how the project is actually distributed:

1. `README.md` presented "As a Composer Library (for plugin developers)" as a peer to plugin installation, and marked "Using Jetpack Autoloader" as **Highly Recommended**. Both describe consuming MCP Adapter as a vendored library.
1. The docs told plugin developers to wire up their own autoloader, when the correct mechanism is the `Requires Plugins` plugin header. WordPress then guarantees load order without any autoloader work.

## How?

| File | Change |
| ---- | ------ |
| `README.md` | Removed the `As a Composer Library (for plugin developers)` and `Using Jetpack Autoloader (Highly Recommended)` sections. Installation is now Manually / With WP-CLI / With WP-Env. Added `As a dependency of your plugin`, covering the `Requires Plugins` header. |
| `readme.txt` | Replaced the `composer require wordpress/mcp-adapter` line with standard WordPress.org numbered installation steps, matching the format used by `WordPress/ai`. |
| `docs/README.md` | Installation Guide description no longer reads "(Composer recommended)". |
| `docs/getting-started/installation.md` | Removed "Method 2: Composer Package" and its Jetpack Autoloader subsection. Restructured into installing the plugin, then depending on it from your own plugin. |
| `docs/getting-started/README.md` | Removed Composer from the prerequisites and from Step 1. Deleted the "Initialize MCP Adapter" step, which only existed because the library path required a manual `McpAdapter::instance()` call, and renumbered the remaining steps. |
| `docs/troubleshooting/common-issues.md` | Removed the "Why Use Jetpack Autoloader?" section and the consumer-facing `vendor/autoload_packages.php` checks. The "Class Not Found" answer is now "the plugin is not active" rather than "load an autoloader". |

Kept deliberately:

- The `php-mcp-schema` dependency note in `README.md`, which is accurate. It is resolved by Composer at build time and shipped inside the release zip.
- The "Composer autoloader was not found" troubleshooting entries, which match the plugin's own admin notice string and point at `vendor/autoload_packages.php`, the file `Autoloader.php` actually loads.
- `CONTRIBUTING.md` and `docs/guides/testing.md`, which are contributor build tooling rather than install advice.

No code changed. This is documentation only.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Auditing the docs for Composer and Jetpack Autoloader references, drafting the replacement prose, and cross-checking the claims against `composer.json`, `includes/Autoloader.php`, `package.json`, and the `WordPress/ai` repository. All wording and scope decisions were reviewed and edited by me.

## Testing Instructions

This PR changes documentation only, so testing is a review of the rendered files plus a few checks that nothing was missed.

1. Confirm no user-facing doc still recommends installing MCP Adapter through Composer:

   ```bash
   grep -rn -i "composer require\|wpackagist\|jetpack" README.md readme.txt docs/ \
     | grep -v "docs/guides/testing.md"
   ```

   The only expected hit is the comment in `docs/troubleshooting/common-issues.md` clarifying that the autoloader file is `autoload_packages.php` rather than `autoload.php`.

2. Confirm the build tooling references survived, since these are still correct:

   ```bash
   grep -n "php-mcp-schema" README.md
   grep -rn "composer install" docs/
   ```

3. Render `README.md`, `docs/getting-started/installation.md`, `docs/getting-started/README.md`, and `docs/troubleshooting/common-issues.md` on GitHub and confirm no broken internal anchors. The removed sections had no inbound links, and `readme.txt` still points at `#installation`, which continues to exist.

4. Verify `readme.txt` still parses as a valid WordPress.org readme, for example with the Plugin Check plugin, and that the Installation tab renders as a numbered list.

5. Follow `docs/getting-started/installation.md` end to end on a clean WordPress 6.9 site. Install the release zip, activate, and confirm the default server responds at `/wp-json/mcp/mcp-adapter-default-server` without any Composer or autoloader step.

## Changelog Entry

> Developer - Updated the installation documentation to cover installing MCP Adapter as a WordPress plugin only, removing the Composer library and Jetpack Autoloader instructions.
