### PR TITLE
Keep the STDIO bridge alive when standard input is a socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+### Fixed
+- The STDIO bridge no longer exits after 60 seconds without input when its standard input is a socket. PHP applies `default_socket_timeout` to blocking socket reads, and the bridge treated the resulting `false` from `fgets()` as end of input. Clients that connect STDIO servers over a socket pair, such as Claude Code, saw the server drop a minute into every idle period.
+
 ## [0.6.1] - 2026-08-13
 
 ### Fixed

--- a/includes/Cli/StdioServerBridge.php
+++ b/includes/Cli/StdioServerBridge.php
@@ -100,6 +100,8 @@ class StdioServerBridge {
 
 		$this->is_running = true;
 
+		$this->wait_for_input_indefinitely( STDIN );
+
 		// Log to stderr to keep stdout clean for MCP messages
 		$this->log_to_stderr( sprintf( 'MCP STDIO Bridge started for server: %s', $this->server->get_server_id() ) );
 
@@ -329,6 +331,25 @@ class StdioServerBridge {
 		}
 
 		return $this->encode_response( JsonRpcResponseBuilder::create_success_response( $id, $result ) );
+	}
+
+	/**
+	 * Make blocking reads on the input stream wait until data arrives.
+	 *
+	 * When standard input is a socket rather than a pipe (Claude Code connects
+	 * STDIO servers over a socket pair), PHP applies default_socket_timeout,
+	 * 60 seconds by default, to each blocking read. Once that passes with no
+	 * input, fgets() returns false and the serve loop takes it as end of input,
+	 * so the server exited after a minute of idle time. A timeout of -1 means
+	 * wait indefinitely, the same value the ini setting uses. Pipes and files
+	 * have no read timeout; stream_set_timeout() returns false for them and
+	 * nothing changes.
+	 *
+	 * @param resource $stream The input stream.
+	 * @return void
+	 */
+	private function wait_for_input_indefinitely( $stream ): void {
+		stream_set_timeout( $stream, -1 );
 	}
 
 	/**

--- a/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
+++ b/tests/phpunit/Unit/Cli/StdioServerBridgeTest.php
@@ -696,4 +696,97 @@ final class StdioServerBridgeTest extends TestCase {
 		// Should succeed since ping doesn't need params
 		$this->assertArrayHasKey( 'result', $response );
 	}
+
+	public function test_wait_for_input_indefinitely_outlasts_the_socket_read_timeout(): void {
+		if ( ! function_exists( 'proc_open' ) ) {
+			$this->markTestSkipped( 'proc_open() is not available.' );
+		}
+
+		$pair = $this->socket_pair_or_skip();
+		$this->assertTrue( stream_set_timeout( $pair[0], 0, 200000 ) );
+
+		// With the short timeout in place an idle read gives up, which is the bug being guarded against.
+		$this->assertFalse( fgets( $pair[0] ) );
+		$this->assertTrue( stream_get_meta_data( $pair[0] )['timed_out'] );
+
+		$this->wait_for_input_indefinitely( $pair[0] );
+
+		$writer = null;
+
+		try {
+			// The writer only speaks after the old timeout would have expired.
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open -- A separate process is the only way to write after a delay while this one blocks in fgets().
+			$writer = proc_open(
+				array( PHP_BINARY, '-r', 'usleep( 500000 ); echo "late\n";' ),
+				array( 1 => $pair[1] ),
+				$pipes
+			);
+			$this->assertIsResource( $writer );
+
+			// The child has its own copy of the writing end. Closing ours means a writer that
+			// exits without writing produces EOF, so the read below fails instead of hanging.
+			// A stream_select() bound would defeat the test: it waits regardless of the read
+			// timeout, and fgets() then finds the data already there.
+			fclose( $pair[1] );
+
+			$this->assertSame( "late\n", fgets( $pair[0] ) );
+			$this->assertFalse( stream_get_meta_data( $pair[0] )['timed_out'] );
+		} finally {
+			if ( is_resource( $writer ) ) {
+				proc_close( $writer );
+			}
+			if ( is_resource( $pair[1] ) ) {
+				fclose( $pair[1] );
+			}
+			fclose( $pair[0] );
+		}
+	}
+
+	public function test_wait_for_input_indefinitely_leaves_non_socket_streams_alone(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Opens an in-memory stream, not a file.
+		$stream = fopen( 'php://memory', 'r+' );
+		$this->assertIsResource( $stream );
+
+		// stream_set_timeout() reports false for streams without a timeout; that must not surface as a warning.
+		$this->wait_for_input_indefinitely( $stream );
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite -- Writes to an in-memory test stream, not the file system.
+		fwrite( $stream, "only\n" );
+		rewind( $stream );
+
+		$this->assertSame( "only\n", fgets( $stream ) );
+		$this->assertFalse( fgets( $stream ) );
+
+		fclose( $stream );
+	}
+
+	/**
+	 * Create a connected socket pair, or skip the test where that is not supported.
+	 *
+	 * @return array{0: resource, 1: resource}
+	 */
+	private function socket_pair_or_skip(): array {
+		if ( ! defined( 'STREAM_PF_UNIX' ) ) {
+			$this->markTestSkipped( 'Unix socket pairs are not available on this platform.' );
+		}
+
+		$pair = stream_socket_pair( STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0 );
+
+		if ( false === $pair ) {
+			$this->markTestSkipped( 'stream_socket_pair() is not supported here.' );
+		}
+
+		return $pair;
+	}
+
+	/**
+	 * Call the private wait_for_input_indefinitely() method on the bridge.
+	 *
+	 * @param resource $stream Stream to prepare.
+	 */
+	private function wait_for_input_indefinitely( $stream ): void {
+		$method = new \ReflectionMethod( $this->bridge, 'wait_for_input_indefinitely' );
+		$method->setAccessible( true );
+		$method->invoke( $this->bridge, $stream );
+	}
 }


