### PR TITLE
docs: migrate deprecation information to docs/README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,7 @@ Join the `#core-ai` channel [on WordPress Slack](http://wordpress.slack.com) ([s
 
 ## Coding standards
 
-In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). All code in the MCP Adapter must follow these requirements:
-
-- **WordPress**: 6.9+
-- **PHP**: 7.4+
+In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/).
 
 We include [several tools](#useful-commands) to help ensure your code meets these standards.
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/downl
 }
 ```
 
-### As a Composer Library (for plugin developers)
+### As a Composer Library (Deprecated)
 
-Plugin developers may wish to install MCP Adapter as a Composer dependency to integrate MCP functionality into their own plugins.
-
-```bash
-composer require wordpress/mcp-adapter
-```
+> **Deprecated:** Installing MCP Adapter directly via `composer require wordpress/mcp-adapter` is no longer supported. Use [wpackagist](https://wpackagist.org/) instead, which mirrors the WordPress.org plugin as a Composer package:
+>
+> ```bash
+> composer require wpackagist-plugin/mcp-adapter
+> ```
 
 #### Using Jetpack Autoloader (Highly Recommended)
 

--- a/README.md
+++ b/README.md
@@ -8,347 +8,38 @@ The official WordPress package for MCP integration that exposes WordPress abilit
 
 ## Overview
 
-This adapter bridges WordPress's Abilities API with the [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/), providing a standardized way for AI agents to interact with WordPress functionality. It includes HTTP and STDIO transport support, comprehensive error handling, and an extensible architecture for custom integrations.
+MCP Adapter bridges WordPress's [Abilities API](https://developer.wordpress.org/news/2025/11/introducing-the-wordpress-abilities-api/) with the [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/), giving AI agents a standardized way to interact with WordPress functionality. It includes HTTP and STDIO transport support, comprehensive error handling, and an extensible architecture for custom integrations.
 
 ## Features
 
-### Core Functionality
-
-- **Ability-to-MCP Conversion**: Automatically converts WordPress abilities into MCP tools, resources, and prompts
-- **Multi-Server Management**: Create and manage multiple MCP servers with unique configurations
-- **Extensible Transport Layer**:
-    - **HTTP Transport**: Unified transport implementing [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports) for HTTP-based communication
-    - **STDIO Transport**: Process-based communication via standard input/output for local development and CLI integration
-    - **Custom Transport Support**: Implement `McpTransportInterface` to create specialized communication protocols
-    - **Multi-Transport Configuration**: Configure servers with multiple transport methods simultaneously
-- **Flexible Error Handling**:
-    - **Built-in Error Handler**: Default WordPress-compatible error logging included
-    - **Custom Error Handlers**: Implement `McpErrorHandlerInterface` for custom logging, monitoring, or notification
-      systems
-    - **Server-specific Handlers**: Different error handling strategies per MCP server
-- **Observability**:
-    - **Built-in Observability**: Default zero-overhead metrics tracking with configurable handlers
-    - **Custom Observability Handlers**: Implement `McpObservabilityHandlerInterface` for integration with monitoring
-      systems
-- **Validation**: Built-in validation for tools, resources, and prompts with extensible validation rules
-- **Permission Control**: Granular permission checking for all exposed functionality with configurable [transport permissions](docs/guides/transport-permissions.md)
-
-### MCP Component Support
-
-- **[Tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools.md)**: Convert WordPress abilities into executable MCP tools for AI agent interactions
-- **[Resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources.md)**: Expose WordPress data as MCP resources for contextual information access
-- **[Prompts](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts.md)**: Transform abilities into structured MCP prompts for AI guidance and templates
-- **Server Discovery**: Automatic registration and discovery of MCP servers following MCP protocol standards
-- **Built-in Abilities**: Core WordPress abilities for system introspection and ability management
-- **CLI Integration**: WP-CLI commands supporting STDIO transport as defined in MCP specification
+- **Ability-to-MCP conversion** — WordPress abilities automatically become MCP [tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools.md), [resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources.md), and [prompts](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts.md)
+- **Multi-server management** — run multiple MCP servers, each with its own transports, abilities, and handlers
+- **HTTP and STDIO transports**, plus a `McpTransportInterface` for custom protocols — see [Custom Transports](docs/guides/custom-transports.md)
+- **Pluggable error handling and observability** — swap in your own logging or monitoring via `McpErrorHandlerInterface` and `McpObservabilityHandlerInterface` — see [Error Handling](docs/guides/error-handling.md) and [Observability](docs/guides/observability.md)
+- **Granular permissions** — per-server transport authentication and per-ability permission checks — see [Transport Permissions](docs/guides/transport-permissions.md)
 
 ## Architecture
 
-For a full breakdown of the component structure, see the [Architecture Overview](docs/architecture/overview.md).
+See the [Architecture Overview](docs/architecture/overview.md) for the full component breakdown.
 
-## Dependencies
+## Getting Started
 
-- **PHP**: >= 7.4
-- **WordPress**: >= 6.9 (includes the [Abilities API](https://developer.wordpress.org/news/2025/11/introducing-the-wordpress-abilities-api/) in core — no separate plugin)
-- **[php-mcp-schema](https://github.com/WordPress/php-mcp-schema)** (`^0.1.0`): Typed DTOs for MCP protocol types
+Follow the [Quick Start Guide](docs/getting-started/README.md) to register your first ability and expose it via MCP, or jump straight to the [Basic Examples](docs/getting-started/basic-examples.md) for complete tool, resource, and prompt samples.
 
-## Installation
+WordPress abilities are private by default. Set `meta.public` (or `meta.mcp.public`) to `true` to expose one, then reach it through the [default server's](docs/guides/default-server.md) three meta-tools (`mcp-adapter/discover-abilities`, `mcp-adapter/get-ability-info`, `mcp-adapter/execute-ability`) — see [Creating Abilities](docs/guides/creating-abilities.md) for the full opt-in model.
 
-MCP Adapter is distributed as a WordPress plugin. Install and activate it like any other plugin. The release ships with everything it needs, so there is no autoloader to wire up and no build step to run.
+## Connecting MCP Clients
 
-Requires WordPress 6.9 or newer; the Abilities API is part of core, so there is no separate plugin to install.
-
-### Manually
-
-Download the latest stable `mcp-adapter.zip` from the [GitHub Releases page](https://github.com/WordPress/mcp-adapter/releases/latest), then upload it from **Plugins → Add Plugin → Upload Plugin** and activate it.
-
-### With WP-CLI
-
-```bash
-wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip --activate
-```
-
-### With WP-Env
-
-```jsonc
-// .wp-env.json
-{
-  "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "plugins": [
-    "https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip"
-  ]
-}
-```
-
-### As a dependency of your plugin
-
-The `WP\MCP` classes are provided by the MCP Adapter plugin, so declare it as a plugin dependency using the `Requires Plugins` field in your [plugin header](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/):
-
-```php
-<?php
-/**
- * Plugin Name:      My Plugin
- * Description:      Adds MCP tools for my feature.
- * Requires Plugins: mcp-adapter
- */
-```
-
-### Using MCP Adapter in Your Plugin
-
-Check availability and initialize on `plugins_loaded` so all plugins are available before the adapter starts:
-
-```php
-add_action( 'plugins_loaded', function() {
-    if ( ! class_exists( 'WP\MCP\Core\McpAdapter' ) ) {
-        // MCP Adapter is not active — show an admin notice or return early.
-        return;
-    }
-
-    \WP\MCP\Core\McpAdapter::instance();
-} );
-```
-
-## Basic Usage
-
-The MCP Adapter automatically creates a default server that exposes registered WordPress abilities through a layered architecture. This provides immediate MCP functionality without requiring manual server configuration.
-
-**How it works:**
-- WordPress abilities registered via `wp_register_ability()` with `meta.public` set to `true` are discoverable and executable on the default server via its built-in adapter tools
-- Set `meta.mcp.public` explicitly to override the high-level setting for MCP only; `false` opts a public ability out, while `true` exposes an otherwise private ability to MCP
-- On the default server, public abilities are accessed through `mcp-adapter/discover-abilities`, `mcp-adapter/get-ability-info`, and `mcp-adapter/execute-ability` rather than being auto-registered individually in `tools/list`
-- Alternatively, abilities can be explicitly listed when creating a [custom MCP server](#creating-custom-mcp-servers); in that case, they can be exposed directly as MCP tools, resources, or prompts without requiring the `meta.mcp.public` flag
-- The default server supports both HTTP and STDIO transports and supports multiple MCP protocol versions
-- Built-in error handling and observability are included
-- Access via HTTP: `/wp-json/mcp/mcp-adapter-default-server`
-- Access via STDIO: `wp mcp-adapter serve --server=mcp-adapter-default-server`
-
-<details>
-<summary><strong>Create a new ability (click to expand)</strong></summary>
-
-```php
-// Simply register a WordPress ability
-add_action( 'wp_abilities_api_init', function() {
-    wp_register_ability( 'my-plugin/get-posts', [
-        'label' => 'Get Posts',
-        'description' => 'Retrieve WordPress posts with optional filtering',
-        'category' => 'site',
-        'input_schema' => [
-            'type' => 'object',
-            'properties' => [
-                'numberposts' => [
-                    'type' => 'integer',
-                    'description' => 'Number of posts to retrieve',
-                    'default' => 5,
-                    'minimum' => 1,
-                    'maximum' => 100
-                ],
-                'post_status' => [
-                    'type' => 'string',
-                    'description' => 'Post status to filter by',
-                    'enum' => ['publish', 'draft', 'private'],
-                    'default' => 'publish'
-                ]
-            ]
-        ],
-        'output_schema' => [
-            'type' => 'array',
-            'items' => [
-                'type' => 'object',
-                'properties' => [
-                    'ID' => ['type' => 'integer'],
-                    'post_title' => ['type' => 'string'],
-                    'post_content' => ['type' => 'string'],
-                    'post_date' => ['type' => 'string'],
-                    'post_author' => ['type' => 'string']
-                ]
-            ]
-        ],
-        'execute_callback' => function( $input ) {
-            $args = [
-                'numberposts' => $input['numberposts'] ?? 5,
-                'post_status' => $input['post_status'] ?? 'publish'
-            ];
-            return get_posts( $args );
-        },
-        'permission_callback' => function() {
-            return current_user_can( 'read' );
-        },
-        'meta' => [
-            'public' => true, // Expose to clients, including the default MCP server
-        ],
-    ]);
-});
-
-// With the meta.public flag, the ability is exposed through the default MCP server.
-// In the default server configuration, discover it via `discover-abilities`
-// and invoke it via `mcp-adapter/execute-ability` rather than expecting
-// it to appear as its own entry in `tools/list`.
-// To opt out of MCP while remaining public to other clients, explicitly set
-// meta.mcp.public to false.
-// To expose only through MCP, omit `meta.public` and set `meta.mcp.public` to true.
-// Without either public flag, abilities are only accessible through custom MCP
-// servers that explicitly list them.
-// Note: how far `meta.public` reaches depends on the WordPress version. WordPress
-// core starts applying `meta.public` to the REST API (`meta.show_in_rest`) in 7.1. On
-// WordPress 6.9 and 7.0, this adapter honors `meta.public` for MCP, but REST API
-// access still requires setting `meta.show_in_rest` to true.
-```
-
-</details>
-
-For detailed information about creating WordPress abilities, see the [Abilities API developer documentation](https://developer.wordpress.org/news/2025/11/introducing-the-wordpress-abilities-api/).
-
-### Connecting to MCP Servers
-
-The MCP Adapter supports multiple connection methods. Here are examples for connecting with MCP clients:
-
-#### STDIO Transport (Local Development)
-
-For local development and testing, you can interact directly with MCP servers using WP-CLI commands:
-
-```bash
-# List all available MCP servers
-wp mcp-adapter list
-
-# Test the discover abilities tool to see all available WordPress abilities
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"mcp-adapter-discover-abilities","arguments":{}}}' | wp mcp-adapter serve --user=admin --server=mcp-adapter-default-server
-
-# Test listing available tools
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | wp mcp-adapter serve --user=admin --server=mcp-adapter-default-server
-```
-
-#### MCP Client Configuration
-
-Configure MCP clients (Claude Desktop, Claude Code, VS Code, Cursor, etc.) to connect to your WordPress MCP servers.
-
-<details>
-<summary><strong>STDIO Transport Configuration for local sites (click to expand)</strong></summary>
-
-```json
-{
-  "mcpServers": {
-    "wordpress-default": {
-      "command": "wp",
-      "args": [
-        "--path=/path/to/your/wordpress/site",
-        "mcp-adapter",
-        "serve",
-        "--server=mcp-adapter-default-server",
-        "--user=admin"
-      ]
-    },
-    "wordpress-custom": {
-      "command": "wp",
-      "args": [
-        "--path=/path/to/your/wordpress/site",
-        "mcp-adapter",
-        "serve",
-        "--server=your-custom-server-id",
-        "--user=admin"
-      ]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>HTTP Transport via Proxy (click to expand)</strong></summary>
-
-The [`@automattic/mcp-wordpress-remote`](https://www.npmjs.com/package/@automattic/mcp-wordpress-remote) proxy runs locally and translates STDIO-based MCP communication from AI clients into HTTP REST API calls that WordPress understands. Authentication uses [WordPress Application Passwords](https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/).
-
-```json
-{
-  "mcpServers": {
-    "wordpress-http-default": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@automattic/mcp-wordpress-remote@latest"
-      ],
-      "env": {
-        "WP_API_URL": "http://your-site.test/wp-json/mcp/mcp-adapter-default-server",
-        "LOG_FILE": "/path/to/logs/mcp-adapter.log",
-        "WP_API_USERNAME": "your-username",
-        "WP_API_PASSWORD": "your-application-password"
-      }
-    },
-    "wordpress-http-custom": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@automattic/mcp-wordpress-remote@latest"
-      ],
-      "env": {
-        "WP_API_URL": "http://your-site.test/wp-json/your-namespace/your-route",
-        "LOG_FILE": "/path/to/logs/mcp-adapter.log",
-        "WP_API_USERNAME": "your-username",
-        "WP_API_PASSWORD": "your-application-password"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-## Advanced Usage
-
-### Creating Custom MCP Servers
-
-For advanced use cases, you can create custom MCP servers with specific configurations:
-
-```php
-add_action( 'mcp_adapter_init', function( $adapter ) {
-    $adapter->create_server(
-        'my-server-id',                    // Unique server identifier
-        'my-namespace',                    // REST API namespace
-        'mcp',                             // REST API route
-        'My MCP Server',                   // Server name
-        'Description of my server',        // Server description
-        'v1.0.0',                          // Server version
-        array(                             // Transport methods
-            \WP\MCP\Transport\HttpTransport::class,
-        ),
-        \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,        // Error handler
-        \WP\MCP\Infrastructure\Observability\NullMcpObservabilityHandler::class,    // Observability handler
-        array( 'my-plugin/my-ability' ),   // Abilities to expose as tools
-        array(),                           // Resources (optional)
-        array()                            // Prompts (optional)
-    );
-} );
-```
-
-### Custom Transport Implementation
-
-The MCP Adapter includes production-ready HTTP transports. For specialized requirements like custom authentication, message queues, or enterprise integrations, you can create custom transport protocols.
-
-See the [Custom Transports Guide](docs/guides/custom-transports.md) for detailed implementation instructions.
-
-
-### Custom Transport Permissions
-
-The MCP Adapter supports custom authentication logic through transport permission callbacks. Instead of the default `is_user_logged_in()` check, you can implement custom authentication for your MCP servers.
-
-See the [Transport Permissions Guide](docs/guides/transport-permissions.md) for detailed authentication patterns.
-
-### Custom Error Handler
-
-The MCP Adapter includes a default WordPress-compatible error handler, but you can implement custom error handling to integrate with existing logging systems, monitoring tools, or meet specific requirements.
-
-See the [Error Handling Guide](docs/guides/error-handling.md) for detailed implementation instructions.
-
-### Custom Observability Handler
-
-The MCP Adapter includes built-in observability for tracking metrics and events. You can implement custom observability handlers to integrate with monitoring systems, analytics platforms, or performance tracking tools.
-
-See the [Observability Guide](docs/guides/observability.md) for detailed metrics tracking and custom handler implementation.
+Connect via WP-CLI over STDIO, or point an HTTP client at `/wp-json/mcp/mcp-adapter-default-server`. Configuration examples for Claude Desktop and other MCP clients — both direct STDIO and HTTP-via-proxy — are in the [CLI Usage Guide](docs/guides/cli-usage.md).
 
 ## Migration
 
-- [Migration Guide: v0.5.0](docs/migration/v0.5.0.md) — Breaking changes and upgrade instructions
-- [Migration Guide: v0.3.0](docs/migration/v0.3.0.md) — Transport, observability, and hook name changes
+- [Migration Guide: v0.5.0](docs/migration/v0.5.0.md)
+- [Migration Guide: v0.3.0](docs/migration/v0.3.0.md)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, coding standards, and the contribution workflow, and the [Testing Guide](docs/guides/testing.md) for running the test suite.
 
 ## License
 [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -114,8 +114,8 @@ curl -X POST "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
 
 ## Next Steps
 
+- **[Installation Guide](./installation.md)** - Detailed installation options
 - **[Creating Abilities](../guides/creating-abilities.md)** - Build tools, resources, and prompts
-- **[Installation Guide](installation.md)** - Detailed installation options
 - **[Architecture Overview](../architecture/overview.md)** - Understand system design
 - **[Error Handling](../guides/error-handling.md)** - Custom logging and monitoring
 - **[Transport Permissions](../guides/transport-permissions.md)** - Authentication and authorization

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,6 +18,21 @@ Requires WordPress 6.9 or newer. The Abilities API ships with core — you do no
 
 > **Deprecated:** Installing MCP Adapter directly via composer require wordpress/mcp-adapter is no longer supported. Use [wpackagist](https://wpackagist.org/) instead, which mirrors the WordPress.org plugin as a Composer package:
 >
+> If your project does not already include the wpackagist repository, add it to `composer.json` first:
+>
+> ```json
+> {
+>   "repositories": [
+>     {
+>       "type": "composer",
+>       "url": "https://wpackagist.org"
+>     }
+>   ]
+> }
+> ```
+>
+> Then install the plugin package:
+>
 > ```bash
 > composer require wpackagist-plugin/mcp-adapter
 > ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,27 +16,26 @@ The plugin automatically initializes and creates a default MCP server at `/wp-js
 
 Requires WordPress 6.9 or newer. The Abilities API ships with core — you do not need a separate abilities-api plugin.
 
-### Method 2: Composer Package (for plugin developers)
+### Method 2: As a Composer Library (Deprecated)
 
-If you are building a plugin that depends on MCP Adapter, install it as a Composer package:
-
-```bash
-composer require wordpress/mcp-adapter
-```
+> **Deprecated:** Installing MCP Adapter directly via composer require wordpress/mcp-adapter is no longer supported. Use [wpackagist](https://wpackagist.org/) instead, which mirrors the WordPress.org plugin as a Composer package:
+>
+> ```bash
+> composer require wpackagist-plugin/mcp-adapter
+> ```
 
 #### Using Jetpack Autoloader (Highly Recommended)
 
-When multiple plugins use the MCP Adapter, use the [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) to prevent version conflicts:
+When multiple plugins use the MCP Adapter, it's highly recommended to use the  [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) to prevent version conflicts. The Jetpack Autoloader ensures that only the latest version of shared packages is loaded, eliminating conflicts when different plugins use different versions of the same dependency.
 
 ```bash
 composer require automattic/jetpack-autoloader
 ```
 
-Then load it in your plugin:
+Then load it in your main plugin file instead of the standard Composer autoloader:
 
 ```php
 <?php
-// Load the Jetpack autoloader instead of vendor/autoload.php
 require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
 
 use WP\MCP\Core\McpAdapter;

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -37,7 +37,7 @@ Requires WordPress 6.9 or newer. The Abilities API ships with core — you do no
 > composer require wpackagist-plugin/mcp-adapter
 > ```
 
-#### Using Jetpack Autoloader (Highly Recommended)
+#### Using Jetpack Autoloader
 
 When multiple plugins use the MCP Adapter, it's highly recommended to use the  [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) to prevent version conflicts. The Jetpack Autoloader ensures that only the latest version of shared packages is loaded, eliminating conflicts when different plugins use different versions of the same dependency.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-MCP Adapter is distributed as a WordPress plugin. Install and activate it like any other plugin. Requires WordPress 6.9 or newer.
+MCP Adapter is distributed as a WordPress plugin and should be installed and activated like any other plugin.
 
 ## Installing the plugin
 
@@ -12,60 +12,30 @@ wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/downl
 
 The plugin automatically initializes and creates a default MCP server at `/wp-json/mcp/mcp-adapter-default-server`.
 
-Requires WordPress 6.9 or newer. The Abilities API ships with core — you do not need a separate abilities-api plugin.
+### With wp-env
 
-### Method 2: As a Composer Library (Deprecated)
+To include MCP Adapter in a [`wp-env`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) environment, add it to the `plugins` array in `.wp-env.json`:
 
-> **Deprecated:** Installing MCP Adapter directly via composer require wordpress/mcp-adapter is no longer supported. Use [wpackagist](https://wpackagist.org/) instead, which mirrors the WordPress.org plugin as a Composer package:
->
-> If your project does not already include the wpackagist repository, add it to `composer.json` first:
->
-> ```json
-> {
->   "repositories": [
->     {
->       "type": "composer",
->       "url": "https://wpackagist.org"
->     }
->   ]
-> }
-> ```
->
-> Then install the plugin package:
->
-> ```bash
-> composer require wpackagist-plugin/mcp-adapter
-> ```
-
-#### Using Jetpack Autoloader
-
-When multiple plugins use the MCP Adapter, it's highly recommended to use the  [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) to prevent version conflicts. The Jetpack Autoloader ensures that only the latest version of shared packages is loaded, eliminating conflicts when different plugins use different versions of the same dependency.
-
-```bash
-composer require automattic/jetpack-autoloader
+```jsonc
+// .wp-env.json
+{
+  "$schema": "https://schemas.wp.org/trunk/wp-env.json",
+  "plugins": [
+    "https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip"
+  ]
+}
 ```
 
-Then load it in your main plugin file instead of the standard Composer autoloader:
+## As a dependency
 
-```php
-<?php
-require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
+Plugin authors and developers may wish to rely on MCP Adapter as a dependency and ensure it is installed and activated by users relying on their plugin. You can do that in one of the following ways.
 
-use WP\MCP\Core\McpAdapter;
+### As a Plugin Dependency (recommended)
 
-// Initialize the adapter
-McpAdapter::instance();
-```
+> [!IMPORTANT]
+> Using MCP Adapter as a plugin dependency requires the plugin to be listed on the WordPress.org plugin directory, and is not currently supported. See [#178](https://github.com/WordPress/mcp-adapter/issues/178) to track progress on plugin submission.
 
-#### Benefits
-- Version conflict resolution
-- Plugin compatibility 
-- WordPress optimized
-- Automatic dependency management
-
-#### Using MCP Adapter in Your Plugin
-
-Once the MCP Adapter plugin is active, you can use it in your own plugins:
+The best way to ensure that MCP Adapter is installed and activated is to include it as one of your Requires Plugins in your [plugin header](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/). For example:
 
 ```php
 <?php
@@ -75,183 +45,61 @@ Once the MCP Adapter plugin is active, you can use it in your own plugins:
  * Version:          1.0.0
  * Requires Plugins: mcp-adapter
  */
-
-// Prevent direct access
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
-
-class MyMcpPlugin {
-    
-    public function __construct() {
-        add_action( 'plugins_loaded', [ $this, 'init' ] );
-    }
-    
-    public function init() {
-        // Check if MCP Adapter is available
-        if ( ! class_exists( 'WP\MCP\Core\McpAdapter' ) ) {
-            add_action( 'admin_notices', [ $this, 'missing_mcp_adapter_notice' ] );
-            return;
-        }
-        
-        // Check if Abilities API is available
-        if ( ! function_exists( 'wp_register_ability' ) ) {
-            add_action( 'admin_notices', [ $this, 'missing_abilities_api_notice' ] );
-            return;
-        }
-        
-        // Register your abilities and MCP server
-        $this->register_abilities();
-        $this->setup_mcp_server();
-    }
-    
-    private function register_abilities() {
-        add_action( 'wp_abilities_api_init', function() {
-            wp_register_ability( 'my-plugin/get-posts', [
-                'label' => 'Get Posts',
-                'description' => 'Retrieve WordPress posts',
-                'category' => 'site',
-                'input_schema' => [
-                    'type' => 'object',
-                    'properties' => [
-                        'numberposts' => [
-                            'type' => 'integer',
-                            'default' => 5,
-                            'minimum' => 1,
-                            'maximum' => 100
-                        ]
-                    ]
-                ],
-                'execute_callback' => function( $input ) {
-                    return get_posts( [ 'numberposts' => $input['numberposts'] ?? 5 ] );
-                },
-                'permission_callback' => function() {
-                    return current_user_can( 'read' );
-                }
-            ]);
-        });
-    }
-    
-    private function setup_mcp_server() {
-        add_action( 'mcp_adapter_init', [ $this, 'create_mcp_server' ] );
-    }
-    
-    public function create_mcp_server( $adapter ) {
-        $adapter->create_server(
-            'my-plugin-server',
-            'my-plugin',
-            'mcp',
-            'My Plugin MCP Server',
-            'Custom MCP server for my plugin',
-            '1.0.0',
-            [ \WP\MCP\Transport\HttpTransport::class ],
-            \WP\MCP\Infrastructure\ErrorHandling\ErrorLogMcpErrorHandler::class,
-            null, // observability handler (null = use default)
-            [ 'my-plugin/get-posts' ] // tools
-        );
-    }
-    
-    public function missing_mcp_adapter_notice() {
-        echo '<div class="notice notice-error"><p>';
-        echo 'My MCP Plugin requires the MCP Adapter plugin to be active.';
-        echo '</p></div>';
-    }
-    
-    public function missing_abilities_api_notice() {
-        echo '<div class="notice notice-error"><p>';
-        echo 'My MCP Plugin requires WordPress 6.9 or newer (Abilities API is included in core).';
-        echo '</p></div>';
-    }
-}
-
-new MyMcpPlugin();
 ```
 
-## Verifying Installation
+### As a Composer Library
 
-### Check Plugin Status
+While not recommended, there are some situations where you may want to bundle a copy of MCP Adapter with your plugin. In that case, you can add it as a Composer dependency:
 
-1. **WordPress Admin**: Go to Plugins → Installed Plugins and verify "MCP Adapter" is active
+```bash
+composer require wordpress/mcp-adapter
+```
 
-2. **WP-CLI**: Check plugin status:
-   ```bash
-   wp plugin status mcp-adapter
-   ```
+If you are bundling MCP Adapter with your plugin, we suggest using [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) as your autoloader or a dependency prefixer like [Strauss](https://github.com/BrianHenryIE/strauss) to avoid conflicts with the MCP Adapter plugin or other legacy plugins that may be bundling their own copy of MCP Adapter.
 
-3. **REST API**: Test the default MCP server:
-   ```bash
-   # Test basic connectivity
-   curl "https://yoursite.com/wp-json/"
-   
-   # Test MCP endpoint (requires authentication)
-   curl -X POST "https://yoursite.com/wp-json/mcp/mcp-adapter-default-server" \
-     -H "Content-Type: application/json" \
-     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
-   ```
+## Checking availability with code
 
-### Quick Test
-
-Add this to a plugin or theme temporarily:
+To ensure that the MCP Adapter plugin is active and available, you should check for the existence of the `WP\MCP\Core\McpAdapter` class before using any MCP Adapter functionality. For example:
 
 ```php
-add_action( 'wp_loaded', function() {
-    if ( class_exists( 'WP\MCP\Core\McpAdapter' ) ) {
-        error_log( 'MCP Adapter is loaded and ready' );
-    } else {
-        error_log( 'MCP Adapter not found' );
-    }
-});
+// The `plugins_loaded` hook ensures that all plugins are loaded before we check for MCP Adapter.
+add_action( 'plugins_loaded', static function() {
+  if ( ! class_exists( 'WP\MCP\Core\McpAdapter' ) ) {
+    // Show an admin notice if MCP Adapter is not active.
+    add_action( 'admin_notices', static function() {
+      wp_display_notice(
+        __( 'MCP Adapter plugin is required for this plugin to function. Please install and activate it.', 'my-plugin-textdomain' ),
+        'error'
+      );
+    } );
+    return;
+  }
+
+  // If you reach this point, MCP Adapter is active and you can safely use its classes and functions.
+  $adapter = \WP\MCP\Core\McpAdapter::instance();
+
+} );
 ```
 
-## Troubleshooting
-
-### Common Issues
-
-**MCP Adapter plugin not found**
-- Verify the plugin is installed in `wp-content/plugins/mcp-adapter/`
-- Check the plugin is activated in WordPress admin
-
-**"The Composer autoloader was not found"**
-- Only affects source checkouts; the release zip ships with its `vendor/` directory
-- Run `composer install` in the plugin directory
-- Check `vendor/autoload_packages.php` exists
-
-**"WordPress Abilities API not available"**
-- Requires WordPress 6.9 or higher. The Abilities API is part of core — there is no separate plugin to install.
-
-**REST API not responding**
-- Check WordPress REST API is enabled
-- Verify permalink structure is not "Plain"
-- Test basic REST API: `curl "https://yoursite.com/wp-json/"`
-
-### Debug Mode
-
-Enable debug logging:
+You can also check for specific plugin version using the `WP_MCP_VERSION` constant. For example,
 
 ```php
-// Add to wp-config.php
-define( 'WP_DEBUG', true );
-define( 'WP_DEBUG_LOG', true );
+if ( ! defined( 'WP_MCP_VERSION' ) || version_compare( WP_MCP_VERSION, '1.0.0', '<' ) ) {
+  // Show an admin notice if MCP Adapter is not active or does not meet the version requirement.
+  add_action( 'admin_notices', static function() {
+    wp_display_notice(
+      __( 'MCP Adapter plugin version 1.0.0 or higher is required for this plugin to function. Please update it.', 'my-plugin-textdomain' ),
+      'error'
+    );
+  } );
+  return;
+}
 ```
-
-Check debug log for MCP Adapter messages.
 
 ## Next Steps
 
 Once installation is complete:
 
-1. **Read the [README](../../README.md)** for basic usage examples
-2. **Follow [Creating Abilities](../guides/creating-abilities.md)** to build your MCP tools
-3. **Review [Architecture Overview](../architecture/overview.md)** for system design
-
-## Dependencies
-
-### Required
-- **PHP**: >= 7.4
-- **WordPress**: >= 6.9
-
-### Optional
-- **WP-CLI**: For command-line MCP server testing
-- **Composer**: Only needed to build from a source checkout; release builds ship with their dependencies
-
-The MCP Adapter automatically handles initialization and creates a default server when activated.
+1. **Follow [Creating Abilities](../guides/creating-abilities.md)** to build your MCP tools.
+2. **Read [Basic Examples](./basic-examples.md)** to see how to use MCP Adapter in your plugin.
+3. **Review [Architecture Overview](../architecture/overview.md)** for system design.

--- a/docs/guides/cli-usage.md
+++ b/docs/guides/cli-usage.md
@@ -95,11 +95,13 @@ The STDIO transport uses JSON-RPC 2.0 protocol for communication:
 
 ### Using with MCP Clients
 
-Many MCP clients can launch subprocess servers. Here's how to configure them:
+Configure MCP clients (Claude Desktop, Claude Code, VS Code, Cursor, etc.) to connect to your WordPress MCP servers. Many MCP clients can launch subprocess servers directly via STDIO; others need an HTTP proxy.
 
-#### Claude Desktop Configuration
+#### STDIO transport (local sites)
 
-```json
+Many MCP clients can launch subprocess servers. Point the client's config at the `wp` binary:
+
+```jsonc
 {
   "mcpServers": {
     "wordpress": {
@@ -108,14 +110,41 @@ Many MCP clients can launch subprocess servers. Here's how to configure them:
         "--path=/path/to/your/wordpress/site",
         "mcp-adapter",
         "serve",
-        "--server=your-server-id",
+        // Change the server ID and user as needed
+        "--server=mcp-adapter-default-server",
         "--user=admin"
       ]
+    },
+  }
+}
+```
+
+#### HTTP transport via proxy
+
+The [`@automattic/mcp-wordpress-remote`](https://www.npmjs.com/package/@automattic/mcp-wordpress-remote) proxy runs locally and translates STDIO-based MCP communication from AI clients into HTTP REST API calls that WordPress understands. Authentication uses [WordPress Application Passwords](https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/).
+
+```jsonc
+{
+  "mcpServers": {
+    "wordpress": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@automattic/mcp-wordpress-remote@latest"
+      ],
+      "env": {
+        // Update these to match your environment details
+        "WP_API_URL": "http://your-site.test/wp-json/mcp/mcp-adapter-default-server",
+        "LOG_FILE": "/path/to/logs/mcp-adapter.log",
+        "WP_API_USERNAME": "your-username",
+        "WP_API_PASSWORD": "your-application-password"
+      }
     }
   }
 }
 ```
 
+For more information, see the [@automattic/mcp-wordpress-remote](https://www.npmjs.com/package/@automattic/mcp-wordpress-remote) package documentation.
 
 ### Development Workflow
 
@@ -148,7 +177,6 @@ wp mcp-adapter serve --user=editor
 # Run as specific user ID
 wp mcp-adapter serve --user=123
 ```
-
 
 ### Permission Debugging
 

--- a/readme.txt
+++ b/readme.txt
@@ -18,12 +18,12 @@ The MCP Adapter bridges WordPress's Abilities API with the [Model Context Protoc
 
 **Features:**
 
-* **Ability-to-MCP Conversion** – Automatically converts WordPress abilities into MCP tools, resources, and prompts.
-* **Multi-Server Management** – Create and manage multiple MCP servers with unique configurations.
-* **Extensible Transport Layer** – Built-in HTTP and STDIO transports, plus support for custom transport protocols.
-* **Flexible Error Handling** – Default WordPress-compatible error logging with support for custom, server-specific handlers.
-* **Observability** – Zero-overhead metrics tracking with configurable handlers.
-* **Permission Control** – Granular, configurable permission checking for all exposed functionality.
+* **Ability-to-MCP Conversion** - Automatically converts WordPress abilities into MCP tools, resources, and prompts.
+* **Multi-Server Management** - Create and manage multiple MCP servers with unique configurations.
+* **Extensible Transport Layer** - Built-in HTTP and STDIO transports, plus support for custom transport protocols.
+* **Flexible Error Handling** - Default WordPress-compatible error logging with support for custom, server-specific handlers.
+* **Observability** - Zero-overhead metrics tracking with configurable handlers.
+* **Permission Control** - Granular, configurable permission checking for all exposed functionality.
 
 == Installation ==
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/mcp-adapter/blob/trunk/CONTRIBUTING.md -->

## What?

Cleans up the WordPress installation information, including consolidated installation instructions, and usage warnings regarding using as a library.

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #178 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Docs: Cleanup and consolidate installation instructions.
