### PR TITLE
Fix wp-env builds for PHP 7.4 and 8.0 after Debian bullseye end of life

### DIFF
--- a/bin/patch-wp-env-bullseye.mjs
+++ b/bin/patch-wp-env-bullseye.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Point the Debian bullseye apt sources in wp-env's WordPress image at
+ * archive.debian.org.
+ *
+ * Debian 11 (bullseye) reached end of life on 2026-08-31 and left the regular
+ * mirrors. The official wordpress:php7.4 and wordpress:php8.0 images are the
+ * last two built on bullseye, so `apt-get update` fails while wp-env builds
+ * them and the PHP 7.4 and 8.0 test jobs never start. wp-env already rewrites
+ * the sources for stretch and buster; this adds the same rewrite for bullseye
+ * until a released wp-env carries it.
+ *
+ * Upstream fix: https://github.com/WordPress/gutenberg/pull/82478, merged on
+ * 2026-09-05 and not in wp-env 11.14.0. The `wp-env` and `wp-env:test` npm
+ * scripts run this before every wp-env command because `.npmrc` blocks
+ * lifecycle hooks. Remove the script and those two calls once the installed
+ * wp-env contains the bullseye rewrite; until then the script detects that
+ * case and stays silent.
+ *
+ * Idempotent, and a no-op for every other PHP version: the inserted `sed`
+ * calls match nothing in the sources list of the newer Debian images.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+const template = join(
+	dirname(
+		createRequire( import.meta.url ).resolve(
+			'@wordpress/env/package.json'
+		)
+	),
+	'lib/runtime/docker/docker-config.js'
+);
+
+// Last line of wp-env's own buster rewrite. The bullseye rewrite goes after it.
+const anchor = "RUN sed -i '/buster-updates/d' /etc/apt/sources.list";
+
+// bullseye-security is dropped, not repointed: archive.debian.org does not
+// serve it yet.
+const patch = `
+
+# bullseye (https://www.debian.org/News/2026/20260831)
+RUN sed -i 's|deb.debian.org/debian bullseye|archive.debian.org/debian bullseye|g' /etc/apt/sources.list
+RUN sed -i '/bullseye-security/d' /etc/apt/sources.list
+RUN sed -i '/bullseye-updates/d' /etc/apt/sources.list`;
+
+const source = readFileSync( template, 'utf8' );
+
+if ( source.includes( 'archive.debian.org/debian bullseye' ) ) {
+	// Already patched, or wp-env now ships the rewrite. Stay quiet: this runs
+	// before every wp-env command.
+} else if ( source.includes( anchor ) ) {
+	writeFileSync( template, source.replace( anchor, anchor + patch ) );
+	console.log( `Patched bullseye apt sources into ${ template }.` );
+} else {
+	// A warning, not an error: wp-env commands that never build the PHP 7.4
+	// or 8.0 image must still work.
+	console.warn(
+		`::warning::Could not patch bullseye apt sources into ${ template }; wp-env internals changed. PHP 7.4 and 8.0 environments will fail to build.`
+	);
+}

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
 		"lint:php:stan": "wp-env run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script phpstan",
 		"plugin-zip": "wp-scripts plugin-zip",
 		"test:php": "npm run wp-env:test -- run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ vendor/bin/phpunit -c phpunit.xml.dist",
-		"wp-env": "wp-env",
+		"wp-env": "node bin/patch-wp-env-bullseye.mjs && wp-env",
 		"wp-env:cli": "wp-env run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/",
-		"wp-env:test": "wp-env --config=.wp-env.test.json"
+		"wp-env:test": "node bin/patch-wp-env-bullseye.mjs && wp-env --config=.wp-env.test.json"
 	},
 	"devDependencies": {
 		"@wordpress/env": "^11.14.0",


### PR DESCRIPTION
## What?

See #321 (follow-up to remove this workaround).

Adds `bin/patch-wp-env-bullseye.mjs` and calls it from the `wp-env` and `wp-env:test` npm scripts, so the PHP 7.4 and 8.0 test environments build again in CI and locally.

## Why?

Every PHP 7.4 and 8.0 job in the test matrix has failed since 2026-09-07. Debian 11 (bullseye) reached end of life on 2026-08-31 and left the regular mirrors, and `wordpress:php7.4` and `wordpress:php8.0` are the last official images built on it. wp-env's generated Dockerfile runs `apt-get update`, which now stops on an expired `bullseye-security` release file before any test runs:

    E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired
    ERROR: process "/bin/sh -c apt-get -qy update" did not complete successfully: exit code: 100

wp-env already rewrites the apt sources for stretch and buster. The same rewrite for bullseye was merged upstream in WordPress/gutenberg#82478 on 2026-09-05, but no published `@wordpress/env` release contains it yet (latest is 11.14.0 from 2026-08-26).

## How?

The script inserts the upstream rewrite into the wp-env Dockerfile template in `node_modules`, directly after wp-env's own buster block:

- `deb.debian.org/debian bullseye` is repointed to `archive.debian.org/debian bullseye`.
- `bullseye-security` is dropped, not repointed, because archive.debian.org does not serve that suite.
- `bullseye-updates` is dropped for the same reason.

Decisions:

- The call is inlined into the `wp-env` and `wp-env:test` scripts rather than a `postinstall` hook. `.npmrc` sets `ignore-scripts = true`, which blocks lifecycle hooks and pre/post scripts, so a hook would never run.
- The script is idempotent and stays silent when the template already contains the bullseye rewrite. Once an installed `@wordpress/env` ships the upstream fix, the script becomes a no-op.
- If the template shape changes and the anchor is missing, the script prints a GitHub warning annotation and exits 0, so commands that never build the PHP 7.4 or 8.0 image keep working.
- `wp-env:cli` and the `lint:php*` scripts are unchanged. They run `wp-env run`, which never builds an image.
- `bin/` is not listed in `files` in `package.json`, so the script does not ship in the plugin zip.

This is a temporary workaround. Remove the script and the two calls in `package.json` in the same PR that bumps `@wordpress/env` to the first release containing WordPress/gutenberg#82478 (any version published from trunk after 2026-09-05). The script already detects that release and becomes a no-op, so nothing breaks if the bump lands first. Tracked in #321.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5.1
Used for: Root-cause investigation, the patch script, and local verification; reviewed and edited by me.

## Testing Instructions

1. Run `npm ci`.
2. Run `WP_ENV_PHP_VERSION=7.4 npm run wp-env:test start`. The script prints `Patched bullseye apt sources into ...` and the environment starts.
3. Run `npm run wp-env:test -- run cli php -- -v` and confirm PHP 7.4.
4. Run `npm run test:php` and confirm the suite passes.
5. Run `npm run wp-env:test start` again without the variable to restore the default PHP image.

Performed locally:

- Throwaway builds of `wordpress:php7.4` and `wordpress:php8.0` with the rewrite: `apt-get update` and `apt-get install git sudo` succeed.
- Fresh `npm ci`, then `WP_ENV_PHP_VERSION=7.4 npm run wp-env:test start`: image built, `php -v` reports 7.4.33.
- `npm run test:php` on PHP 7.4: 1038 tests, 3889 assertions, 1 skipped, 0 failures.
- Running the script twice patches once and is silent the second time.

## Changelog Entry

> Developer - Work around the Debian bullseye end of life so wp-env builds the PHP 7.4 and 8.0 test environments again.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.5%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fmcp-adapter%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-322-539936ed53818ec3d26040053112e533df2d10db-mcp-adapter.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->