### PR DESCRIPTION
## What?
Closes #308

Stops the WP-CLI STDIO bridge from exiting after 60 seconds without input when its standard input is a socket.

## Why?
When stdin is a socket rather than a pipe (Claude Code connects stdio MCP servers over a socket pair), PHP applies `default_socket_timeout` to the blocking `fgets( STDIN )` in the serve loop. After 60 idle seconds the read returns `false` with the client still connected, the loop treats that as end of input, and the server exits. In practice the server dropped a minute into every idle period and the client reported it as failed. Run from a shell with a pipe on stdin the same command lives forever, which is why it was easy to miss. Details and a standalone repro are in the linked issue.

## How?
`stream_set_timeout( STDIN, -1 )` is called once before entering the loop. -1 means wait indefinitely, the same value `default_socket_timeout` accepts. It goes through a small private method so it can be unit tested. On a pipe or a file `stream_set_timeout()` returns false without a warning and nothing changes, so the plain pipe case is untouched. I did not use PHP_INT_MAX because PHP converts the timeout to milliseconds in an int before polling.

The test puts a 200 ms timeout on a socket pair, first shows an idle read gives up with `timed_out` set, then applies the fix and reads a line that a child PHP process writes 500 ms later. The parent closes its copy of the writing end right after starting the child, so a child that exits without writing produces EOF and the read fails instead of hanging. A second test runs the call against `php://memory` for the non-socket path. Both skip if `proc_open()` or Unix socket pairs are unavailable. With the `stream_set_timeout()` call stubbed out the first test fails in about two seconds.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude
Used for: tracing the cause (strace on the running bridge, checking PHP socket timeout behavior), and drafting the patch, tests, and this write-up. I reviewed and ran everything myself and take responsibility for it.

## Testing Instructions
1. Start a stdio server with a socket pair on stdin. The Python snippet in the linked issue does this; or point Claude Code at `wp mcp-adapter serve --server=mcp-adapter-default --user=1`.
2. Without this change the process exits with code 0 about 61 seconds after the initialize request, and the client shows the server as disconnected.
3. With this change it stays up; a `ping` request after two or more idle minutes still gets `{"jsonrpc":"2.0","id":...,"result":{}}`.
4. `composer lint`, `composer phpstan`, and `composer test` pass (994 unit and 42 integration tests locally on PHP 8.4 with WordPress 7.0.4).

## Changelog Entry
Fixed: The STDIO bridge no longer exits after 60 seconds without input when its standard input is a socket.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.5%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fmcp-adapter%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-309-04dc4e668ea6c9d0a3c73804ab3552ab758b0712-mcp-adapter.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->