### PR TITLE
fix: pass three arguments to mcp_adapter_validation_enabled at every call site

### DIFF
--- a/includes/Core/McpServer.php
+++ b/includes/Core/McpServer.php
@@ -161,9 +161,9 @@ class McpServer {
 		 *
 		 * @since 0.3.0
 		 *
-		 * @param bool      $enabled   Whether validation is enabled. Default false.
-		 * @param string    $server_id The server ID being configured.
-		 * @param \WP\MCP\Core\McpServer $server    The McpServer instance being constructed.
+		 * @param bool                       $enabled   Whether validation is enabled. Default false.
+		 * @param string|null               $server_id The server ID being configured, or null when no server is in scope.
+		 * @param \WP\MCP\Core\McpServer|null $server    The McpServer instance, or null when no server is in scope.
 		 */
 		$this->mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false, $this->server_id, $this );
 

--- a/includes/Domain/Prompts/McpPrompt.php
+++ b/includes/Domain/Prompts/McpPrompt.php
@@ -203,7 +203,7 @@ final class McpPrompt implements McpComponentInterface {
 		}
 
 		// Optional deep validation if enabled.
-		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false, null, null );
 		if ( $mcp_validation_enabled ) {
 			$validation_result = McpPromptValidator::validate_prompt_dto( $prompt );
 			if ( is_wp_error( $validation_result ) ) {
@@ -273,7 +273,7 @@ final class McpPrompt implements McpComponentInterface {
 		}
 
 		// Optional deep validation if enabled.
-		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false, null, null );
 		if ( $mcp_validation_enabled ) {
 			$validation_result = McpPromptValidator::validate_prompt_dto( $prompt );
 			if ( is_wp_error( $validation_result ) ) {

--- a/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -510,7 +510,7 @@ class RegisterAbilityAsMcpPrompt {
 		}
 
 		// Optional deep validation if enabled.
-		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false, null, null );
 		if ( $mcp_validation_enabled ) {
 			$validation_result = McpPromptValidator::validate_prompt_dto( $prompt_dto );
 			if ( is_wp_error( $validation_result ) ) {

--- a/includes/Domain/Resources/McpResource.php
+++ b/includes/Domain/Resources/McpResource.php
@@ -196,7 +196,7 @@ final class McpResource implements McpComponentInterface {
 		}
 
 		// Optional deep validation if enabled.
-		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false, null, null );
 		if ( $mcp_validation_enabled ) {
 			$validation_result = McpResourceValidator::validate_resource_dto( $resource );
 			if ( is_wp_error( $validation_result ) ) {

--- a/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -462,7 +462,7 @@ class RegisterAbilityAsMcpResource {
 		}
 
 		// Optional deep validation if enabled.
-		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false, null, null );
 		if ( $mcp_validation_enabled ) {
 			$validation_result = McpResourceValidator::validate_resource_dto( $resource_dto );
 			if ( is_wp_error( $validation_result ) ) {

--- a/includes/Domain/Tools/McpTool.php
+++ b/includes/Domain/Tools/McpTool.php
@@ -189,7 +189,7 @@ final class McpTool implements McpComponentInterface {
 		}
 
 		// Optional deep validation if enabled.
-		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false, null, null );
 		if ( $mcp_validation_enabled ) {
 			$validation_result = McpToolValidator::validate_tool_dto( $tool );
 			if ( is_wp_error( $validation_result ) ) {

--- a/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -81,7 +81,7 @@ class RegisterAbilityAsMcpTool {
 		}
 
 		// Optional deep validation if enabled.
-		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false );
+		$mcp_validation_enabled = apply_filters( 'mcp_adapter_validation_enabled', false, null, null );
 		if ( $mcp_validation_enabled ) {
 			$validation_result = McpToolValidator::validate_tool_dto( $tool_dto );
 			if ( is_wp_error( $validation_result ) ) {

--- a/tests/phpunit/Integration/WordPressFiltersTest.php
+++ b/tests/phpunit/Integration/WordPressFiltersTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace WP\MCP\Tests\Integration;
 
 use WP\MCP\Core\McpServer;
+use WP\MCP\Domain\Prompts\McpPrompt;
+use WP\MCP\Domain\Prompts\McpPromptBuilder;
+use WP\MCP\Domain\Resources\McpResource;
+use WP\MCP\Domain\Tools\McpTool;
 use WP\MCP\Tests\Fixtures\DummyErrorHandler;
 use WP\MCP\Tests\Fixtures\DummyObservabilityHandler;
 use WP\MCP\Tests\TestCase;
@@ -29,5 +33,75 @@ final class WordPressFiltersTest extends TestCase {
 		$this->assertFalse( $server->is_mcp_validation_enabled() );
 
 		remove_filter( 'mcp_adapter_validation_enabled', '__return_false' );
+	}
+
+	/**
+	 * A 3-argument callback is the documented signature on McpServer. Domain
+	 * factories must pass the extra args (null when no server is in scope) so
+	 * ability conversion does not raise ArgumentCountError and drop tools.
+	 */
+	public function test_validation_filter_three_argument_callback_does_not_break_component_conversion(): void {
+		$callback = static function ( $enabled, $server_id, $server ) {
+			return false;
+		};
+		add_filter( 'mcp_adapter_validation_enabled', $callback, 10, 3 );
+
+		try {
+			$server = $this->makeServer(
+				array( 'test/always-allowed' ),
+				array( 'test/resource' ),
+				array( 'test/prompt' )
+			);
+
+			$this->assertNotEmpty( $server->get_tools() );
+			$this->assertNotEmpty( $server->get_resources() );
+			$this->assertNotEmpty( $server->get_prompts() );
+
+			$tool = McpTool::fromArray(
+				array(
+					'name'    => 'filter-arity-tool',
+					'handler' => static function () {
+						return array( 'ok' => true );
+					},
+				)
+			);
+			$this->assertNotWPError( $tool );
+
+			$resource = McpResource::fromArray(
+				array(
+					'uri'     => 'WordPress://local/filter-arity',
+					'handler' => static function () {
+						return 'ok';
+					},
+				)
+			);
+			$this->assertNotWPError( $resource );
+
+			$prompt = McpPrompt::fromArray(
+				array(
+					'name'    => 'filter-arity-prompt',
+					'handler' => static function () {
+						return array();
+					},
+				)
+			);
+			$this->assertNotWPError( $prompt );
+
+			$builder = new class() extends McpPromptBuilder {
+				protected function configure(): void {
+					$this->name        = 'filter-arity-builder-prompt';
+					$this->description = 'Exercises the validation filter from fromBuilder';
+				}
+
+				public function handle( array $arguments ): array {
+					return array();
+				}
+			};
+
+			$built = McpPrompt::fromBuilder( $builder );
+			$this->assertNotWPError( $built );
+		} finally {
+			remove_filter( 'mcp_adapter_validation_enabled', $callback );
+		}
 	}
 }


### PR DESCRIPTION
## What?
Closes #305

Pass the documented extra arguments (`$server_id`, `$server`) at every `mcp_adapter_validation_enabled` application. Domain factories that have no server in scope pass `null, null`.

## Why?
`McpServer` applies this filter with three arguments. Seven domain factories applied it with one. An integrator who registers a three-argument callback (`add_filter( 'mcp_adapter_validation_enabled', $cb, 10, 3 )`) gets `ArgumentCountError` during ability-to-tool conversion, and the server can come up without its tools.

Verified against the v0.6.1 release zip by the reporter, and still reproduced on current trunk: `RegisterAbilityAsMcpTool::build()` passed one argument into a three-parameter callback while constructing a server that registers `test/always-allowed`.

The extra arguments were added on `McpServer` in ee97837 so multi-server hooks could tell servers apart, and were never mirrored in the domain factories.

## How?
Every remaining `apply_filters( 'mcp_adapter_validation_enabled', false )` now passes `null, null` for the documented extra args. `McpServer` is unchanged at the call site (it already passed `$this->server_id, $this`); its hook docs now state that those extra args are null when no server is in scope.

Alternative considered: have domain factories read `McpServer::is_mcp_validation_enabled()` and stop re-applying the filter (the reporter's preferred shape). Domain factories are public and used without a server (`McpTool::fromArray()` and the rest). Importing `McpServer` into Domain would reverse the existing Core to Domain direction.

A callback that enables validation only for a given `$server_id` still will not see that id during conversion.

A follow-up can pass an optional `?bool $mcp_validation_enabled` from `McpComponentRegistry` into the factories if you would rather the filter fire once per server on the registration path.

## Testing Instructions
1. `add_filter( 'mcp_adapter_validation_enabled', function( $enabled, $server_id, $server ) { return false; }, 10, 3 );`
2. Create an `McpServer` that registers at least one ability as a tool (and optionally a resource and a prompt).
3. Construction should complete and the components should be registered. Previously this raised `ArgumentCountError`.
4. `McpTool::fromArray()`, `McpResource::fromArray()`, `McpPrompt::fromArray()`, and `McpPrompt::fromBuilder()` with the same callback should also succeed.

Covered by `WordPressFiltersTest::test_validation_filter_three_argument_callback_does_not_break_component_conversion`.

## Changelog Entry

> Fixed - `mcp_adapter_validation_enabled` is applied with three arguments at every call site, so three-argument callbacks no longer raise `ArgumentCountError` during ability conversion.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.5%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fmcp-adapter%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-327-b116400bccd228061eb771d11f6f16f458bce705-mcp-adapter.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->