### PR TITLE
test(cli): cover serve user context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,6 +234,9 @@ jobs:
         run: |
           npm run test:php
 
+      - name: Run WP-CLI command registration tests
+        run: npm run test:cli
+
       - name: Upload code coverage report
         continue-on-error: true
         if: ${{ matrix.coverage }}

--- a/docs/guides/cli-usage.md
+++ b/docs/guides/cli-usage.md
@@ -19,13 +19,13 @@ Serves an MCP server via STDIO transport for communication with MCP clients.
 #### Syntax
 
 ```bash
-wp mcp-adapter serve [--server=<server-id>] [--user=<id|login|email>]
+wp mcp-adapter serve [--server=<server-id>]
 ```
 
 #### Options
 
 - `--server=<server-id>` - The ID of the MCP server to serve. If not specified, uses the first available server.
-- `--user=<id|login|email>` - Run as a specific WordPress user for permission checks. Without this, runs as unauthenticated (limited capabilities).
+- `--user=<id|login|email>` is a WP-CLI global option that selects the WordPress user for permission checks. It is not a `mcp-adapter serve` option. Without it, the server runs as unauthenticated with limited capabilities.
 
 #### Examples
 

--- a/includes/Cli/McpCommand.php
+++ b/includes/Cli/McpCommand.php
@@ -37,13 +37,13 @@ final class McpCommand extends \WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Serve the default MCP server as admin user
-	 *     wp mcp serve --user=admin
+	 *     wp mcp-adapter serve --user=admin
 	 *
 	 *     # Serve a specific server as user with ID 1
-	 *     wp mcp serve --server=my-mcp-server --user=1
+	 *     wp mcp-adapter serve --server=my-mcp-server --user=1
 	 *
 	 *     # Serve without authentication (limited capabilities)
-	 *     wp mcp serve --server=public-server
+	 *     wp mcp-adapter serve --server=public-server
 	 *
 	 * @when after_wp_load
 	 * @synopsis [--server=<server-id>]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"lint:php:stan": "wp-env run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script phpstan",
 		"plugin-zip": "wp-scripts plugin-zip",
 		"test:php": "npm run wp-env:test -- run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ vendor/bin/phpunit -c phpunit.xml.dist",
+		"test:cli": "npm run wp-env:test -- run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ sh tests/cli/test-serve-user-context.sh",
 		"wp-env": "node bin/patch-wp-env-bullseye.mjs && wp-env",
 		"wp-env:cli": "wp-env run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/",
 		"wp-env:test": "node bin/patch-wp-env-bullseye.mjs && wp-env --config=.wp-env.test.json"

--- a/tests/cli/assert-serve-user-context.php
+++ b/tests/cli/assert-serve-user-context.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Validates the user context seen by the serve command in a real WP-CLI run.
+ *
+ * @package WP\MCP\Tests
+ */
+
+\WP_CLI::add_wp_hook(
+	'plugins_loaded',
+	static function (): void {
+		add_filter(
+			'mcp_adapter_enable_stdio_transport',
+			static function (): bool {
+				if ( 1 !== get_current_user_id() || ! current_user_can( 'read' ) ) {
+					\WP_CLI::error( 'WP-CLI global --user was not applied to the MCP server user context.' );
+				}
+
+				return false;
+			}
+		);
+	}
+);

--- a/tests/cli/test-serve-user-context.sh
+++ b/tests/cli/test-serve-user-context.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -eu
+
+help_output="$(wp mcp-adapter serve --help 2>&1)"
+
+case "$help_output" in
+	*"already registered"*)
+		printf '%s\n' "$help_output" >&2
+		exit 1
+		;;
+	esac
+
+case "$help_output" in
+	*"global \`--user\` flag"*)
+		;;
+	*)
+		printf '%s\n' "$help_output" >&2
+		exit 1
+		;;
+esac
+
+if serve_output="$(wp mcp-adapter serve --server=mcp-adapter-default-server --user=admin --require=tests/cli/assert-serve-user-context.php 2>&1)"; then
+	printf '%s\n' "$serve_output" >&2
+	exit 1
+fi
+
+case "$serve_output" in
+	*"The STDIO transport is disabled."*)
+		;;
+	*)
+		printf '%s\n' "$serve_output" >&2
+		exit 1
+		;;
+esac


### PR DESCRIPTION
## Summary

The historical `serve --user` synopsis collision is already fixed on `trunk`. This follow-up corrects the canonical `wp mcp-adapter serve` examples, describes `--user` as WP-CLI global behavior, and adds a real WordPress/WP-CLI context test to CI.

Relates to #325.

## Validation

- `php -l includes/Cli/McpCommand.php`
- `php -l tests/cli/assert-serve-user-context.php`
- `sh -n tests/cli/test-serve-user-context.sh`
- `composer lint -- includes/Cli/McpCommand.php tests/cli/assert-serve-user-context.php`
- `composer phpstan`
- `git diff --check`

A disposable non-Docker WordPress runtime verified `wp mcp-adapter serve --help`, explicit `--user=admin` resolves user ID 1, no `--user` resolves an anonymous user ID 0, and an invalid user selector fails before serving. The CI test uses the Docker-backed wp-env runtime. Docker is unavailable locally, so `npm run test:cli` and the full Docker-backed PHPUnit suite were not run locally.

## AI Assistance

OpenAI gpt-5.6-terra via direct OpenCode implementation and verification; OpenAI gpt-6-astra via OpenCode orchestration and review.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.5%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fmcp-adapter%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-326-59e8f22d4d8c3c015f348c0de16218e9cabc842f-mcp-adapter.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->