### PR TITLE
Fix resources/read 500 on ability-backed resources with an object input schema

### DIFF
--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -11,6 +11,7 @@ declare( strict_types=1 );
 namespace WP\MCP\Domain\Resources;
 
 use WP\MCP\Domain\Contracts\McpComponentInterface;
+use WP\MCP\Domain\Utils\AbilityArgumentNormalizer;
 use WP\MCP\Domain\Utils\McpValidator;
 use WP\MCP\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface;
 use WP\MCP\Infrastructure\Observability\FailureReason;
@@ -269,10 +270,15 @@ final class McpResource implements McpComponentInterface {
 	 * @return mixed
 	 */
 	public function execute( $arguments ) {
-		// Ability-backed resources match existing behavior: no args passed to abilities.
+		// Ability-backed resources receive no ability input: the resources/read
+		// params (uri) are protocol-level, not ability arguments. The empty
+		// argument set is normalized so abilities with an object input schema
+		// receive an empty array instead of null, matching McpTool and McpPrompt.
 		if ( null !== $this->ability ) {
+			$args = AbilityArgumentNormalizer::normalize( $this->ability, array() );
+
 			try {
-				return $this->ability->execute();
+				return $this->ability->execute( $args );
 			} catch ( \Throwable $throwable ) {
 				return new WP_Error(
 					'mcp_execution_failed',
@@ -305,10 +311,15 @@ final class McpResource implements McpComponentInterface {
 	 * @return bool|\WP_Error
 	 */
 	public function check_permission( $arguments ) {
-		// Ability-backed resources match existing behavior: no args passed to abilities.
+		// Ability-backed resources receive no ability input: the resources/read
+		// params (uri) are protocol-level, not ability arguments. The empty
+		// argument set is normalized so abilities with an object input schema
+		// receive an empty array instead of null, matching McpTool and McpPrompt.
 		if ( null !== $this->ability ) {
+			$args = AbilityArgumentNormalizer::normalize( $this->ability, array() );
+
 			try {
-				return $this->ability->check_permissions();
+				return $this->ability->check_permissions( $args );
 			} catch ( \Throwable $throwable ) {
 				return new WP_Error(
 					'mcp_permission_check_failed',

--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -270,10 +270,7 @@ final class McpResource implements McpComponentInterface {
 	 * @return mixed
 	 */
 	public function execute( $arguments ) {
-		// Ability-backed resources receive no ability input: the resources/read
-		// params (uri) are protocol-level, not ability arguments. The empty
-		// argument set is normalized so abilities with an object input schema
-		// receive an empty array instead of null, matching McpTool and McpPrompt.
+		// resources/read params are protocol-level, so the ability gets no input.
 		if ( null !== $this->ability ) {
 			$args = AbilityArgumentNormalizer::normalize( $this->ability, array() );
 
@@ -311,10 +308,7 @@ final class McpResource implements McpComponentInterface {
 	 * @return bool|\WP_Error
 	 */
 	public function check_permission( $arguments ) {
-		// Ability-backed resources receive no ability input: the resources/read
-		// params (uri) are protocol-level, not ability arguments. The empty
-		// argument set is normalized so abilities with an object input schema
-		// receive an empty array instead of null, matching McpTool and McpPrompt.
+		// resources/read params are protocol-level, so the ability gets no input.
 		if ( null !== $this->ability ) {
 			$args = AbilityArgumentNormalizer::normalize( $this->ability, array() );
 

--- a/tests/phpunit/Unit/Resources/McpResourceTest.php
+++ b/tests/phpunit/Unit/Resources/McpResourceTest.php
@@ -56,10 +56,10 @@ final class McpResourceTest extends TestCase {
 				'category'            => 'test',
 				'input_schema'        => array( 'type' => 'object' ),
 				'execute_callback'    => static function ( $input ) {
-					return is_array( $input ) ? 'object schema content' : 'unexpected input';
+					return array() === $input ? 'object schema content' : 'unexpected input';
 				},
 				'permission_callback' => static function ( $input ) {
-					return is_array( $input );
+					return array() === $input;
 				},
 				'meta'                => array(
 					'mcp' => array(
@@ -77,17 +77,17 @@ final class McpResourceTest extends TestCase {
 		$mcp_resource = McpResource::fromAbility( $ability );
 		$this->assertNotWPError( $mcp_resource );
 
-		// resources/read passes protocol-level params (uri); the ability must
-		// receive a normalized empty argument set that satisfies its object
-		// schema instead of a zero-argument call that validates null against it.
-		$permission = $mcp_resource->check_permission( array( 'uri' => 'WordPress://local/resource-object-schema' ) );
-		$this->assertTrue( $permission );
+		// The uri is protocol-level, so the ability must receive [], not null.
+		try {
+			$permission = $mcp_resource->check_permission( array( 'uri' => 'WordPress://local/resource-object-schema' ) );
+			$this->assertTrue( $permission );
 
-		$result = $mcp_resource->execute( array( 'uri' => 'WordPress://local/resource-object-schema' ) );
-		$this->assertNotWPError( $result );
-		$this->assertSame( 'object schema content', $result );
-
-		wp_unregister_ability( 'test/resource-object-schema' );
+			$result = $mcp_resource->execute( array( 'uri' => 'WordPress://local/resource-object-schema' ) );
+			$this->assertNotWPError( $result );
+			$this->assertSame( 'object schema content', $result );
+		} finally {
+			wp_unregister_ability( 'test/resource-object-schema' );
+		}
 	}
 
 	public function test_permission_callback_supports_zero_arg_callable(): void {

--- a/tests/phpunit/Unit/Resources/McpResourceTest.php
+++ b/tests/phpunit/Unit/Resources/McpResourceTest.php
@@ -47,6 +47,49 @@ final class McpResourceTest extends TestCase {
 		$this->assertSame( 'plain string content', $result );
 	}
 
+	public function test_ability_backed_resource_with_object_input_schema_executes(): void {
+		$this->register_ability_in_hook(
+			'test/resource-object-schema',
+			array(
+				'label'               => 'Resource Object Schema',
+				'description'         => 'Ability-backed resource with an object input schema',
+				'category'            => 'test',
+				'input_schema'        => array( 'type' => 'object' ),
+				'execute_callback'    => static function ( $input ) {
+					return is_array( $input ) ? 'object schema content' : 'unexpected input';
+				},
+				'permission_callback' => static function ( $input ) {
+					return is_array( $input );
+				},
+				'meta'                => array(
+					'mcp' => array(
+						'public' => true,
+						'type'   => 'resource',
+						'uri'    => 'WordPress://local/resource-object-schema',
+					),
+				),
+			)
+		);
+
+		$ability = wp_get_ability( 'test/resource-object-schema' );
+		$this->assertNotNull( $ability );
+
+		$mcp_resource = McpResource::fromAbility( $ability );
+		$this->assertNotWPError( $mcp_resource );
+
+		// resources/read passes protocol-level params (uri); the ability must
+		// receive a normalized empty argument set that satisfies its object
+		// schema instead of a zero-argument call that validates null against it.
+		$permission = $mcp_resource->check_permission( array( 'uri' => 'WordPress://local/resource-object-schema' ) );
+		$this->assertTrue( $permission );
+
+		$result = $mcp_resource->execute( array( 'uri' => 'WordPress://local/resource-object-schema' ) );
+		$this->assertNotWPError( $result );
+		$this->assertSame( 'object schema content', $result );
+
+		wp_unregister_ability( 'test/resource-object-schema' );
+	}
+
 	public function test_permission_callback_supports_zero_arg_callable(): void {
 		$mcp_resource = McpResource::fromArray(
 			array(


### PR DESCRIPTION
## What?
Closes #261

`resources/read` returns a 500 for any ability-backed resource whose ability declares an object `input_schema`. This routes the empty argument set through `AbilityArgumentNormalizer` so the ability receives `[]` instead of being called with zero arguments.

## Why?
`McpResource::execute()` and `check_permission()` called the backing ability with no arguments at all. For an ability with `'input_schema' => array( 'type' => 'object' )`, core then validates `null` against that schema and the read fails:

```
Internal error: Ability "..." has invalid input. Reason: input is not of type object.
```

Full credit to @lhero-org for the root-cause analysis in #261, which identified the exact failing call and ruled out the sibling `tools/call` path already fixed in #230.

## How?
`McpTool` and `McpPrompt` already normalize their arguments through `AbilityArgumentNormalizer`; `McpResource` was the one component that did not. This applies the same pattern in both `execute()` and `check_permission()`:

- Abilities with an object schema now receive an empty array.
- Abilities with no schema still receive `null`, unchanged legacy behavior.
- A schema with a top-level `default` still has that default applied by core.

Scope note: the `resources/read` protocol params (`uri`) are intentionally *not* forwarded as ability input. They are protocol-level, and the added test asserts the ability receives exactly `[]`, so a regression that forwarded `uri` would fail.

## Testing Instructions
1. Register an ability whose `input_schema` is `array( 'type' => 'object' )` and expose it as an MCP resource via `meta.mcp.type = 'resource'`.
2. Call `resources/read` for that resource's URI.
3. Before this change: `Internal error: Ability "..." has invalid input. Reason: input is not of type object.` After: the resource reads normally.

Automated coverage: `test_ability_backed_resource_with_object_input_schema_executes` in `tests/phpunit/Unit/Resources/McpResourceTest.php`.

```
composer test -- --filter McpResourceTest
```

## Changelog Entry

> Fixed - `resources/read` returning a 500 for ability-backed resources whose ability declares an object input schema.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.5%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fmcp-adapter%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-299-6d3ba8bfabc6e06e3e53f3d76f9ebaab5b3b7e9d-mcp-adapter.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
