### PR TITLE
dev!: Mark `WP\MCP\Cli` classes as final and cleanup internals

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -57,6 +57,8 @@
 	<rule ref="WordPress-VIP-Go">
 		<!-- Deprecated: @todo remove in PHPCS 4.0 -->
 		<exclude name="WordPressVIPMinimum.JS" />
+		<!-- Support non-VIP environments -->
+		<exclude name="WordPressVIPMinimum.Classes.RestrictedExtendClasses.wp_cli" />
 	</rule>
 	<rule ref="WordPress-Extra">
 		<!-- Needed to typehint, see: https://github.com/WordPress/WordPress-Coding-Standards/issues/403 -->

--- a/includes/Cli/McpCommand.php
+++ b/includes/Cli/McpCommand.php
@@ -18,7 +18,7 @@ use function WP_CLI\Utils\format_items;
  * Provides commands to serve MCP servers over STDIO transport for
  * communication with MCP clients via subprocess.
  */
-class McpCommand extends \WP_CLI_Command { // phpcs:ignore
+final class McpCommand extends \WP_CLI_Command {
 
 	/**
 	 * Serve an MCP server via STDIO transport.

--- a/includes/Cli/StdioServerBridge.php
+++ b/includes/Cli/StdioServerBridge.php
@@ -130,7 +130,7 @@ final class StdioServerBridge {
 					// Use fwrite() for precise binary-safe JSON-RPC protocol communication.
 					// WP_CLI output functions would add formatting/prefixes that break MCP protocol.
 					// MCP requires exact control over stdout for machine-to-machine communication.
-					fwrite( STDOUT, $response . "\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite -- This is for CLI output.
+					fwrite( STDOUT, $response . "\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite, WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- This is for CLI output.
 					fflush( STDOUT );
 				}
 			} catch ( \Throwable $e ) {
@@ -150,7 +150,7 @@ final class StdioServerBridge {
 					)
 				);
 
-				fwrite( STDOUT, $error_response . "\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite -- This is for CLI output.
+				fwrite( STDOUT, $error_response . "\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite,WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- This is for CLI output.
 				fflush( STDOUT );
 			}
 		}
@@ -164,7 +164,7 @@ final class StdioServerBridge {
 	 * @param string $message The message to log.
 	 */
 	private function log_to_stderr( string $message ): void {
-		fwrite( STDERR, "[MCP STDIO Bridge] $message\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite -- This is for CLI output.
+		fwrite( STDERR, "[MCP STDIO Bridge] $message\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite,WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- This is for CLI output.
 	}
 
 	/**

--- a/includes/Cli/StdioServerBridge.php
+++ b/includes/Cli/StdioServerBridge.php
@@ -24,7 +24,7 @@ use WP\MCP\Transport\Infrastructure\RequestRouter;
  * requests to the appropriate MCP server. Unlike transport implementations,
  * this is a presentation layer service that can work with any server.
  */
-class StdioServerBridge {
+final class StdioServerBridge {
 
 	/**
 	 * The MCP server to expose via STDIO.
@@ -130,7 +130,7 @@ class StdioServerBridge {
 					// Use fwrite() for precise binary-safe JSON-RPC protocol communication.
 					// WP_CLI output functions would add formatting/prefixes that break MCP protocol.
 					// MCP requires exact control over stdout for machine-to-machine communication.
-					fwrite( STDOUT, $response . "\n" ); // phpcs:ignore
+					fwrite( STDOUT, $response . "\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite -- This is for CLI output.
 					fflush( STDOUT );
 				}
 			} catch ( \Throwable $e ) {
@@ -150,7 +150,7 @@ class StdioServerBridge {
 					)
 				);
 
-				fwrite( STDOUT, $error_response . "\n" ); // phpcs:ignore
+				fwrite( STDOUT, $error_response . "\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite -- This is for CLI output.
 				fflush( STDOUT );
 			}
 		}
@@ -164,7 +164,7 @@ class StdioServerBridge {
 	 * @param string $message The message to log.
 	 */
 	private function log_to_stderr( string $message ): void {
-		fwrite( STDERR, "[MCP STDIO Bridge] $message\n" ); // phpcs:ignore
+		fwrite( STDERR, "[MCP STDIO Bridge] $message\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite -- This is for CLI output.
 	}
 
 	/**
@@ -304,31 +304,29 @@ class StdioServerBridge {
 	/**
 	 * Format a handler result as a JSON-RPC response.
 	 *
-	 * @param array $result The handler result.
+	 * @param array<string,mixed> $result The handler result.
 	 * @param mixed $id The request ID.
 	 *
 	 * @return string The JSON-RPC response string.
 	 */
 	private function format_response( array $result, $id ): string {
-		// Check if result contains an error
-		if ( isset( $result['error'] ) ) {
-			$error = $result['error'];
-
-			// Ensure error has required fields
-			$error_payload = array(
-				'code'    => $error['code'] ?? McpErrorFactory::INTERNAL_ERROR,
-				'message' => $error['message'] ?? 'Internal error',
-			);
-
-			// Add data field if present
-			if ( isset( $error['data'] ) ) {
-				$error_payload['data'] = $error['data'];
-			}
-
-			return $this->encode_response( JsonRpcResponseBuilder::create_error_response( $id, $error_payload ) );
+		// If there is no error, return a success response
+		if ( ! isset( $result['error'] ) ) {
+			return $this->encode_response( JsonRpcResponseBuilder::create_success_response( $id, $result ) );
 		}
 
-		return $this->encode_response( JsonRpcResponseBuilder::create_success_response( $id, $result ) );
+		// Ensure error has required fields
+		$error_payload = array(
+			'code'    => $result['error']['code'] ?? McpErrorFactory::INTERNAL_ERROR,
+			'message' => $result['error']['message'] ?? 'Internal error',
+		);
+
+		// Add data field if present
+		if ( isset( $result['error']['data'] ) ) {
+			$error_payload['data'] = $result['error']['data'];
+		}
+
+		return $this->encode_response( JsonRpcResponseBuilder::create_error_response( $id, $error_payload ) );
 	}
 
 	/**

--- a/includes/Cli/StdioServerBridge.php
+++ b/includes/Cli/StdioServerBridge.php
@@ -260,10 +260,10 @@ final class StdioServerBridge {
 	/**
 	 * Create a JSON-RPC error response.
 	 *
-	 * @param mixed $id The request ID (can be null).
-	 * @param int $code The error code.
-	 * @param string $message The error message.
-	 * @param string $data Optional error data.
+	 * @param int|string|float|null $id      The request ID, parsed from the JSON-RPC request (or null for notifications).
+	 * @param int                   $code    The error code.
+	 * @param string                $message The error message.
+	 * @param string                $data    Optional error data.
 	 *
 	 * @return string The JSON error response string.
 	 */
@@ -305,7 +305,7 @@ final class StdioServerBridge {
 	 * Format a handler result as a JSON-RPC response.
 	 *
 	 * @param array<string,mixed> $result The handler result.
-	 * @param mixed $id The request ID.
+	 * @param int|string|float    $id     The request ID, parsed from the JSON-RPC request.
 	 *
 	 * @return string The JSON-RPC response string.
 	 */

--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -254,10 +254,10 @@ class HttpRequestHandler {
 	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext $context The HTTP request context.
 	 *
 	 * @return array{
-		 *   code: int,
-		 *   message: string,
-		 *   data: mixed|null
-		 * }|null Null when the header is absent or valid, error payload otherwise.
+	 *   code: int,
+	 *   message: string,
+	 *   data: mixed|null
+	 * }|null Null when the header is absent or valid, error payload otherwise.
 	 */
 	private function validate_protocol_version_header( HttpRequestContext $context ): ?array {
 		if ( null === $context->protocol_version ) {

--- a/includes/Transport/Infrastructure/HttpRequestHandler.php
+++ b/includes/Transport/Infrastructure/HttpRequestHandler.php
@@ -253,7 +253,11 @@ class HttpRequestHandler {
 	 *
 	 * @param \WP\MCP\Transport\Infrastructure\HttpRequestContext $context The HTTP request context.
 	 *
-	 * @return array|null Null when the header is absent or valid, error payload otherwise.
+	 * @return array{
+		 *   code: int,
+		 *   message: string,
+		 *   data: mixed|null
+		 * }|null Null when the header is absent or valid, error payload otherwise.
 	 */
 	private function validate_protocol_version_header( HttpRequestContext $context ): ?array {
 		if ( null === $context->protocol_version ) {
@@ -264,7 +268,16 @@ class HttpRequestHandler {
 			return null;
 		}
 
-		return McpErrorFactory::create_error(
+		/**
+		 * Necessary because the McpSchema's `Error` class doesn't allow for type-hinted array shapes.
+		 *
+		 * @var array{
+		 *   code: int,
+		 *   message: string,
+		 *   data: mixed|null
+		 * } $error
+		 */
+		$error = McpErrorFactory::create_error( // phpcs:ignore SlevomatCodingStandard.Variables.UselessVariable.UselessVariable
 			McpErrorFactory::INVALID_REQUEST,
 			sprintf(
 				'Bad Request: Unsupported protocol version: %s (supported versions: %s)',
@@ -272,6 +285,7 @@ class HttpRequestHandler {
 				implode( ', ', McpVersionNegotiator::SUPPORTED_PROTOCOL_VERSIONS )
 			)
 		)->toArray();
+		return $error;
 	}
 
 	/**

--- a/includes/Transport/Infrastructure/JsonRpcResponseBuilder.php
+++ b/includes/Transport/Infrastructure/JsonRpcResponseBuilder.php
@@ -26,7 +26,7 @@ class JsonRpcResponseBuilder {
 	 * @param mixed                 $result The result data to return.
 	 *
 	 * @return array{
-	 * 	jsonrpc: string,
+	 *  jsonrpc: string,
 	 *  id: string|int|float|null,
 	 *  result: object
 	 * } The formatted JSON-RPC response.
@@ -47,7 +47,7 @@ class JsonRpcResponseBuilder {
 	 * @param array{code: int, message: string, data?: mixed} $error     The error array.
 	 *
 	 * @return array{
-	 * 	jsonrpc: string,
+	 *  jsonrpc: string,
 	 *  id: string|int|float|null,
 	 *  error: array{
 	 *    code: int,

--- a/includes/Transport/Infrastructure/JsonRpcResponseBuilder.php
+++ b/includes/Transport/Infrastructure/JsonRpcResponseBuilder.php
@@ -22,10 +22,14 @@ class JsonRpcResponseBuilder {
 	/**
 	 * Create a JSON-RPC 2.0 success response.
 	 *
-	 * @param mixed $request_id The request ID from the original JSON-RPC request (string, number, or null).
-	 * @param mixed $result The result data to return.
+	 * @param string|int|float|null $request_id The request ID from the original JSON-RPC request.
+	 * @param mixed                 $result The result data to return.
 	 *
-	 * @return array The formatted JSON-RPC response.
+	 * @return array{
+	 * 	jsonrpc: string,
+	 *  id: string|int|float|null,
+	 *  result: object
+	 * } The formatted JSON-RPC response.
 	 */
 	public static function create_success_response( $request_id, $result ): array {
 		return array(
@@ -39,10 +43,18 @@ class JsonRpcResponseBuilder {
 	/**
 	 * Create a JSON-RPC 2.0 error response.
 	 *
-	 * @param mixed $request_id The request ID from the original JSON-RPC request (string, number, or null).
-	 * @param array $error The error array with 'code', 'message', and optional 'data'.
+	 * @param string|int|float|null                          $request_id The request ID from the original JSON-RPC request.
+	 * @param array{code: int, message: string, data?: mixed} $error     The error array.
 	 *
-	 * @return array The formatted JSON-RPC error response.
+	 * @return array{
+	 * 	jsonrpc: string,
+	 *  id: string|int|float|null,
+	 *  error: array{
+	 *    code: int,
+	 *    message: string,
+	 *    data?: mixed
+	 *  }
+	 * } The formatted JSON-RPC error response.
 	 */
 	public static function create_error_response( $request_id, array $error ): array {
 		return array(


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/mcp-adapter/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Part of https://github.com/WordPress/mcp-adapter/issues/22

<!-- In a few words, what is the PR actually doing? -->

This PR audits and cleans up the PHP classes in the CLI namespace.

> [!NOTE]
> While marking classes final is technically a breaking change, functionally the plugin doesn't support extending them anyway.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Reducing the footprint for potential breaking changes before the release to .org.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Replaces use of blanket `phpcs:ignore` annotations with specific smells + reasons
- Marks both `Cli\McpCommand` and `Cli\StdioServerBridge` as `final`
- Reduces the cyclomatic complexity in `StdioServerBridge` and narrows the typehints to what those methods (and their callers expect).

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

None

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

N/a

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Mark `WP\MCP\Cli` classes as `final` and improve their internal type-safety.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.5%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fmcp-adapter%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-306-c314ef20afc78df64792eca3560fe68e1f48b00b-mcp-adapter.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->