### PR TITLE
fix: set cache-defense headers on MCP HTTP endpoint responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file, per [the Ke
 ### Changed
 - Usage of MCP Adapter as a bundled library has been deprecated in favor of using the canonical MCP Adapter plugin. See the [vx.y.z migration guide](migration/vx.y.z.md) for instructions on how to migrate away from a bundled copy of MCP Adapter.
 
+### Fixed
+- The MCP HTTP endpoint now sends `Cache-Control: no-store, no-cache, must-revalidate, private` and `Pragma: no-cache` headers, and defines `DONOTCACHEPAGE`, on every response. Previously, full-page caches (LiteSpeed, WP Rocket, W3 Total Cache, WP Super Cache, host-level FastCGI cache) could cache and replay a response to a different user, since the endpoint carried no cache-defense signal.
+
 ## [0.6.1] - 2026-08-13
 
 ### Fixed

--- a/includes/Transport/HttpTransport.php
+++ b/includes/Transport/HttpTransport.php
@@ -147,8 +147,18 @@ class HttpTransport implements McpRestTransportInterface {
 	 * @return \WP_REST_Response
 	 */
 	public function handle_request( \WP_REST_Request $request ): \WP_REST_Response {
-		$context = new HttpRequestContext( $request );
+		// Prevent full-page caches (LiteSpeed, WP Rocket, W3TC, WP Super Cache, etc.)
+		// from caching and replaying MCP responses to other users.
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- DONOTCACHEPAGE is the WordPress-wide page-cache convention; it cannot be prefixed.
+		}
 
-		return $this->request_handler->handle_request( $context );
+		$context  = new HttpRequestContext( $request );
+		$response = $this->request_handler->handle_request( $context );
+
+		$response->header( 'Cache-Control', 'no-store, no-cache, must-revalidate, private' );
+		$response->header( 'Pragma', 'no-cache' );
+
+		return $response;
 	}
 }

--- a/tests/phpunit/Integration/HttpTransportTest.php
+++ b/tests/phpunit/Integration/HttpTransportTest.php
@@ -990,6 +990,58 @@ final class HttpTransportTest extends TestCase {
 		$this->assertStringContainsString( 'Method not allowed', $data['error']['message'] );
 	}
 
+	// ========== Cache Defense Tests ==========
+
+	public function test_post_response_has_cache_defense_headers(): void {
+		$request  = $this->createPostRequest(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 1,
+				'method'  => 'initialize',
+				'params'  => array(
+					'protocolVersion' => '2025-11-25',
+					'clientInfo'      => array(
+						'name'    => 'test-client',
+						'version' => '1.0.0',
+					),
+				),
+			)
+		);
+		$response = $this->transport->handle_request( $request );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertEquals( 'no-store, no-cache, must-revalidate, private', $headers['Cache-Control'] );
+		$this->assertArrayHasKey( 'Pragma', $headers );
+		$this->assertEquals( 'no-cache', $headers['Pragma'] );
+		$this->assertTrue( defined( 'DONOTCACHEPAGE' ) && true === DONOTCACHEPAGE );
+	}
+
+	public function test_get_response_has_cache_defense_headers(): void {
+		$request = new WP_REST_Request( 'GET', '/test-mcp' );
+		$request->set_header( 'Accept', 'text/event-stream' );
+
+		$response = $this->transport->handle_request( $request );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertEquals( 'no-store, no-cache, must-revalidate, private', $headers['Cache-Control'] );
+		$this->assertArrayHasKey( 'Pragma', $headers );
+		$this->assertEquals( 'no-cache', $headers['Pragma'] );
+	}
+
+	public function test_delete_response_has_cache_defense_headers(): void {
+		$request = new WP_REST_Request( 'DELETE', '/test-mcp' );
+
+		$response = $this->transport->handle_request( $request );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertEquals( 'no-store, no-cache, must-revalidate, private', $headers['Cache-Control'] );
+		$this->assertArrayHasKey( 'Pragma', $headers );
+		$this->assertEquals( 'no-cache', $headers['Pragma'] );
+	}
+
 	// ========== Helper Methods ==========
 
 	private function createPostRequest( array $body ): WP_REST_Request {


### PR DESCRIPTION
## Summary
- `HttpTransport::register_routes()` exposes POST/GET/DELETE on the MCP endpoint, but `handle_request()` never emitted `Cache-Control`/`Pragma` headers or defined `DONOTCACHEPAGE`. Under a full-page cache with default settings (LiteSpeed, WP Rocket, W3 Total Cache, WP Super Cache, host-level FastCGI cache), a response could be cached and served to a different user on a subsequent request.
- `handle_request()` now defines `DONOTCACHEPAGE` (guarded with `defined()`) and sets `Cache-Control: no-store, no-cache, must-revalidate, private` plus `Pragma: no-cache` on every response, applied uniformly at the transport layer so POST, GET, and DELETE are all covered without relying on individual handlers to opt in.

## Test plan
- [x] Added `test_post_response_has_cache_defense_headers`, `test_get_response_has_cache_defense_headers`, and `test_delete_response_has_cache_defense_headers` in `tests/phpunit/Integration/HttpTransportTest.php`, asserting the headers/constant on each method.
- [x] `composer lint` (phpcs) — clean, no errors.
- [x] `composer phpstan` — no errors.
- [x] `npm run test:php -- --filter HttpTransportTest` — 29 tests, 115 assertions, all passing.
- [x] `npm run test:php` (full suite) — 1037 tests, 3959 assertions, 1 pre-existing skip, no failures.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.5%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fmcp-adapter%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-314-3abbf70925e7afa91b2fd6ab1c21dbc899e4d5fa-mcp-adapter.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->